### PR TITLE
Improve ux for default "email" team names

### DIFF
--- a/src/configs/keys.ts
+++ b/src/configs/keys.ts
@@ -1,20 +1,4 @@
 /*
- * local storage keys in use
- */
-export const STORAGE_KEYS = {
-  SELECTED_TEAM_ID: 'selected_team_id',
-  DEVELOPER_SETTINGS: 'developer_settings',
-}
-
-/*
- * react-query keys in use
- */
-export const QUERY_KEYS = {
-  USER: () => 'user',
-  TEAMS: () => 'user-teams',
-}
-
-/*
  * cookie keys in use
  */
 export const COOKIE_KEYS = {

--- a/src/features/dashboard/sandboxes/stores/table-store.ts
+++ b/src/features/dashboard/sandboxes/stores/table-store.ts
@@ -6,7 +6,7 @@ import {
   SortingState,
 } from '@tanstack/react-table'
 import { StartedAtFilter } from '../table-filters'
-import { PollingInterval } from '@/types/dashboard'
+import { PollingInterval } from '@/types/dashboard.types'
 import { createHashStorage } from '@/lib/utils/store'
 import { trackTableInteraction } from '../table-config'
 

--- a/src/features/dashboard/sidebar/menu.tsx
+++ b/src/features/dashboard/sidebar/menu.tsx
@@ -92,7 +92,7 @@ export default function DashboardSidebarMenu({
                 </span>
                 {selectedTeam ? (
                   <span className="text-fg truncate font-sans text-sm normal-case">
-                    {selectedTeam.name}
+                    {selectedTeam.transformed_default_name || selectedTeam.name}
                   </span>
                 ) : (
                   <Skeleton className="h-4 w-full" />
@@ -128,7 +128,7 @@ export default function DashboardSidebarMenu({
                       </AvatarFallback>
                     </Avatar>
                     <span className="flex-1 truncate font-sans">
-                      {team.name}
+                      {team.transformed_default_name || team.name}
                     </span>
                   </DropdownMenuRadioItem>
                 ))

--- a/src/features/dashboard/team/name-card.tsx
+++ b/src/features/dashboard/team/name-card.tsx
@@ -5,7 +5,6 @@ import { Button } from '@/ui/primitives/button'
 import { Input } from '@/ui/primitives/input'
 import { Skeleton } from '@/ui/primitives/skeleton'
 import { useSelectedTeam } from '@/lib/hooks/use-teams'
-import { useEffect } from 'react'
 import { zodResolver } from '@hookform/resolvers/zod'
 import {
   Card,

--- a/src/features/dashboard/team/name-card.tsx
+++ b/src/features/dashboard/team/name-card.tsx
@@ -20,6 +20,7 @@ import {
   FormItem,
   FormControl,
   FormMessage,
+  FormLabel,
 } from '@/ui/primitives/form'
 import { useToast } from '@/lib/hooks/use-toast'
 import { defaultSuccessToast, defaultErrorToast } from '@/lib/hooks/use-toast'
@@ -91,7 +92,7 @@ export function NameCard({ className }: NameCardProps) {
           Change your team name to display on your invoices and receipts.
         </CardDescription>
       </CardHeader>
-      <CardContent>
+      <CardContent className="pt-0">
         {team ? (
           <Form {...form}>
             <form
@@ -102,10 +103,18 @@ export function NameCard({ className }: NameCardProps) {
                 control={form.control}
                 name="name"
                 render={({ field }) => (
-                  <FormItem className="flex-1">
+                  <FormItem className="flex-1 gap-1">
                     <FormControl>
                       <Input placeholder="Acme, Inc." {...field} />
                     </FormControl>
+                    {team.transformed_default_name && (
+                      <span className="text-fg-500 ml-0.5 text-xs">
+                        Seen as -{' '}
+                        <span className="text-contrast-2">
+                          {team.transformed_default_name}
+                        </span>
+                      </span>
+                    )}
                     <FormMessage />
                   </FormItem>
                 )}

--- a/src/features/dashboard/team/name-card.tsx
+++ b/src/features/dashboard/team/name-card.tsx
@@ -20,7 +20,6 @@ import {
   FormItem,
   FormControl,
   FormMessage,
-  FormLabel,
 } from '@/ui/primitives/form'
 import { useToast } from '@/lib/hooks/use-toast'
 import { defaultSuccessToast, defaultErrorToast } from '@/lib/hooks/use-toast'
@@ -115,7 +114,7 @@ export function NameCard({ className }: NameCardProps) {
                         </span>
                       </span>
                     )}
-                    <FormMessage />
+                    <FormMessage className="mt-1" />
                   </FormItem>
                 )}
               />

--- a/src/features/dashboard/team/name-card.tsx
+++ b/src/features/dashboard/team/name-card.tsx
@@ -25,6 +25,8 @@ import { useToast } from '@/lib/hooks/use-toast'
 import { defaultSuccessToast, defaultErrorToast } from '@/lib/hooks/use-toast'
 import { UpdateTeamNameSchema } from '@/server/team/types'
 import { useHookFormOptimisticAction } from '@next-safe-action/adapter-react-hook-form/hooks'
+import { AnimatePresence, motion } from 'motion/react'
+import { exponentialSmoothing } from '@/lib/utils'
 
 interface NameCardProps {
   className?: string
@@ -106,14 +108,28 @@ export function NameCard({ className }: NameCardProps) {
                     <FormControl>
                       <Input placeholder="Acme, Inc." {...field} />
                     </FormControl>
-                    {team.transformed_default_name && (
-                      <span className="text-fg-500 ml-0.5 text-xs">
-                        Seen as -{' '}
-                        <span className="text-contrast-2">
-                          {team.transformed_default_name}
-                        </span>
-                      </span>
-                    )}
+                    <AnimatePresence initial={false}>
+                      {team.transformed_default_name && (
+                        <motion.span
+                          className="text-fg-500 ml-0.5 text-xs"
+                          animate={{
+                            opacity: 1,
+                            filter: 'blur(0px)',
+                            height: 'auto',
+                          }}
+                          exit={{ opacity: 0, filter: 'blur(4px)', height: 0 }}
+                          transition={{
+                            duration: 0.4,
+                            ease: exponentialSmoothing(3),
+                          }}
+                        >
+                          Seen as -{' '}
+                          <span className="text-contrast-2">
+                            {team.transformed_default_name}
+                          </span>
+                        </motion.span>
+                      )}
+                    </AnimatePresence>
                     <FormMessage className="mt-1" />
                   </FormItem>
                 )}

--- a/src/features/dashboard/team/profile-picture-card.tsx
+++ b/src/features/dashboard/team/profile-picture-card.tsx
@@ -1,6 +1,5 @@
 'use client'
 
-import { Skeleton } from '@/ui/primitives/skeleton'
 import { useSelectedTeam, useTeams } from '@/lib/hooks/use-teams'
 import { useRef, useState } from 'react'
 import { useToast } from '@/lib/hooks/use-toast'
@@ -56,7 +55,7 @@ export function ProfilePictureCard({ className }: ProfilePictureCardProps) {
     if (e.target.files && e.target.files[0] && team?.id) {
       const file = e.target.files[0]
 
-      const MAX_FILE_SIZE = 5 * 1024 * 1024 // 5MB (or match your config limit)
+      const MAX_FILE_SIZE = 5 * 1024 * 1024 // 5MB in bytes
 
       if (file.size > MAX_FILE_SIZE) {
         toast(
@@ -114,7 +113,7 @@ export function ProfilePictureCard({ className }: ProfilePictureCardProps) {
             </Badge>
           </AvatarFallback>
           <AnimatePresence>
-            {isHovered && !isUploading && (
+            {isHovered && !isUploading ? (
               <motion.div
                 className={cn(
                   cardVariants({ variant: 'layer' }),
@@ -139,38 +138,34 @@ export function ProfilePictureCard({ className }: ProfilePictureCardProps) {
               >
                 <Pencil className="h-5 w-5 text-white" />
               </motion.div>
-            )}
+            ) : isUploading ? (
+              <motion.div
+                className={cn(
+                  cardVariants({ variant: 'layer' }),
+                  'absolute top-1/2 left-1/2 flex size-10 -translate-x-1/2 -translate-y-1/2 items-center justify-center rounded-full'
+                )}
+                variants={{
+                  initial: {
+                    opacity: 0,
+                    scale: 0,
+                    filter: 'blur(8px)',
+                  },
+                  animate: {
+                    opacity: 1,
+                    scale: 1,
+                    filter: 'blur(0px)',
+                  },
+                }}
+                initial="initial"
+                animate="animate"
+                exit="initial"
+                transition={{ duration: 0.2, ease: exponentialSmoothing(5) }}
+              >
+                <Loader2 className="h-5 w-5 animate-spin text-white" />
+              </motion.div>
+            ) : null}
           </AnimatePresence>
         </Avatar>
-
-        <AnimatePresence>
-          {isUploading && (
-            <motion.div
-              className={cn(
-                cardVariants({ variant: 'layer' }),
-                'absolute top-1/2 left-1/2 flex size-10 -translate-x-1/2 -translate-y-1/2 items-center justify-center rounded-full'
-              )}
-              variants={{
-                initial: {
-                  opacity: 0,
-                  scale: 0,
-                  filter: 'blur(8px)',
-                },
-                animate: {
-                  opacity: 1,
-                  scale: 1,
-                  filter: 'blur(0px)',
-                },
-              }}
-              initial="initial"
-              animate="animate"
-              exit="initial"
-              transition={{ duration: 0.2, ease: exponentialSmoothing(5) }}
-            >
-              <Loader2 className="h-5 w-5 animate-spin text-white" />
-            </motion.div>
-          )}
-        </AnimatePresence>
       </div>
       <input
         type="file"

--- a/src/lib/hooks/use-server-context.tsx
+++ b/src/lib/hooks/use-server-context.tsx
@@ -1,14 +1,14 @@
 'use client'
 
-import { TeamWithDefault } from '@/types/dashboard'
+import { ClientTeam } from '@/types/dashboard'
 import { User } from '@supabase/supabase-js'
 import { createContext, useContext, ReactNode } from 'react'
 
 interface ServerContextValue {
   selectedTeamId: string | null
   selectedTeamSlug: string | null
-  teams: TeamWithDefault[]
-  selectedTeam: TeamWithDefault | null
+  teams: ClientTeam[]
+  selectedTeam: ClientTeam | null
   user: User
 }
 
@@ -18,8 +18,8 @@ interface ServerContextProviderProps {
   children: ReactNode
   teamId?: string | null
   teamSlug?: string | null
-  teams: TeamWithDefault[]
-  selectedTeam: TeamWithDefault | null
+  teams: ClientTeam[]
+  selectedTeam: ClientTeam | null
   user: User
 }
 

--- a/src/lib/hooks/use-server-context.tsx
+++ b/src/lib/hooks/use-server-context.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { ClientTeam } from '@/types/dashboard'
+import { ClientTeam } from '@/types/dashboard.types'
 import { User } from '@supabase/supabase-js'
 import { createContext, useContext, ReactNode } from 'react'
 

--- a/src/server/team/get-team.ts
+++ b/src/server/team/get-team.ts
@@ -1,7 +1,7 @@
 import 'server-only'
 
 import { supabaseAdmin } from '@/lib/clients/supabase/admin'
-import { ClientTeam } from '@/types/dashboard'
+import { ClientTeam } from '@/types/dashboard.types'
 import { z } from 'zod'
 import { authActionClient } from '@/lib/clients/action'
 import { returnServerError } from '@/lib/utils/action'

--- a/src/server/team/get-team.ts
+++ b/src/server/team/get-team.ts
@@ -1,7 +1,7 @@
 import 'server-only'
 
 import { supabaseAdmin } from '@/lib/clients/supabase/admin'
-import { TeamWithDefault } from '@/types/dashboard'
+import { ClientTeam } from '@/types/dashboard'
 import { z } from 'zod'
 import { authActionClient } from '@/lib/clients/action'
 import { returnServerError } from '@/lib/utils/action'
@@ -39,12 +39,12 @@ export const getTeam = authActionClient
       throw teamError
     }
 
-    const teamWithDefault: TeamWithDefault = {
+    const ClientTeam: ClientTeam = {
       ...team,
       is_default: userTeamsRelationData?.is_default,
     }
 
-    return teamWithDefault
+    return ClientTeam
   })
 
 export const getUserTeams = authActionClient
@@ -98,7 +98,7 @@ export const getUserTeams = authActionClient
       authUsers?.map((user) => [user.id, user.email]) || []
     )
 
-    const teams: TeamWithDefault[] = usersTeamsData.map((userTeam) => {
+    const teams: ClientTeam[] = usersTeamsData.map((userTeam) => {
       const team = userTeam.teams
       const isDefault = defaultTeamIds.has(team.id)
 

--- a/src/server/team/get-team.ts
+++ b/src/server/team/get-team.ts
@@ -103,10 +103,16 @@ export const getUserTeams = authActionClient
       const isDefault = defaultTeamIds.has(team.id)
 
       let transformedDefaultName
+      // generate a transformed default name if the team is a default team and the team name is the same as the default user's email
       if (isDefault && team.name === userEmailMap.get(userTeam.user_id)) {
         const email = team.name
-        const username = email.split('@')[0]
-        transformedDefaultName = `Team of ${username}`
+        const splitEmail = email.split('@')
+
+        if (splitEmail.length > 0 && splitEmail[0]) {
+          const username =
+            splitEmail[0].charAt(0).toUpperCase() + splitEmail[0].slice(1)
+          transformedDefaultName = `${username}'s Team`
+        }
       }
 
       return {

--- a/src/server/team/types.ts
+++ b/src/server/team/types.ts
@@ -24,7 +24,7 @@ export const TeamNameSchema = z
   .max(32, { message: 'Team name cannot be longer than 32 characters' })
   .regex(/^[a-zA-Z0-9]+(?:[ _-][a-zA-Z0-9]+)*$/, {
     message:
-      'Words can only contain letters and numbers, separated by spaces, underscores, or hyphens',
+      'Names can only contain letters and numbers, separated by spaces, underscores, or hyphens',
   })
 
 // Shared schemas

--- a/src/types/actions.d.ts
+++ b/src/types/actions.d.ts
@@ -1,4 +1,4 @@
-import { ClientTeam } from './dashboard'
+import { ClientTeam } from './dashboard.types'
 
 /*
  * Server actions do not return thrown error messages in production, for security.

--- a/src/types/actions.d.ts
+++ b/src/types/actions.d.ts
@@ -1,4 +1,4 @@
-import { TeamWithDefault } from './dashboard'
+import { ClientTeam } from './dashboard'
 
 /*
  * Server actions do not return thrown error messages in production, for security.

--- a/src/types/dashboard.d.ts
+++ b/src/types/dashboard.d.ts
@@ -1,6 +1,6 @@
 import { Database } from './database.types'
 
-export type TeamWithDefault = Database['public']['Tables']['teams']['Row'] & {
+export type ClientTeam = Database['public']['Tables']['teams']['Row'] & {
   is_default?: boolean
   // provides a transformed name for teams that are default ones and have "unchanged" default names
   // e.g. "max.mustermann@gmail.com" -> "Team of max.mustermann"

--- a/src/types/dashboard.d.ts
+++ b/src/types/dashboard.d.ts
@@ -2,6 +2,9 @@ import { Database } from './database.types'
 
 export type TeamWithDefault = Database['public']['Tables']['teams']['Row'] & {
   is_default?: boolean
+  // provides a transformed name for teams that are default ones and have "unchanged" default names
+  // e.g. "max.mustermann@gmail.com" -> "Team of max.mustermann"
+  transformed_default_name?: string
 }
 
 export type PollingInterval = 0 | 15 | 30 | 60 // seconds

--- a/src/types/dashboard.types.ts
+++ b/src/types/dashboard.types.ts
@@ -3,7 +3,7 @@ import { Database } from './database.types'
 export type ClientTeam = Database['public']['Tables']['teams']['Row'] & {
   is_default?: boolean
   // provides a transformed name for teams that are default ones and have "unchanged" default names
-  // e.g. "max.mustermann@gmail.com" -> "Team of max.mustermann"
+  // e.g. "max.mustermann@gmail.com" -> "Max.mustermann's Team"
   transformed_default_name?: string
 }
 

--- a/src/ui/polling-button.tsx
+++ b/src/ui/polling-button.tsx
@@ -8,7 +8,7 @@ import {
 } from '@/ui/primitives/select'
 import { RefreshCw } from 'lucide-react'
 import { Separator } from './primitives/separator'
-import { PollingInterval } from '@/types/dashboard'
+import { PollingInterval } from '@/types/dashboard.types'
 import { useEffect, useState } from 'react'
 
 interface PollingButtonProps {
@@ -76,7 +76,7 @@ export function PollingButton({
           onRefresh()
           setRemainingTime(pollingInterval) // Reset timer on manual refresh
         }}
-        className="h-6 text-fg-500"
+        className="text-fg-500 h-6"
         disabled={isPolling}
       >
         <RefreshCw
@@ -90,9 +90,9 @@ export function PollingButton({
         value={pollingInterval.toString()}
         onValueChange={handleIntervalChange}
       >
-        <SelectTrigger className="h-6 w-fit gap-1 whitespace-nowrap border-none bg-transparent pl-2 text-fg-300">
+        <SelectTrigger className="text-fg-300 h-6 w-fit gap-1 border-none bg-transparent pl-2 whitespace-nowrap">
           Auto-refresh
-          <span className="ml-1 text-accent">
+          <span className="text-accent ml-1">
             {pollingInterval === 0 ? 'Off' : formatTime(remainingTime)}
           </span>
         </SelectTrigger>

--- a/src/ui/primitives/avatar.tsx
+++ b/src/ui/primitives/avatar.tsx
@@ -25,7 +25,10 @@ const AvatarImage = React.forwardRef<
 >(({ className, ...props }, ref) => (
   <AvatarPrimitive.Image
     ref={ref}
-    className={cn('aspect-square h-full w-full', className)}
+    className={cn(
+      'aspect-square h-full w-full object-cover object-center',
+      className
+    )}
     {...props}
   />
 ))


### PR DESCRIPTION
Currently default teams for users get the email of the owner assigned as the name. We had reports that this confused people. To make default team appearances more user friendly, we will transform default "unchanged" team names as follows in the ui:

`ben.fornefeld@gmail.com` -> `Ben.fornefeld's Team`

This is done by appending `transformed_default_name` attribute to the `ClientTeam` type, when a team has a default "unchanged" team name, in the `getUserTeams` server function.

To further clear up confusion, when navigating to `/team`, default transformed team names receive a hint "Seen as - Ben Fornefeld's Team" under the team name settings.

![Screenshot 2025-05-05 at 5 53 52 PM](https://github.com/user-attachments/assets/b2430a57-f2f7-4613-bb3a-ba0f871a069d)

Also this pr:
1. adds object-cover to profile pictures
2. improves avatar uploading rendering
3. removes unused storage/state keys