### PR TITLE
Fix middleware rewrite handling to comply with CVE-2025-29927

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -50,7 +50,7 @@
         "lucide-react": "^0.474.0",
         "motion": "^12.0.6",
         "nanoid": "^5.0.9",
-        "next": "^15.3.0-canary.21",
+        "next": "^15.3.0-canary.23",
         "next-logger": "^5.0.1",
         "next-safe-action": "^7.10.4",
         "next-themes": "^0.4.4",
@@ -542,25 +542,25 @@
 
     "@napi-rs/wasm-runtime": ["@napi-rs/wasm-runtime@0.2.7", "", { "dependencies": { "@emnapi/core": "^1.3.1", "@emnapi/runtime": "^1.3.1", "@tybys/wasm-util": "^0.9.0" } }, "sha512-5yximcFK5FNompXfJFoWanu5l8v1hNGqNHh9du1xETp9HWk/B/PzvchX55WYOPaIeNglG8++68AAiauBAtbnzw=="],
 
-    "@next/env": ["@next/env@15.3.0-canary.21", "", {}, "sha512-heC4nz+8K39M9A+ov0H7E1FdEDJJ7ezXTNeI2VFG+lz4MDMOJ+K2SoIvjh5g0l35NX5iyeKpPDjDyctotGvI7g=="],
+    "@next/env": ["@next/env@15.3.0-canary.23", "", {}, "sha512-WaS/4IYliYQPw9ylCDkJevzUkgwKGj3lI4eznEWr80i5xwVE77cczrmEEfwzceNeQySxaxYIQdjkV019+S319g=="],
 
     "@next/eslint-plugin-next": ["@next/eslint-plugin-next@15.2.3", "", { "dependencies": { "fast-glob": "3.3.1" } }, "sha512-eNSOIMJtjs+dp4Ms1tB1PPPJUQHP3uZK+OQ7iFY9qXpGO6ojT6imCL+KcUOqE/GXGidWbBZJzYdgAdPHqeCEPA=="],
 
-    "@next/swc-darwin-arm64": ["@next/swc-darwin-arm64@15.3.0-canary.21", "", { "os": "darwin", "cpu": "arm64" }, "sha512-E3PSOavuaHxKUPGDGy7iFLPz1IvXcimlR3WqNgE590Wxahtq1CDeLQGaAPr3iTDlriauJHKCUl+VvRNQ/yUT1Q=="],
+    "@next/swc-darwin-arm64": ["@next/swc-darwin-arm64@15.3.0-canary.23", "", { "os": "darwin", "cpu": "arm64" }, "sha512-Elplw67rEj5MZLxH4AG21ruV9eH9j9dhvdZHXYVcf6V/McJSgYH0w6mE5haFXhDVUibtj5l0eFOPtFWNmAV2ZQ=="],
 
-    "@next/swc-darwin-x64": ["@next/swc-darwin-x64@15.3.0-canary.21", "", { "os": "darwin", "cpu": "x64" }, "sha512-i2i/KoNRSLKEd589NGIM64bHYy3tFKT6qnRHQQovSlwWdllWm8nWGJSsFJ9kN5ufOfk6xmrqvIPmXXMQ2mMagg=="],
+    "@next/swc-darwin-x64": ["@next/swc-darwin-x64@15.3.0-canary.23", "", { "os": "darwin", "cpu": "x64" }, "sha512-7Gjts9MgNYd3vaygtkycBAj8vVtHE9scwIKFta++6oXLzr1BtABKZbp7We09zzhVMK6TcWhLVY476G/IiHIUcw=="],
 
-    "@next/swc-linux-arm64-gnu": ["@next/swc-linux-arm64-gnu@15.3.0-canary.21", "", { "os": "linux", "cpu": "arm64" }, "sha512-NQJxStyPjPx8eUoxiYy+QuqqmdcqJpNdteSVI9mfQhSAfzwV/hkBq07DkP0qvHKniJZ/cONZK3YKdNu0tZfiKA=="],
+    "@next/swc-linux-arm64-gnu": ["@next/swc-linux-arm64-gnu@15.3.0-canary.23", "", { "os": "linux", "cpu": "arm64" }, "sha512-0IPGbPHchIxhSForVwd528P+G6DG0/jrX/tvWkX0colkzg6gC8s8f3HAzBBMAfktnhxYHgx2Qs4T3Ev8pUj1xw=="],
 
-    "@next/swc-linux-arm64-musl": ["@next/swc-linux-arm64-musl@15.3.0-canary.21", "", { "os": "linux", "cpu": "arm64" }, "sha512-gNvBv1CsmBjceILlnP1p+yfj99ffOqTyTVGlbpnsjSI+yT6xVxOs5N0bjDAnyG4MJjy4g8rh6/wD9T0sYN8OOQ=="],
+    "@next/swc-linux-arm64-musl": ["@next/swc-linux-arm64-musl@15.3.0-canary.23", "", { "os": "linux", "cpu": "arm64" }, "sha512-5B66QKsHCQ2sakOjm89t4IlDz5/JpEe/yKdtcUBfUSQTHWN+AvYrpEjDzuAhQcHnJibzNDFnwb1Ch3C3GSohIQ=="],
 
-    "@next/swc-linux-x64-gnu": ["@next/swc-linux-x64-gnu@15.3.0-canary.21", "", { "os": "linux", "cpu": "x64" }, "sha512-FHEmhvliKoTZHflk3J55GsdkB5tW5l86/H0t6rseVAN+mkgd2DHpKttDcnZggrRFjMsp0y9F6ICtHXltrBrs8g=="],
+    "@next/swc-linux-x64-gnu": ["@next/swc-linux-x64-gnu@15.3.0-canary.23", "", { "os": "linux", "cpu": "x64" }, "sha512-TIrlksSn7lzD5sRvzc/0suimOlrCECUgIUG6/wFR1bjUWJz9girtKPvzALQbeeuCrHbSnONBLd5qNHMA1jbZkA=="],
 
-    "@next/swc-linux-x64-musl": ["@next/swc-linux-x64-musl@15.3.0-canary.21", "", { "os": "linux", "cpu": "x64" }, "sha512-jCIm/yD2+jRnsHbzHQxKdgZYBfsNPyq71uRGIvzzZxBFQ7/gfdxOARHzGvXGKVIrBn3GWDdLzJNPCr3morWE6w=="],
+    "@next/swc-linux-x64-musl": ["@next/swc-linux-x64-musl@15.3.0-canary.23", "", { "os": "linux", "cpu": "x64" }, "sha512-d2S5ki/qHaQ96qErld2H+PbrrXVxM1IaOd+4o3YT8aZO8L5biKDqyjAPrPz/R6Wg/stpZ+8/tV6dx4kuBzqykw=="],
 
-    "@next/swc-win32-arm64-msvc": ["@next/swc-win32-arm64-msvc@15.3.0-canary.21", "", { "os": "win32", "cpu": "arm64" }, "sha512-LTEX5LR96mQWxlx1BZZzp6TB97xwVXOlw15DLKB+AyR3pXsIa4uvmMQnWu9cW+ZOcELsVVo+TSG2k/ZQRt+O/A=="],
+    "@next/swc-win32-arm64-msvc": ["@next/swc-win32-arm64-msvc@15.3.0-canary.23", "", { "os": "win32", "cpu": "arm64" }, "sha512-2zUi5D2dkkiMxQeeuuBlcrJ2bzMp/aAFcjCVtwomXstF+IGfi9xgN0T4hbGE8ocZYByO1FLgnVVGlh8qxbNnlw=="],
 
-    "@next/swc-win32-x64-msvc": ["@next/swc-win32-x64-msvc@15.3.0-canary.21", "", { "os": "win32", "cpu": "x64" }, "sha512-t8GXPH7JqJZlu5lLGMIV5g3sVyP0yrfEVgbjAYB8hafIRek6wZBsifSX9cAVTs86LH8hdCsb3pQzv8cEDV6qbA=="],
+    "@next/swc-win32-x64-msvc": ["@next/swc-win32-x64-msvc@15.3.0-canary.23", "", { "os": "win32", "cpu": "x64" }, "sha512-Wqx2N39BtqfLZP/t3w0529rZEsxwGPenRh8AlIon0lWyULK3Ho+SWipkR0R5l5rBoZDz8LKPbU+8t2IpGbkiHQ=="],
 
     "@nodelib/fs.scandir": ["@nodelib/fs.scandir@2.1.5", "", { "dependencies": { "@nodelib/fs.stat": "2.0.5", "run-parallel": "^1.1.9" } }, "sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g=="],
 
@@ -2492,7 +2492,7 @@
 
     "neo-async": ["neo-async@2.6.2", "", {}, "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw=="],
 
-    "next": ["next@15.3.0-canary.21", "", { "dependencies": { "@next/env": "15.3.0-canary.21", "@swc/counter": "0.1.3", "@swc/helpers": "0.5.15", "busboy": "1.6.0", "caniuse-lite": "^1.0.30001579", "postcss": "8.4.31", "styled-jsx": "5.1.6" }, "optionalDependencies": { "@next/swc-darwin-arm64": "15.3.0-canary.21", "@next/swc-darwin-x64": "15.3.0-canary.21", "@next/swc-linux-arm64-gnu": "15.3.0-canary.21", "@next/swc-linux-arm64-musl": "15.3.0-canary.21", "@next/swc-linux-x64-gnu": "15.3.0-canary.21", "@next/swc-linux-x64-musl": "15.3.0-canary.21", "@next/swc-win32-arm64-msvc": "15.3.0-canary.21", "@next/swc-win32-x64-msvc": "15.3.0-canary.21", "sharp": "^0.33.5" }, "peerDependencies": { "@opentelemetry/api": "^1.1.0", "@playwright/test": "^1.41.2", "babel-plugin-react-compiler": "*", "react": "^18.2.0 || 19.0.0-rc-de68d2f4-20241204 || ^19.0.0", "react-dom": "^18.2.0 || 19.0.0-rc-de68d2f4-20241204 || ^19.0.0", "sass": "^1.3.0" }, "optionalPeers": ["@opentelemetry/api", "@playwright/test", "babel-plugin-react-compiler", "sass"], "bin": { "next": "dist/bin/next" } }, "sha512-NcJOEbi3K+XXhaVlRQ+89rEsz6g99cokecS0LK36BtM0JRVFLoAb5EMYRIywYTGOfwCqOOzKXyKtZvMNfiz8aw=="],
+    "next": ["next@15.3.0-canary.23", "", { "dependencies": { "@next/env": "15.3.0-canary.23", "@swc/counter": "0.1.3", "@swc/helpers": "0.5.15", "busboy": "1.6.0", "caniuse-lite": "^1.0.30001579", "postcss": "8.4.31", "styled-jsx": "5.1.6" }, "optionalDependencies": { "@next/swc-darwin-arm64": "15.3.0-canary.23", "@next/swc-darwin-x64": "15.3.0-canary.23", "@next/swc-linux-arm64-gnu": "15.3.0-canary.23", "@next/swc-linux-arm64-musl": "15.3.0-canary.23", "@next/swc-linux-x64-gnu": "15.3.0-canary.23", "@next/swc-linux-x64-musl": "15.3.0-canary.23", "@next/swc-win32-arm64-msvc": "15.3.0-canary.23", "@next/swc-win32-x64-msvc": "15.3.0-canary.23", "sharp": "^0.33.5" }, "peerDependencies": { "@opentelemetry/api": "^1.1.0", "@playwright/test": "^1.41.2", "babel-plugin-react-compiler": "*", "react": "^18.2.0 || 19.0.0-rc-de68d2f4-20241204 || ^19.0.0", "react-dom": "^18.2.0 || 19.0.0-rc-de68d2f4-20241204 || ^19.0.0", "sass": "^1.3.0" }, "optionalPeers": ["@opentelemetry/api", "@playwright/test", "babel-plugin-react-compiler", "sass"], "bin": { "next": "dist/bin/next" } }, "sha512-zEL+08B+J8MO87QtEpzXCrxIjlrw84pXRqFBJJ+rxuLRSQuTjqSH3FHAQz0OUHgLvtyfQHFg2z9EqMmsYtWgOQ=="],
 
     "next-logger": ["next-logger@5.0.1", "", { "dependencies": { "lilconfig": "^3.1.2" }, "peerDependencies": { "next": ">=9.0.0", "pino": "^8.0.0 || ^9.0.0", "winston": "^3.0.0" }, "optionalPeers": ["pino", "winston"] }, "sha512-zWTPtS0YwTB+4iSK4VxUVtCYt+zg8+Sx2Tjbtgmpd4SXsFnWdmCbXAeFZFKtEH8yNlucLCUaj0xqposMQ9rKRg=="],
 

--- a/package.json
+++ b/package.json
@@ -83,7 +83,7 @@
     "lucide-react": "^0.474.0",
     "motion": "^12.0.6",
     "nanoid": "^5.0.9",
-    "next": "^15.3.0-canary.21",
+    "next": "^15.3.0-canary.23",
     "next-logger": "^5.0.1",
     "next-safe-action": "^7.10.4",
     "next-themes": "^0.4.4",

--- a/src/configs/domains.ts
+++ b/src/configs/domains.ts
@@ -1,6 +1,6 @@
 import { BASE_URL } from './urls'
 
-export const LANDING_PAGE_DOMAIN = 'e2b-landing-page.com'
+export const LANDING_PAGE_DOMAIN = 'www.e2b-landing-page.com'
 export const LANDING_PAGE_FRAMER_DOMAIN = 'e2b-landing-page.framer.website'
 export const BLOG_FRAMER_DOMAIN = 'e2b-blog.framer.website'
 export const DOCS_NEXT_DOMAIN =

--- a/src/server/auth/validate-email.ts
+++ b/src/server/auth/validate-email.ts
@@ -62,7 +62,7 @@ export async function validateEmail(
     const response = await fetch(
       `https://api.zerobounce.net/v2/validate?api_key=${process.env.ZEROBOUNCE_API_KEY}&email=${email}&ip_address=`
     )
-    // Parse the JSON response from the ZeroBounce API
+
     const responseData = await response.json()
 
     // Convert the mx_found string value to a boolean if it's 'true' or 'false'

--- a/src/server/middleware.ts
+++ b/src/server/middleware.ts
@@ -220,12 +220,22 @@ export const handleUrlRewrites = async (
   }
 
   try {
-    const res = await fetch(url.toString(), { ...request })
+    const res = await fetch(url.toString(), {
+      headers: {
+        'User-Agent': 'Mozilla/5.0 (compatible; E2BProxy/1.0)',
+        Accept:
+          'text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,*/*;q=0.8',
+        'Accept-Language': 'en-US,en;q=0.5',
+        'Accept-Encoding': 'gzip, deflate, br',
+        Connection: 'keep-alive',
+        'Upgrade-Insecure-Requests': '1',
+        'Cache-Control': 'no-cache',
+        Pragma: 'no-cache',
+      },
+      redirect: 'follow',
+    })
     const htmlBody = await res.text()
     const modifiedHtmlBody = replaceUrls(htmlBody, url.pathname, 'href="', '">')
-
-    logDebug('request headers', request.headers)
-    logDebug('response headers', res.headers)
 
     return new NextResponse(modifiedHtmlBody, {
       status: res.status,

--- a/src/server/middleware.ts
+++ b/src/server/middleware.ts
@@ -8,6 +8,7 @@ import { AUTH_URLS, PROTECTED_URLS } from '@/configs/urls'
 import { supabaseAdmin } from '@/lib/clients/supabase/admin'
 import { z } from 'zod'
 import { createServerClient } from '@supabase/ssr'
+import { logDebug } from '@/lib/clients/logger'
 
 /**
  * Core function to resolve team ID and ensure access for dashboard routes.
@@ -222,6 +223,9 @@ export const handleUrlRewrites = async (
     const res = await fetch(url.toString(), { ...request })
     const htmlBody = await res.text()
     const modifiedHtmlBody = replaceUrls(htmlBody, url.pathname, 'href="', '">')
+
+    logDebug('request headers', request.headers)
+    logDebug('response headers', res.headers)
 
     return new NextResponse(modifiedHtmlBody, {
       status: res.status,

--- a/src/server/middleware.ts
+++ b/src/server/middleware.ts
@@ -8,7 +8,6 @@ import { AUTH_URLS, PROTECTED_URLS } from '@/configs/urls'
 import { supabaseAdmin } from '@/lib/clients/supabase/admin'
 import { z } from 'zod'
 import { createServerClient } from '@supabase/ssr'
-import { logDebug } from '@/lib/clients/logger'
 
 /**
  * Core function to resolve team ID and ensure access for dashboard routes.

--- a/src/server/middleware.ts
+++ b/src/server/middleware.ts
@@ -2,7 +2,7 @@ import { checkUserTeamAuthorization, resolveTeamId } from '@/lib/utils/server'
 import { kv } from '@/lib/clients/kv'
 import { KV_KEYS } from '@/configs/keys'
 import { NextRequest, NextResponse } from 'next/server'
-import { replaceUrls } from '@/configs/domains'
+import { LANDING_PAGE_DOMAIN, replaceUrls } from '@/configs/domains'
 import { COOKIE_KEYS } from '@/configs/keys'
 import { AUTH_URLS, PROTECTED_URLS } from '@/configs/urls'
 import { supabaseAdmin } from '@/lib/clients/supabase/admin'
@@ -220,18 +220,15 @@ export const handleUrlRewrites = async (
   }
 
   try {
+    if (url.hostname === LANDING_PAGE_DOMAIN) {
+      return NextResponse.rewrite(url.toString())
+    }
+
+    const headers = new Headers(request.headers)
+
     const res = await fetch(url.toString(), {
-      headers: {
-        'User-Agent': 'Mozilla/5.0 (compatible; E2BProxy/1.0)',
-        Accept:
-          'text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,*/*;q=0.8',
-        'Accept-Language': 'en-US,en;q=0.5',
-        'Accept-Encoding': 'gzip, deflate, br',
-        Connection: 'keep-alive',
-        'Upgrade-Insecure-Requests': '1',
-        'Cache-Control': 'no-cache',
-        Pragma: 'no-cache',
-      },
+      ...request,
+      headers,
       redirect: 'follow',
     })
     const htmlBody = await res.text()


### PR DESCRIPTION
Although mentioned in [CVE-2025-29927](https://github.com/advisories/GHSA-f82v-jwr5-mffw), the version upgrade to resolve the security vulnerability in NextJs in #18 was not enough to fix rewriting issues. This pr explored ways to get around the 406 blockage and in the end settled on:
- using `NextResponse.rewrite` instead of `fetch & new NextResponse`

This approach is far from ideal in terms of performance. It seems like the native NextJs rewrite is doing a lot under the hood before sending the html to the client, potentially adapting additional assets loaded by the rewritten site, as this latency seems to increase with more assets.