### PR TITLE
Fix: define duplex option on non-null body on infra open-api client fetch

### DIFF
--- a/src/lib/clients/api.ts
+++ b/src/lib/clients/api.ts
@@ -8,6 +8,7 @@ export const infra = createClient<InfraPaths>({
       headers,
       body,
       method,
+      duplex: !!body ? 'half' : undefined,
       ...options,
     })
   },


### PR DESCRIPTION
Since we replace the infra openapi clients fetch function with next.js native fetch, and the open-api client always passes bodies as `ReadableStream`, we have to set `duplex: "half"` on the overridden fetch client when body is defined.

Fixes #80 