### PR TITLE
Add NO_INDEX & VERBOSE flags

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -65,3 +65,6 @@ NEXT_PUBLIC_DEFAULT_API_DOMAIN=e2b.dev
 
 # Set to 1 to use mock data
 # NEXT_PUBLIC_MOCK_DATA=0
+
+# Set to 1 to enable verbose logging
+# NEXT_PUBLIC_VERBOSE=0

--- a/.env.example
+++ b/.env.example
@@ -41,6 +41,9 @@ NEXT_PUBLIC_DEFAULT_API_DOMAIN=e2b.dev
 # ZeroBounce API key for email validation
 # ZEROBOUNCE_API_KEY=
 
+# Set to 1 to enable no-indexing
+# NO_INDEX=0
+
 # =================================
 # OPTIONAL CLIENT ENVIRONMENT VARIABLES
 # =================================

--- a/src/app/(rewrites)/[[...slug]]/route.ts
+++ b/src/app/(rewrites)/[[...slug]]/route.ts
@@ -81,23 +81,9 @@ export async function GET(request: NextRequest): Promise<Response> {
       const newHeaders = new Headers(res.headers)
       newHeaders.delete('content-encoding')
 
-      // take precautions if NO_INDEX is set
+      // Add noindex header if NO_INDEX is set
       if (NO_INDEX) {
-        // add noindex header
         newHeaders.set('X-Robots-Tag', 'noindex, nofollow')
-        // remove any existing robots meta tags and add our own
-        const modifiedHtml = modifiedHtmlBody
-          .replace(/<meta[^>]*name=["']robots["'][^>]*>/gi, '')
-          .replace(
-            /<head[^>]*>/i,
-            (match) =>
-              `${match}<meta name="robots" content="noindex, nofollow">`
-          )
-
-        return new Response(modifiedHtml, {
-          status: res.status,
-          headers: newHeaders,
-        })
       }
 
       return new Response(modifiedHtmlBody, {

--- a/src/app/(rewrites)/[[...slug]]/route.ts
+++ b/src/app/(rewrites)/[[...slug]]/route.ts
@@ -8,6 +8,7 @@ import { ERROR_CODES } from '@/configs/logs'
 import { NextRequest } from 'next/server'
 import sitemap from '@/app/sitemap'
 import { BASE_URL } from '@/configs/urls'
+import { NO_INDEX } from '@/lib/utils/flags'
 
 export const revalidate = 900
 export const dynamic = 'force-static'
@@ -79,6 +80,25 @@ export async function GET(request: NextRequest): Promise<Response> {
       // create new headers without content-encoding to ensure proper rendering
       const newHeaders = new Headers(res.headers)
       newHeaders.delete('content-encoding')
+
+      // take precautions if NO_INDEX is set
+      if (NO_INDEX) {
+        // add noindex header
+        newHeaders.set('X-Robots-Tag', 'noindex, nofollow')
+        // remove any existing robots meta tags and add our own
+        const modifiedHtml = modifiedHtmlBody
+          .replace(/<meta[^>]*name=["']robots["'][^>]*>/gi, '')
+          .replace(
+            /<head[^>]*>/i,
+            (match) =>
+              `${match}<meta name="robots" content="noindex, nofollow">`
+          )
+
+        return new Response(modifiedHtml, {
+          status: res.status,
+          headers: newHeaders,
+        })
+      }
 
       return new Response(modifiedHtmlBody, {
         status: res.status,

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -12,6 +12,7 @@ import { Toaster } from '@/ui/primitives/toaster'
 import Head from 'next/head'
 import { GTMHead } from '@/features/google-tag-manager'
 import { Analytics } from '@vercel/analytics/next'
+import { NO_INDEX } from '@/lib/utils/flags'
 
 export const metadata: Metadata = {
   metadataBase: new URL(BASE_URL),
@@ -28,6 +29,7 @@ export const metadata: Metadata = {
     title: METADATA.title,
     description: METADATA.description,
   },
+  robots: NO_INDEX ? 'noindex, nofollow' : 'index, follow',
 }
 
 export default function RootLayout({

--- a/src/app/robots.ts
+++ b/src/app/robots.ts
@@ -1,11 +1,21 @@
-import { MetadataRoute } from 'next'
+import type { MetadataRoute } from 'next'
+import { NO_INDEX } from '@/lib/utils/flags'
 
 export default function robots(): MetadataRoute.Robots {
+  if (NO_INDEX) {
+    return {
+      rules: {
+        userAgent: '*',
+        disallow: '/',
+      },
+    }
+  }
+
   return {
     rules: {
       userAgent: '*',
       allow: '/',
     },
-    sitemap: 'https://e2b.dev/sitemap.xml',
+    sitemap: `${process.env.NEXT_PUBLIC_SUPABASE_URL}/sitemap.xml`,
   }
 }

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -15,6 +15,7 @@ import {
   LANDING_PAGE_FRAMER_DOMAIN,
 } from '@/configs/domains'
 import { BLOG_FRAMER_DOMAIN } from '@/configs/domains'
+import { NO_INDEX } from '@/lib/utils/flags'
 
 // Cache the sitemap for 24 hours (in seconds)
 const SITEMAP_CACHE_TIME = 24 * 60 * 60
@@ -168,6 +169,11 @@ async function getSitemap(site: Site): Promise<MetadataRoute.Sitemap> {
  * @returns Complete sitemap for the E2B website
  */
 export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
+  // Return empty sitemap if NO_INDEX is set
+  if (NO_INDEX) {
+    return []
+  }
+
   let mergedSitemap: MetadataRoute.Sitemap = []
 
   // Fetch sitemaps from all configured sites (Webflow & Framer sites + docs)

--- a/src/lib/clients/action.ts
+++ b/src/lib/clients/action.ts
@@ -4,6 +4,7 @@ import { z } from 'zod'
 import { UnknownError } from '@/types/errors'
 import { logDebug, logError, logSuccess } from './logger'
 import { ActionError } from '../utils/action'
+import { VERBOSE } from '../utils/flags'
 
 export const actionClient = createSafeActionClient({
   handleServerError(e) {
@@ -31,7 +32,7 @@ export const actionClient = createSafeActionClient({
   defaultValidationErrorsShape: 'flattened',
 }).use(async ({ next, clientInput, metadata }) => {
   let startTime
-  if (process.env.NODE_ENV === 'development') {
+  if (VERBOSE) {
     startTime = performance.now()
   }
 
@@ -56,14 +57,14 @@ export const actionClient = createSafeActionClient({
       result: rest,
       input: clientInput,
     })
-  } else if (process.env.NODE_ENV === 'development') {
+  } else if (VERBOSE) {
     logSuccess(`${actionOrFunction} '${actionOrFunctionName}' succeeded:`, {
       result: rest,
       input: clientInput,
     })
   }
 
-  if (process.env.NODE_ENV === 'development' && startTime) {
+  if (VERBOSE && startTime) {
     const endTime = performance.now()
     logDebug(
       `${actionOrFunction} '${actionOrFunctionName}' execution took ${endTime - startTime} ms`

--- a/src/lib/env.ts
+++ b/src/lib/env.ts
@@ -3,6 +3,7 @@ import { z } from 'zod'
 export const serverSchema = z.object({
   SUPABASE_SERVICE_ROLE_KEY: z.string().min(1),
   COOKIE_ENCRYPTION_KEY: z.string().min(32),
+  NO_INDEX: z.string().optional(),
 
   BILLING_API_URL: z.string().url().optional(),
   DEVELOPMENT_INFRA_API_DOMAIN: z.string().optional(),

--- a/src/lib/env.ts
+++ b/src/lib/env.ts
@@ -26,6 +26,7 @@ export const clientSchema = z.object({
   NEXT_PUBLIC_EXPOSE_STORYBOOK: z.string().optional(),
   NEXT_PUBLIC_SCAN: z.string().optional(),
   NEXT_PUBLIC_MOCK_DATA: z.string().optional(),
+  NEXT_PUBLIC_VERBOSE: z.string().optional(),
 })
 
 export const testEnvSchema = z.object({

--- a/src/lib/utils/flags.ts
+++ b/src/lib/utils/flags.ts
@@ -1,1 +1,4 @@
 export const NO_INDEX = process.env.NO_INDEX === '1'
+export const VERBOSE =
+  process.env.NODE_ENV === 'development' ||
+  process.env.NEXT_PUBLIC_VERBOSE === '1'

--- a/src/lib/utils/flags.ts
+++ b/src/lib/utils/flags.ts
@@ -1,0 +1,1 @@
+export const NO_INDEX = process.env.NO_INDEX === '1'


### PR DESCRIPTION
In order to prevent search engine indexing for our staging / juliett dashboards, but keep rewriting intact for each, this pr adds a NO_INDEX environment variable which takes precautions to tell site crawlers to not index this site.

Additionally this pr:
- adds a NEXT_PUBLIC_VERBOSE environment variable, for better observability in production builds if needed
- try-catches json serialization for sandboxes metadata search