### PR TITLE
Fix: use correct response status code from infra open-api client

### DIFF
--- a/src/server/keys/get-api-keys.ts
+++ b/src/server/keys/get-api-keys.ts
@@ -28,8 +28,8 @@ export const getTeamApiKeys = authActionClient
     })
 
     if (res.error) {
-      const status = res.error?.code ?? 500
-      logError(ERROR_CODES.INFRA, '/api-keys', res.error)
+      const status = res.response.status
+      logError(ERROR_CODES.INFRA, '/api-keys', res.error, res.data)
 
       return handleDefaultInfraError(status)
     }

--- a/src/server/sandboxes/get-sandbox-details.ts
+++ b/src/server/sandboxes/get-sandbox-details.ts
@@ -30,9 +30,15 @@ export const getSandboxDetails = authActionClient
     })
 
     if (res.error) {
-      const status = res.error?.code ?? 500
+      const status = res.response.status
 
-      logError(ERROR_CODES.INFRA, '/sandboxes/{sandboxID}', res.error, res.data)
+      logError(
+        ERROR_CODES.INFRA,
+        '/sandboxes/{sandboxID}',
+        status,
+        res.error,
+        res.data
+      )
 
       if (status === 404) {
         return returnServerError(

--- a/src/server/sandboxes/get-team-sandboxes.ts
+++ b/src/server/sandboxes/get-team-sandboxes.ts
@@ -39,9 +39,9 @@ export const getTeamSandboxes = authActionClient
     })
 
     if (res.error) {
-      const status = res.error?.code ?? 500
+      const status = res.response.status
 
-      logError(ERROR_CODES.INFRA, '/sandboxes', res.error, res.data)
+      logError(ERROR_CODES.INFRA, '/sandboxes', status, res.error, res.data)
 
       return handleDefaultInfraError(status)
     }

--- a/src/server/templates/get-team-templates.ts
+++ b/src/server/templates/get-team-templates.ts
@@ -44,8 +44,8 @@ export const getTeamTemplates = authActionClient
     })
 
     if (res.error) {
-      const status = res.error?.code ?? 500
-      logError(ERROR_CODES.INFRA, '/templates', res.error, res.data)
+      const status = res.response.status
+      logError(ERROR_CODES.INFRA, '/templates', status, res.error, res.data)
 
       return handleDefaultInfraError(status)
     }

--- a/src/server/templates/templates-actions.ts
+++ b/src/server/templates/templates-actions.ts
@@ -31,10 +31,11 @@ export const deleteTemplateAction = authActionClient
     })
 
     if (res.error) {
-      const status = res.error?.code ?? 500
+      const status = res.response.status
       logError(
         ERROR_CODES.INFRA,
         '/templates/{templateID}',
+        status,
         res.error,
         res.data
       )
@@ -91,8 +92,14 @@ export const updateTemplateAction = authActionClient
     })
 
     if (res.error) {
-      const status = res.error?.code ?? 500
-      logError(ERROR_CODES.INFRA, '/templates/{templateID}', res.error)
+      const status = res.response.status
+      logError(
+        ERROR_CODES.INFRA,
+        '/templates/{templateID}',
+        status,
+        res.error,
+        res.data
+      )
 
       if (status === 404) {
         return returnServerError('Template not found')


### PR DESCRIPTION
This pr fixes infra api invocation error handling, by using the correct `response.status` property returned from open-api client invocation, to decide on the error message.