### PR TITLE
Improve: 404 response code for not-found rewrites

### DIFF
--- a/src/app/(auth)/not-found.tsx
+++ b/src/app/(auth)/not-found.tsx
@@ -1,5 +1,0 @@
-import NotFound from '@/ui/not-found'
-
-export default function AuthNotFound() {
-  return <NotFound />
-}

--- a/src/app/(rewrites)/[[...slug]]/route.ts
+++ b/src/app/(rewrites)/[[...slug]]/route.ts
@@ -36,17 +36,16 @@ export async function GET(request: NextRequest): Promise<Response> {
   }
 
   try {
+    const notFound = url.hostname === requestHostname
+
     // if hostname did not change, we want to make sure it does not cache the route based on the build times hostname (127.0.0.1:3000)
-    const fetchUrl =
-      url.hostname === requestHostname
-        ? `${BASE_URL}/not-found`
-        : url.toString()
+    const fetchUrl = notFound ? `${BASE_URL}/not-found` : url.toString()
 
     const res = await fetch(fetchUrl, {
       headers: new Headers(request.headers),
       redirect: 'follow',
       // if the hostname is the same, we don't want to cache the response, since it will not be available in build time
-      ...(url.hostname === requestHostname
+      ...(notFound
         ? { cache: 'no-store' }
         : {
             next: {
@@ -79,7 +78,7 @@ export async function GET(request: NextRequest): Promise<Response> {
 
       // create a new response with the modified HTML
       const modifiedResponse = new Response(html, {
-        status: res.status,
+        status: notFound ? 404 : res.status,
         headers: newHeaders,
       })
 

--- a/src/app/(rewrites)/not-found/page.tsx
+++ b/src/app/(rewrites)/not-found/page.tsx
@@ -1,6 +1,14 @@
 import NotFound from '@/ui/not-found'
+import { Metadata } from 'next'
 
 export const dynamic = 'force-static'
+
+export const metadata: Metadata = {
+  title: '404 - Page Not Found',
+  description:
+    'The page you are looking for might have been removed, had its name changed, or is temporarily unavailable.',
+  robots: 'noindex, nofollow',
+}
 
 export default function NotFoundShell() {
   return <NotFound />

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -20,7 +20,7 @@ export const metadata: Metadata = {
     template: '%s - E2B',
     default: METADATA.title,
   },
-  description: 'Open-source secure sandboxes for AI code execution',
+  description: METADATA.description,
   twitter: {
     title: METADATA.title,
     description: METADATA.description,

--- a/src/app/not-found.tsx
+++ b/src/app/not-found.tsx
@@ -1,4 +1,12 @@
 import NotFound from '@/ui/not-found'
+import { Metadata } from 'next'
+
+export const metadata: Metadata = {
+  title: '404 - Page Not Found',
+  description:
+    'The page you are looking for might have been removed, had its name changed, or is temporarily unavailable.',
+  robots: 'noindex, nofollow',
+}
 
 export default function RootNotFound() {
   return <NotFound />

--- a/src/configs/metadata.ts
+++ b/src/configs/metadata.ts
@@ -33,8 +33,3 @@ export function createMetadata(override: Metadata): Metadata {
     },
   }
 }
-
-export const baseUrl =
-  process.env.NODE_ENV === 'development' || !process.env.VERCEL_URL
-    ? new URL('http://localhost:3000')
-    : new URL(`https://${process.env.VERCEL_URL}`)

--- a/src/lib/utils/server.ts
+++ b/src/lib/utils/server.ts
@@ -2,12 +2,7 @@ import 'server-cli-only'
 
 import { supabaseAdmin } from '@/lib/clients/supabase/admin'
 import { createClient } from '@/lib/clients/supabase/server'
-import { Database } from '@/types/database.types'
-import {
-  E2BError,
-  UnauthenticatedError,
-  UnauthorizedError,
-} from '@/types/errors'
+import { E2BError, UnauthenticatedError } from '@/types/errors'
 import { z } from 'zod'
 import { cookies } from 'next/headers'
 import { unstable_noStore } from 'next/cache'


### PR DESCRIPTION
- returns actual 404 response code for catch-all rewritten not-found's
- adds no index metadata on the not-found pages