### PR TITLE
Add clarification on self-hosting the dashboard application

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,8 @@ Our Dashboard is a modern, feature-rich web application built to manage and moni
 
 ## Getting Started
 
+> **Self-hosting Note**: If you're planning to self-host this dashboard, you'll likely want to self-host our infrastructure first. Please refer to our [infrastructure repository](https://github.com/e2b-dev/infra) for guidance on setting up the E2B platform on your own infrastructure.
+
 ### Prerequisites
 - Node.js 18+
 - Git
@@ -51,7 +53,7 @@ cd dashboard
 bun install
 
 # Using npm
-npm install
+npm install --legacy-peer-deps
 ```
 
 3. Set up required services:

--- a/README.md
+++ b/README.md
@@ -56,18 +56,19 @@ npm install
 
 3. Set up required services:
 
-#### a. Vercel & KV Storage
-```bash
-# Install Vercel CLI
-npm i -g vercel
+#### a. Key-Value Store Setup
+This project requires a Redis-compatible key-value store. You'll need to:
 
-# Link project to Vercel
-vercel link
+1. Set up a Redis instance (self-hosted or using a cloud provider)
+2. Configure the following environment variables in your `.env.local` file:
+   ```
+   KV_URL=your_redis_connection_string
+   KV_REST_API_URL=your_redis_rest_api_url
+   KV_REST_API_TOKEN=your_redis_api_write_token
+   KV_REST_API_READ_ONLY_TOKEN=your_redis_api_read_token
+   ```
 
-# Set up Vercel KV
-vercel storage add
-# Select "KV" and follow the prompts
-```
+> **Note**: For production deployments, we use Vercel KV Storage integration, which provides a managed Redis-compatible store and automatically configures these environment variables. You can add this integration through the Vercel dashboard when deploying your project.
 
 #### b. Supabase Setup
 1. Create a new Supabase project


### PR DESCRIPTION
This pr contains `README` changes that help to resolve confusions seen in #17:
1. note for self-hosters to probably also host their own E2B infrastructure first
2. clarify kv store set-up and integration