### PR TITLE
Refactor /sandboxes/metrics to /sandboxes

### DIFF
--- a/src/features/dashboard/sandboxes/header.tsx
+++ b/src/features/dashboard/sandboxes/header.tsx
@@ -3,17 +3,16 @@ import { Circle, ListFilter } from 'lucide-react'
 import { Table } from '@tanstack/react-table'
 import { SearchInput } from './table-search'
 import SandboxesTableFilters from './table-filters'
-import { SandboxWithMetrics } from './table-config'
 import { PollingButton } from '@/ui/polling-button'
 import { useSandboxTableStore } from './stores/table-store'
-import { Template } from '@/types/api'
+import { Sandbox, Template } from '@/types/api'
 import { useRouter } from 'next/navigation'
 import { useTransition } from 'react'
 
 interface SandboxesHeaderProps {
   searchInputRef: React.RefObject<HTMLInputElement | null>
   templates: Template[]
-  table: Table<SandboxWithMetrics>
+  table: Table<Sandbox>
 }
 
 export function SandboxesHeader({

--- a/src/features/dashboard/sandboxes/table-body.tsx
+++ b/src/features/dashboard/sandboxes/table-body.tsx
@@ -1,18 +1,17 @@
-import { Alert, AlertDescription, AlertTitle } from '@/ui/primitives/alert'
 import { DataTableBody } from '@/ui/data-table'
 import { Table, Row } from '@tanstack/react-table'
-import { SandboxWithMetrics } from './table-config'
 import { memo, useMemo } from 'react'
 import Empty from '@/ui/empty'
 import { Button } from '@/ui/primitives/button'
 import { useSandboxTableStore } from './stores/table-store'
 import { ExternalLink, X } from 'lucide-react'
 import { TableRow } from './table-row'
+import { Sandbox } from '@/types/api'
 
 interface TableBodyProps {
-  sandboxes: SandboxWithMetrics[] | undefined
-  table: Table<SandboxWithMetrics>
-  visualRows: Row<SandboxWithMetrics>[]
+  sandboxes: Sandbox[] | undefined
+  table: Table<Sandbox>
+  visualRows: Row<Sandbox>[]
 }
 
 export const TableBody = memo(function TableBody({

--- a/src/features/dashboard/sandboxes/table-config.tsx
+++ b/src/features/dashboard/sandboxes/table-config.tsx
@@ -34,7 +34,7 @@ export const trackTableInteraction = (
 
 // FILTERS
 
-export const fuzzyFilter: FilterFn<SandboxWithMetrics> = (
+export const fuzzyFilter: FilterFn<Sandbox> = (
   row,
   columnId,
   value,
@@ -102,9 +102,9 @@ export const resourceRangeFilter: FilterFn<SandboxWithMetrics> = (
 
 // TABLE CONFIG
 
-export const fallbackData: SandboxWithMetrics[] = []
+export const fallbackData: Sandbox[] = []
 
-export const COLUMNS: ColumnDef<SandboxWithMetrics>[] = [
+export const COLUMNS: ColumnDef<Sandbox>[] = [
   {
     id: 'pin',
     cell: ({ row }) => (

--- a/src/features/dashboard/sandboxes/table-header.tsx
+++ b/src/features/dashboard/sandboxes/table-header.tsx
@@ -6,12 +6,12 @@ import {
   DataTableRow,
 } from '@/ui/data-table'
 import { flexRender, HeaderGroup, Row, TableState } from '@tanstack/react-table'
-import { SandboxWithMetrics } from './table-config'
 import Scanline from '@/ui/scanline'
+import { Sandbox } from '@/types/api'
 
 interface TableHeaderProps {
-  topRows: Row<SandboxWithMetrics>[]
-  headerGroups: HeaderGroup<SandboxWithMetrics>[]
+  topRows: Row<Sandbox>[]
+  headerGroups: HeaderGroup<Sandbox>[]
   state: TableState
 }
 

--- a/src/features/dashboard/sandboxes/table-row.tsx
+++ b/src/features/dashboard/sandboxes/table-row.tsx
@@ -1,12 +1,11 @@
 import { memo } from 'react'
 import { Row } from '@tanstack/react-table'
-import { SandboxWithMetrics } from './table-config'
 import { DataTableCell, DataTableRow } from '@/ui/data-table'
 import { flexRender } from '@tanstack/react-table'
-import { cn } from '@/lib/utils'
+import { Sandbox } from '@/types/api'
 
 interface TableRowProps {
-  row: Row<SandboxWithMetrics>
+  row: Row<Sandbox>
 }
 
 export const TableRow = memo(function TableRow({ row }: TableRowProps) {

--- a/src/features/dashboard/sandboxes/table.tsx
+++ b/src/features/dashboard/sandboxes/table.tsx
@@ -27,14 +27,14 @@ import { SandboxesHeader } from './header'
 import { TableBody } from './table-body'
 import { subHours } from 'date-fns'
 import { useColumnSizeVars } from '@/lib/hooks/use-column-size-vars'
-import { Template } from '@/types/api'
+import { Sandbox, Template } from '@/types/api'
 import ClientOnly from '@/ui/client-only'
 import TableHeader from './table-header'
 
 const INITIAL_VISUAL_ROWS_COUNT = 50
 
 interface SandboxesTableProps {
-  sandboxes: SandboxWithMetrics[]
+  sandboxes: Sandbox[]
   templates: Template[]
 }
 
@@ -181,7 +181,7 @@ export default function SandboxesTable({
       resourceRange: resourceRangeFilter,
     },
     enableGlobalFilter: true,
-    globalFilterFn: fuzzyFilter as FilterFn<SandboxWithMetrics>,
+    globalFilterFn: fuzzyFilter as FilterFn<Sandbox>,
     onGlobalFilterChange: setGlobalFilter,
     onSortingChange: setSorting,
     onColumnFiltersChange: setColumnFilters,

--- a/src/features/dashboard/sandboxes/table.tsx
+++ b/src/features/dashboard/sandboxes/table.tsx
@@ -117,19 +117,34 @@ export default function SandboxesTable({
 
     // Handle CPU filter
     if (!cpuCount) {
+      newFilters = newFilters.filter((f) => f.id !== 'cpuCount')
+    } else {
+      newFilters = newFilters.filter((f) => f.id !== 'cpuCount')
+      newFilters.push({ id: 'cpuCount', value: cpuCount })
+    }
+
+    // Handle memory filter
+    if (!memoryMB) {
+      newFilters = newFilters.filter((f) => f.id !== 'memoryMB')
+    } else {
+      newFilters = newFilters.filter((f) => f.id !== 'memoryMB')
+      newFilters.push({ id: 'memoryMB', value: memoryMB })
+    }
+
+    /* NOTE: Currently disabled due to issue with the metrics api
+    if (!cpuCount) {
       newFilters = newFilters.filter((f) => f.id !== 'cpuUsage')
     } else {
       newFilters = newFilters.filter((f) => f.id !== 'cpuUsage')
       newFilters.push({ id: 'cpuUsage', value: cpuCount })
     }
 
-    // Handle memory filter
     if (!memoryMB) {
       newFilters = newFilters.filter((f) => f.id !== 'ramUsage')
     } else {
       newFilters = newFilters.filter((f) => f.id !== 'ramUsage')
       newFilters.push({ id: 'ramUsage', value: memoryMB })
-    }
+    } */
 
     resetScroll()
     setColumnFilters(newFilters)

--- a/src/server/sandboxes/get-team-sandboxes.ts
+++ b/src/server/sandboxes/get-team-sandboxes.ts
@@ -8,6 +8,7 @@ import { SandboxWithMetrics } from '@/features/dashboard/sandboxes/table-config'
 import { authActionClient } from '@/lib/clients/action'
 import { returnServerError } from '@/lib/utils/action'
 import { getApiUrl, getTeamApiKey } from '@/lib/utils/server'
+import { Sandbox } from '@/types/api'
 
 const GetTeamSandboxesSchema = z.object({
   teamId: z.string().uuid(),
@@ -35,7 +36,7 @@ export const getTeamSandboxes = authActionClient
     const apiKey = await getTeamApiKey(user.id, teamId)
     const { url } = await getApiUrl()
 
-    const res = await fetch(`${url}/sandboxes/metrics`, {
+    const res = await fetch(`${url}/sandboxes`, {
       method: 'GET',
       headers: {
         'Content-Type': 'application/json',
@@ -45,7 +46,7 @@ export const getTeamSandboxes = authActionClient
 
     if (!res.ok) {
       const content = await res.text()
-      logError(ERROR_CODES.INFRA, '/sandboxes/metrics', content)
+      logError(ERROR_CODES.INFRA, '/sandboxes', content)
 
       // this case should never happen for the original reason, hence we assume the user defined the wrong infra domain
       return returnServerError(
@@ -53,7 +54,7 @@ export const getTeamSandboxes = authActionClient
       )
     }
 
-    const json = (await res.json()) as SandboxWithMetrics[]
+    const json = (await res.json()) as Sandbox[]
 
     return json
   })

--- a/src/ui/json-popover.tsx
+++ b/src/ui/json-popover.tsx
@@ -7,13 +7,15 @@ import {
 import { useState } from 'react'
 import ShikiHighlighter from 'react-shiki'
 import { ScrollArea, ScrollBar } from './primitives/scroll-area'
+import { cn } from '@/lib/utils'
 
 interface JsonPopoverProps {
   json: unknown
   children: React.ReactNode
+  className?: string
 }
 
-export function JsonPopover({ json, children }: JsonPopoverProps) {
+export function JsonPopover({ json, children, className }: JsonPopoverProps) {
   const [isOpen, setIsOpen] = useState(false)
 
   const shikiTheme = useShikiTheme()
@@ -22,7 +24,10 @@ export function JsonPopover({ json, children }: JsonPopoverProps) {
     <Popover open={isOpen} onOpenChange={setIsOpen}>
       <PopoverTrigger asChild>
         <div
-          className="hover:text-fg text-fg-300 h-full cursor-pointer truncate whitespace-nowrap hover:underline"
+          className={cn(
+            'h-full cursor-pointer truncate whitespace-nowrap',
+            className
+          )}
           onDoubleClick={() => setIsOpen(true)}
         >
           {children}


### PR DESCRIPTION
Because of production issues with the /sandboxes/metrics route and in order to unblock the launch of the new dashboard, this pr temporarily refactors:
1. sandboxes page ui artifacts related to metrics
2. how sandboxes are retrieved from api (`/sandboxes/metrics` -> `/sandboxes`)