### PR TITLE
Add auth url redirects for backwards compatibility

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -44,6 +44,23 @@ const config = {
       destination: 'https://us.i.posthog.com/decide',
     },
   ],
+  redirects: async () => [
+    {
+      source: '/docs/api/cli',
+      destination: '/auth/cli',
+      permanent: true,
+    },
+    {
+      source: '/auth/sign-in',
+      destination: '/sign-in',
+      permanent: true,
+    },
+    {
+      source: '/auth/sign-up',
+      destination: '/sign-up',
+      permanent: true,
+    },
+  ],
   skipTrailingSlashRedirect: true,
 }
 

--- a/vercel.json
+++ b/vercel.json
@@ -5,11 +5,6 @@
   "trailingSlash": false,
   "redirects": [
     {
-      "source": "/docs/api/cli",
-      "destination": "/auth/cli",
-      "permanent": true
-    },
-    {
       "source": "/careers",
       "destination": "https://e2bdev.notion.site/Careers-at-E2B-2163f176991f43f69b0984bf2a142920",
       "permanent": true


### PR DESCRIPTION
the new dashboard removed the `/auth `prefix for` /sign-in` `/sign-up` & `/forgot-password`. due to backwards compatibility with having the old dashboard in prod & the new dashboard in testing for certain teams, we should have a redirect in place