### PR TITLE
Update rewrite cookbook page in middleware

### DIFF
--- a/src/configs/rewrites.ts
+++ b/src/configs/rewrites.ts
@@ -21,7 +21,6 @@ export const ROUTE_REWRITE_CONFIG: DomainConfig[] = [
       { path: '/privacy' },
       { path: '/pricing' },
       { path: '/thank-you' },
-      { path: '/cookbook' },
       { path: '/contact' },
       {
         path: '/blog/category',
@@ -35,6 +34,10 @@ export const ROUTE_REWRITE_CONFIG: DomainConfig[] = [
 
 // Middleware native rewrite config
 export const MIDDLEWARE_REWRITE_CONFIG: DomainConfig[] = [
+  {
+    domain: LANDING_PAGE_DOMAIN,
+    rules: [{ path: '/cookbook' }],
+  },
   {
     domain: DOCS_NEXT_DOMAIN,
     rules: [{ path: '/docs' }],


### PR DESCRIPTION
To fix data fetching issues on our `/cookbook` route, we move the rewrite to the middleware using nextjs native rewrites instead of fetch html rewrites.