### PR TITLE
Fix client side sandbox id construction

### DIFF
--- a/src/features/dashboard/sandboxes/table-config.tsx
+++ b/src/features/dashboard/sandboxes/table-config.tsx
@@ -149,15 +149,15 @@ export const COLUMNS: ColumnDef<Sandbox>[] = [
     enableColumnFilter: false,
   }, */
   {
-    accessorKey: 'sandboxID',
+    accessorFn: (row) => `${row?.sandboxID}-${row?.clientID}`,
     header: 'ID',
-    cell: ({ row }) => (
+    cell: ({ getValue }) => (
       <div className="text-fg-500 truncate font-mono text-xs">
-        {row.getValue('sandboxID')}
+        {getValue() as string}
       </div>
     ),
-    size: 160,
-    minSize: 160,
+    size: 240,
+    minSize: 100,
     enableColumnFilter: false,
     enableSorting: false,
     enableGlobalFilter: true,

--- a/src/features/dashboard/sandboxes/table-config.tsx
+++ b/src/features/dashboard/sandboxes/table-config.tsx
@@ -156,7 +156,7 @@ export const COLUMNS: ColumnDef<Sandbox>[] = [
         {getValue() as string}
       </div>
     ),
-    size: 240,
+    size: 300,
     minSize: 100,
     enableColumnFilter: false,
     enableSorting: false,


### PR DESCRIPTION
The infra sends `sandboxID` and `clientID` which need to be constructed client side to get the correct sandbox id usable for users. This pr fixes this issue. Also it improves the UX by increasing the min column size, for users to see the full id by default.