### PR TITLE
Fix: correct middleware rewrites request header forwarding

### DIFF
--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -48,7 +48,9 @@ export async function middleware(request: NextRequest) {
       }
 
       return NextResponse.rewrite(rewriteUrl, {
-        headers,
+        request: {
+          headers,
+        },
       })
     }
 


### PR DESCRIPTION
This pr fixes the forwarding of request headers, including the `x-e2b-should-index` header, by utilizing the correct `NextResponse.rewrite` property `request` for overriding the rewritten `request` inits