### PR TITLE
Remove /changelog rewrite

### DIFF
--- a/src/app/(rewrites)/[[...slug]]/route.ts
+++ b/src/app/(rewrites)/[[...slug]]/route.ts
@@ -36,7 +36,6 @@ export async function GET(request: NextRequest): Promise<Response> {
       '/pricing': LANDING_PAGE_DOMAIN,
       '/cookbook': LANDING_PAGE_DOMAIN,
       '/contact': LANDING_PAGE_DOMAIN,
-      '/changelog': LANDING_PAGE_DOMAIN,
       '/blog': LANDING_PAGE_DOMAIN,
       '/ai-agents': LANDING_PAGE_FRAMER_DOMAIN,
       '/docs': DOCS_NEXT_DOMAIN,


### PR DESCRIPTION
As a result of pausing the work on our Changelog, this pr removes the rewrite for `/changelog` routes/