### PR TITLE
Prepare cli auth & access token retrieval for api key hashing

### DIFF
--- a/src/app/api/team/state/route.ts
+++ b/src/app/api/team/state/route.ts
@@ -1,0 +1,35 @@
+import { cookies } from 'next/headers'
+import { COOKIE_KEYS } from '@/configs/keys'
+import { z } from 'zod'
+import { ResponseCookie } from 'next/dist/compiled/@edge-runtime/cookies'
+
+const TeamStateSchema = z.object({
+  teamId: z.string(),
+  teamSlug: z.string(),
+})
+
+export async function POST(request: Request) {
+  try {
+    const body = TeamStateSchema.parse(await request.json())
+
+    const COOKIE_SETTINGS: Partial<ResponseCookie> = {
+      path: '/',
+      maxAge: 60 * 60 * 24 * 7, // 7 days
+      sameSite: 'lax',
+      secure: process.env.NODE_ENV === 'production',
+    }
+
+    const cookieStore = await cookies()
+
+    cookieStore.set(COOKIE_KEYS.SELECTED_TEAM_ID, body.teamId, COOKIE_SETTINGS)
+    cookieStore.set(
+      COOKIE_KEYS.SELECTED_TEAM_SLUG,
+      body.teamSlug,
+      COOKIE_SETTINGS
+    )
+
+    return Response.json({ success: true })
+  } catch (error) {
+    return Response.json({ error: 'Invalid request' }, { status: 400 })
+  }
+}

--- a/src/features/dashboard/account/user-access-token.tsx
+++ b/src/features/dashboard/account/user-access-token.tsx
@@ -3,10 +3,8 @@
 import { useState } from 'react'
 import { Button } from '@/ui/primitives/button'
 import { Input } from '@/ui/primitives/input'
-import HelpTooltip from '@/ui/help-tooltip'
 import { useToast } from '@/lib/hooks/use-toast'
 import { Eye, EyeOff } from 'lucide-react'
-import { Label } from '@/ui/primitives/label'
 import { Loader } from '@/ui/loader'
 import { getUserAccessTokenAction } from '@/server/user/user-actions'
 import CopyButton from '@/ui/copy-button'
@@ -27,7 +25,7 @@ export default function UserAccessToken({ className }: UserAccessTokenProps) {
     {
       onSuccess: (result) => {
         if (result.data) {
-          setToken(result.data.accessToken)
+          setToken(result.data.token)
           setIsVisible(true)
         }
       },

--- a/src/features/dashboard/sidebar/menu.tsx
+++ b/src/features/dashboard/sidebar/menu.tsx
@@ -40,16 +40,22 @@ export default function DashboardSidebarMenu({
   const [createTeamOpen, setCreateTeamOpen] = useState(false)
   const pathname = usePathname()
 
-  const handleTeamChange = (teamId: string) => {
+  const handleTeamChange = async (teamId: string) => {
     const team = teams.find((t) => t.id === teamId)
-    if (team && selectedTeam) {
-      router.push(
-        pathname
-          .replace(selectedTeam.slug, team.slug)
-          .replace(selectedTeam.id, team.id)
-      )
-      router.refresh()
-    }
+
+    if (!team || !selectedTeam) return
+
+    await fetch('/api/team/state', {
+      method: 'POST',
+      body: JSON.stringify({ teamId: team.id, teamSlug: team.slug }),
+    })
+
+    router.push(
+      pathname
+        .replace(selectedTeam.slug, team.slug)
+        .replace(selectedTeam.id, team.id)
+    )
+    router.refresh()
   }
 
   const handleLogout = () => {

--- a/src/lib/utils/server.ts
+++ b/src/lib/utils/server.ts
@@ -12,11 +12,13 @@ import { z } from 'zod'
 import { cookies } from 'next/headers'
 import { unstable_noStore } from 'next/cache'
 import { COOKIE_KEYS } from '@/configs/keys'
-import { logger } from '../clients/logger'
+import { logError, logger } from '../clients/logger'
 import { kv } from '@/lib/clients/kv'
 import { KV_KEYS } from '@/configs/keys'
 import { ERROR_CODES, INFO_CODES } from '@/configs/logs'
 import { getEncryptedCookie } from './cookies'
+import { SUPABASE_AUTH_HEADERS } from '@/configs/constants'
+import { CreatedAccessToken } from '@/types/api'
 
 /*
  *  This function checks if the user is authenticated and returns the user and the supabase client.
@@ -93,22 +95,35 @@ export async function getTeamApiKey(userId: string, teamId: string) {
 }
 
 /*
- *  This function fetches a user access token for a given user.
- *  If the user does not have an active access token, it throws an error.
+ *  This function generates an e2b user access token for a given user.
  */
-export async function getUserAccessToken(userId: string) {
-  const { data: userAccessTokenData, error: userAccessTokenError } =
-    await supabaseAdmin.from('access_tokens').select('*').eq('user_id', userId)
+export async function generateE2BUserAccessToken(
+  supabaseAccessToken: string,
+  userId: string
+) {
+  const TOKEN_NAME = 'e2b_generated_access_token'
 
-  if (userAccessTokenError) {
-    throw userAccessTokenError
+  const apiUrl = await getApiUrl()
+
+  const response = await fetch(`${apiUrl.url}/access-tokens`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      ...SUPABASE_AUTH_HEADERS(supabaseAccessToken),
+    },
+    body: JSON.stringify({ name: TOKEN_NAME }),
+  })
+
+  if (!response.ok) {
+    const text = await response.text()
+    throw new Error(
+      `Failed to generate e2b user access token for user (${userId}): ${text ?? response.statusText}`
+    )
   }
 
-  if (!userAccessTokenData || userAccessTokenData.length === 0) {
-    throw new Error(`No user access token found for user (user: ${userId})`)
-  }
+  const data: CreatedAccessToken = await response.json()
 
-  return userAccessTokenData[0].access_token
+  return data
 }
 
 // TODO: we should probably add some team permission system here

--- a/src/lib/utils/server.ts
+++ b/src/lib/utils/server.ts
@@ -101,7 +101,7 @@ export async function generateE2BUserAccessToken(
   supabaseAccessToken: string,
   userId: string
 ) {
-  const TOKEN_NAME = 'e2b_generated_access_token'
+  const TOKEN_NAME = 'e2b_dashboard_generated_access_token'
 
   const apiUrl = await getApiUrl()
 

--- a/src/server/auth/get-default-team.ts
+++ b/src/server/auth/get-default-team.ts
@@ -1,6 +1,8 @@
 import 'server-cli-only'
 
 import { supabaseAdmin } from '@/lib/clients/supabase/admin'
+import { logError } from '@/lib/clients/logger'
+import { ERROR_CODES } from '@/configs/logs'
 
 export async function getDefaultTeamRelation(userId: string) {
   const { data, error } = await supabaseAdmin
@@ -8,13 +10,17 @@ export async function getDefaultTeamRelation(userId: string) {
     .select('*')
     .eq('user_id', userId)
     .eq('is_default', true)
-    .single()
 
-  if (error || !data) {
+  if (error || data.length === 0) {
+    logError(ERROR_CODES.SUPABASE, 'Failed to get default team', {
+      userId,
+      error: error?.message,
+      data: data,
+    })
     throw new Error('No default team found')
   }
 
-  return data
+  return data[0]
 }
 
 export async function getDefaultTeam(userId: string) {

--- a/src/server/user/user-actions.ts
+++ b/src/server/user/user-actions.ts
@@ -2,7 +2,7 @@
 
 import { authActionClient } from '@/lib/clients/action'
 import { supabaseAdmin } from '@/lib/clients/supabase/admin'
-import { getUserAccessToken } from '@/lib/utils/server'
+import { generateE2BUserAccessToken } from '@/lib/utils/server'
 import { z } from 'zod'
 import { headers } from 'next/headers'
 import { returnValidationErrors } from 'next-safe-action'
@@ -99,11 +99,12 @@ export const deleteAccountAction = authActionClient
 export const getUserAccessTokenAction = authActionClient
   .metadata({ actionName: 'getUserAccessToken' })
   .action(async ({ ctx }) => {
-    const { user } = ctx
+    const { user, session } = ctx
 
-    const accessToken = await getUserAccessToken(user.id)
+    const token = await generateE2BUserAccessToken(
+      session.access_token,
+      user.id
+    )
 
-    return {
-      accessToken,
-    }
+    return token
   })

--- a/src/types/api.d.ts
+++ b/src/types/api.d.ts
@@ -38,4 +38,18 @@ interface SandboxMetrics {
   timestamp: string
 }
 
-export type { Sandbox, Template, SandboxMetrics, DefaultTemplate }
+interface CreatedAccessToken {
+  id: string
+  name: string
+  token: string
+  tokenMask: string
+  createdAt: string
+}
+
+export type {
+  Sandbox,
+  Template,
+  SandboxMetrics,
+  DefaultTemplate,
+  CreatedAccessToken,
+}


### PR DESCRIPTION
In order to be prepared for our upcoming migration to hashed api keys, this pr introduces the following changes:
1. create new access tokens for cli auth & access token retrieval under `dashboard/account`
2. remove api key return in `/auth/cli`, since it is not required in the cli

Additionally but not entangled, it adds route for manual team selection cookie updates, to fix changing teams on a non team dependent route (e.g `/dashboard/account`)