### PR TITLE
Fix table sorting function to not sort based on date time string

### DIFF
--- a/src/features/dashboard/sandboxes/table-config.tsx
+++ b/src/features/dashboard/sandboxes/table-config.tsx
@@ -337,5 +337,10 @@ export const COLUMNS: ColumnDef<Sandbox>[] = [
     // @ts-expect-error dateRange is not a valid filterFn
     filterFn: 'dateRange',
     enableColumnFilter: true,
+    sortingFn: (rowA, rowB) => {
+      const dateA = new Date(rowA.original.startedAt).getTime();
+      const dateB = new Date(rowB.original.startedAt).getTime();
+      return dateA - dateB;
+    },
   },
 ]

--- a/src/features/dashboard/sandboxes/table-config.tsx
+++ b/src/features/dashboard/sandboxes/table-config.tsx
@@ -317,12 +317,18 @@ export const COLUMNS: ColumnDef<Sandbox>[] = [
   },
   {
     id: 'startedAt',
-    accessorFn: (row) => new Date(row.startedAt).toUTCString(),
+    accessorKey: 'startedAt',
     header: 'Started At',
     cell: ({ row, getValue }) => {
-      const dateTimeString = getValue() as string
-      // Split the date and time parts
-      const [day, date, month, year, time, timezone] = dateTimeString.split(' ')
+      const dateValue = getValue() as string;
+
+      const dateTimeString = useMemo(() => {
+        return new Date(dateValue).toUTCString();
+      }, [dateValue]);
+
+      const [day, date, month, year, time, timezone] = useMemo(() => {
+        return dateTimeString.split(' ');
+      }, [dateTimeString]);
 
       return (
         <div className={cn('h-full truncate font-mono text-xs')}>
@@ -338,9 +344,7 @@ export const COLUMNS: ColumnDef<Sandbox>[] = [
     filterFn: 'dateRange',
     enableColumnFilter: true,
     sortingFn: (rowA, rowB) => {
-      const dateA = new Date(rowA.original.startedAt).getTime();
-      const dateB = new Date(rowB.original.startedAt).getTime();
-      return dateA - dateB;
+      return rowA.original.startedAt.localeCompare(rowB.original.startedAt);
     },
   },
 ]

--- a/src/features/dashboard/sandboxes/table.tsx
+++ b/src/features/dashboard/sandboxes/table.tsx
@@ -171,7 +171,7 @@ export default function SandboxesTable({
     getFilteredRowModel: getFilteredRowModel(),
     getSortedRowModel: getSortedRowModel(),
     enableSorting: true,
-    enableMultiSort: true,
+    enableMultiSort: false,
     columnResizeMode: 'onChange' as const,
     enableColumnResizing: true,
     keepPinnedRows: true,

--- a/src/features/dashboard/templates/table-config.tsx
+++ b/src/features/dashboard/templates/table-config.tsx
@@ -300,11 +300,24 @@ export const useColumns = (deps: unknown[]) => {
         header: 'Created At',
         size: 250,
         minSize: 140,
-        cell: ({ getValue }) => (
-          <div className="text-fg-500 truncate font-mono text-xs">
-            {getValue() as string}
-          </div>
-        ),
+        cell: ({ row, getValue }) => {
+          const dateTimeString = getValue() as string
+          // Split the date and time parts
+          const [day, date, month, year, time, timezone] = dateTimeString.split(' ')
+
+          return (
+            <div className={cn('h-full truncate font-mono text-xs')}>
+              <span className="text-fg-500">{`${day} ${date} ${month} ${year}`}</span>{' '}
+              <span className="text-fg">{time}</span>{' '}
+              <span className="text-fg-500">{timezone}</span>
+            </div>
+          )
+        },
+        sortingFn: (rowA, rowB) => {
+          const dateA = new Date(rowA.original.createdAt).getTime();
+          const dateB = new Date(rowB.original.createdAt).getTime();
+          return dateA - dateB;
+        },
       },
       {
         accessorFn: (row) => new Date(row.updatedAt).toUTCString(),
@@ -313,11 +326,24 @@ export const useColumns = (deps: unknown[]) => {
         size: 250,
         minSize: 140,
         enableGlobalFilter: true,
-        cell: ({ getValue }) => (
-          <div className="text-fg-500 truncate font-mono text-xs">
-            {getValue() as string}
-          </div>
-        ),
+        cell: ({ row, getValue }) => {
+          const dateTimeString = getValue() as string
+          // Split the date and time parts
+          const [day, date, month, year, time, timezone] = dateTimeString.split(' ')
+
+          return (
+            <div className={cn('h-full truncate font-mono text-xs')}>
+              <span className="text-fg-500">{`${day} ${date} ${month} ${year}`}</span>{' '}
+              <span className="text-fg">{time}</span>{' '}
+              <span className="text-fg-500">{timezone}</span>
+            </div>
+          )
+        },
+        sortingFn: (rowA, rowB) => {
+          const dateA = new Date(rowA.original.updatedAt).getTime();
+          const dateB = new Date(rowB.original.updatedAt).getTime();
+          return dateA - dateB;
+        },
       },
       {
         accessorKey: 'public',
@@ -351,7 +377,7 @@ export const templatesTableConfig: Partial<
   getFilteredRowModel: getFilteredRowModel(),
   getSortedRowModel: getSortedRowModel(),
   enableSorting: true,
-  enableMultiSort: true,
+  enableMultiSort: false,
   columnResizeMode: 'onChange',
   enableColumnResizing: true,
   enableGlobalFilter: true,

--- a/src/features/dashboard/templates/table-config.tsx
+++ b/src/features/dashboard/templates/table-config.tsx
@@ -294,16 +294,22 @@ export const useColumns = (deps: unknown[]) => {
         filterFn: 'equals',
       },
       {
-        accessorFn: (row) => new Date(row.createdAt).toUTCString(),
+        accessorKey: 'createdAt',
         enableGlobalFilter: true,
         id: 'createdAt',
         header: 'Created At',
         size: 250,
         minSize: 140,
         cell: ({ row, getValue }) => {
-          const dateTimeString = getValue() as string
-          // Split the date and time parts
-          const [day, date, month, year, time, timezone] = dateTimeString.split(' ')
+          const dateValue = getValue() as string;
+
+          const dateTimeString = useMemo(() => {
+            return new Date(dateValue).toUTCString();
+          }, [dateValue]);
+
+          const [day, date, month, year, time, timezone] = useMemo(() => {
+            return dateTimeString.split(' ');
+          }, [dateTimeString]);
 
           return (
             <div className={cn('h-full truncate font-mono text-xs')}>
@@ -314,22 +320,26 @@ export const useColumns = (deps: unknown[]) => {
           )
         },
         sortingFn: (rowA, rowB) => {
-          const dateA = new Date(rowA.original.createdAt).getTime();
-          const dateB = new Date(rowB.original.createdAt).getTime();
-          return dateA - dateB;
+          return rowA.original.createdAt.localeCompare(rowB.original.createdAt);
         },
       },
       {
-        accessorFn: (row) => new Date(row.updatedAt).toUTCString(),
+        accessorKey: 'updatedAt',
         id: 'updatedAt',
         header: 'Updated At',
         size: 250,
         minSize: 140,
         enableGlobalFilter: true,
         cell: ({ row, getValue }) => {
-          const dateTimeString = getValue() as string
-          // Split the date and time parts
-          const [day, date, month, year, time, timezone] = dateTimeString.split(' ')
+          const dateValue = getValue() as string;
+
+          const dateTimeString = useMemo(() => {
+            return new Date(dateValue).toUTCString();
+          }, [dateValue]);
+
+          const [day, date, month, year, time, timezone] = useMemo(() => {
+            return dateTimeString.split(' ');
+          }, [dateTimeString]);
 
           return (
             <div className={cn('h-full truncate font-mono text-xs')}>
@@ -340,9 +350,7 @@ export const useColumns = (deps: unknown[]) => {
           )
         },
         sortingFn: (rowA, rowB) => {
-          const dateA = new Date(rowA.original.updatedAt).getTime();
-          const dateB = new Date(rowB.original.updatedAt).getTime();
-          return dateA - dateB;
+          return rowA.original.updatedAt.localeCompare(rowB.original.updatedAt);
         },
       },
       {


### PR DESCRIPTION
Currently the table date time columns sorted based on their date time string representations. This pr fixes this, along with disabling multiple sortings at once, since this behavior was confusing users.