### PR TITLE
Feat: Add team e-mail changeablility

### DIFF
--- a/src/features/dashboard/team/change-email-dialog.tsx
+++ b/src/features/dashboard/team/change-email-dialog.tsx
@@ -83,9 +83,9 @@ export function ChangeEmailDialog({
     <Dialog open={open} onOpenChange={handleDialogChange}>
       <DialogContent className="max-w-[500px]">
         <DialogHeader>
-          <DialogTitle>Change Team Email</DialogTitle>
+          <DialogTitle>Change Team E-Mail</DialogTitle>
           <DialogDescription>
-            Update the email address associated with this team.
+            Update the e-mail address associated with this team.
           </DialogDescription>
         </DialogHeader>
 
@@ -97,7 +97,7 @@ export function ChangeEmailDialog({
                 name="email"
                 render={({ field }) => (
                   <FormItem>
-                    <FormLabel>Team Email</FormLabel>
+                    <FormLabel>Team E-Mail</FormLabel>
                     <FormControl>
                       <Input
                         type="email"
@@ -126,7 +126,7 @@ export function ChangeEmailDialog({
                 disabled={isExecuting}
                 loading={isExecuting}
               >
-                Update Email
+                Update E-Mail
               </Button>
             </DialogFooter>
           </form>

--- a/src/features/dashboard/team/change-email-dialog.tsx
+++ b/src/features/dashboard/team/change-email-dialog.tsx
@@ -29,19 +29,21 @@ import {
 } from '@/lib/hooks/use-toast'
 import { UpdateTeamEmailSchema } from '@/server/team/types'
 
-interface EmailChangeDialogProps {
+interface ChangeEmailDialogProps {
   open: boolean
   onOpenChange: (open: boolean) => void
   teamId: string
   currentEmail: string
 }
 
-export function EmailChangeDialog({
+export function ChangeEmailDialog({
   open,
   onOpenChange,
   teamId,
   currentEmail,
-}: EmailChangeDialogProps) {
+}: ChangeEmailDialogProps) {
+  'use no memo'
+
   const {
     form,
     resetFormAndAction,

--- a/src/features/dashboard/team/email-change-dialog.tsx
+++ b/src/features/dashboard/team/email-change-dialog.tsx
@@ -1,0 +1,135 @@
+'use client'
+
+import * as React from 'react'
+import { useHookFormAction } from '@next-safe-action/adapter-react-hook-form/hooks'
+import { zodResolver } from '@hookform/resolvers/zod'
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/ui/primitives/dialog'
+import { Button } from '@/ui/primitives/button'
+import {
+  Form,
+  FormControl,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+} from '@/ui/primitives/form'
+import { Input } from '@/ui/primitives/input'
+import { updateTeamEmailAction } from '@/server/team/team-actions'
+import {
+  toast,
+  defaultSuccessToast,
+  defaultErrorToast,
+} from '@/lib/hooks/use-toast'
+import { UpdateTeamEmailSchema } from '@/server/team/types'
+
+interface EmailChangeDialogProps {
+  open: boolean
+  onOpenChange: (open: boolean) => void
+  teamId: string
+  currentEmail: string
+}
+
+export function EmailChangeDialog({
+  open,
+  onOpenChange,
+  teamId,
+  currentEmail,
+}: EmailChangeDialogProps) {
+  const {
+    form,
+    resetFormAndAction,
+    handleSubmitWithAction,
+    action: { isExecuting },
+  } = useHookFormAction(
+    updateTeamEmailAction,
+    zodResolver(UpdateTeamEmailSchema),
+    {
+      formProps: {
+        defaultValues: {
+          teamId,
+          email: currentEmail,
+        },
+      },
+      actionProps: {
+        onSuccess: () => {
+          toast(defaultSuccessToast('Team email was updated.'))
+          handleDialogChange(false)
+        },
+        onError: () => {
+          toast(defaultErrorToast('Failed to update team email.'))
+        },
+      },
+    }
+  )
+
+  const handleDialogChange = (value: boolean) => {
+    onOpenChange(value)
+
+    if (value) return
+
+    resetFormAndAction()
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={handleDialogChange}>
+      <DialogContent className="max-w-[500px]">
+        <DialogHeader>
+          <DialogTitle>Change Team Email</DialogTitle>
+          <DialogDescription>
+            Update the email address associated with this team.
+          </DialogDescription>
+        </DialogHeader>
+
+        <Form {...form}>
+          <form onSubmit={handleSubmitWithAction}>
+            <div className="flex flex-col gap-3 px-2 py-6">
+              <FormField
+                control={form.control}
+                name="email"
+                render={({ field }) => (
+                  <FormItem>
+                    <FormLabel>Team Email</FormLabel>
+                    <FormControl>
+                      <Input
+                        type="email"
+                        placeholder="Enter team email"
+                        disabled={isExecuting}
+                        {...field}
+                      />
+                    </FormControl>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+            </div>
+
+            <DialogFooter>
+              <Button
+                type="button"
+                variant="outline"
+                onClick={() => handleDialogChange(false)}
+                disabled={isExecuting}
+              >
+                Cancel
+              </Button>
+              <Button
+                type="submit"
+                disabled={isExecuting}
+                loading={isExecuting}
+              >
+                Update Email
+              </Button>
+            </DialogFooter>
+          </form>
+        </Form>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/src/features/dashboard/team/info-card.tsx
+++ b/src/features/dashboard/team/info-card.tsx
@@ -12,7 +12,7 @@ import {
 import { Badge } from '@/ui/primitives/badge'
 import CopyButton from '@/ui/copy-button'
 import { useState } from 'react'
-import { EmailChangeDialog } from './email-change-dialog'
+import { ChangeEmailDialog } from './change-email-dialog'
 import { Button } from '@/ui/primitives/button'
 import { Pencil } from 'lucide-react'
 
@@ -68,7 +68,7 @@ export function InfoCard({ className }: InfoCardProps) {
           )}
         </CardContent>
       </Card>
-      <EmailChangeDialog
+      <ChangeEmailDialog
         open={isEmailChangeDialogOpen}
         onOpenChange={setIsEmailChangeDialogOpen}
         teamId={team?.id ?? ''}

--- a/src/features/dashboard/team/info-card.tsx
+++ b/src/features/dashboard/team/info-card.tsx
@@ -1,6 +1,5 @@
 'use client'
 
-import { Input } from '@/ui/primitives/input'
 import { Skeleton } from '@/ui/primitives/skeleton'
 import { useSelectedTeam } from '@/lib/hooks/use-teams'
 import {
@@ -12,6 +11,10 @@ import {
 } from '@/ui/primitives/card'
 import { Badge } from '@/ui/primitives/badge'
 import CopyButton from '@/ui/copy-button'
+import { useState } from 'react'
+import { EmailChangeDialog } from './email-change-dialog'
+import { Button } from '@/ui/primitives/button'
+import { Pencil } from 'lucide-react'
 
 interface InfoCardProps {
   className?: string
@@ -19,41 +22,58 @@ interface InfoCardProps {
 
 export function InfoCard({ className }: InfoCardProps) {
   const team = useSelectedTeam()
+  const [isEmailChangeDialogOpen, setIsEmailChangeDialogOpen] = useState(false)
 
   return (
-    <Card className={className}>
-      <CardHeader>
-        <CardTitle>Information</CardTitle>
-        <CardDescription>
-          Additional information about this team.
-        </CardDescription>
-      </CardHeader>
-      <CardContent>
-        {team ? (
-          <div className="flex flex-col gap-2">
-            <div className="flex items-center gap-2">
-              <Badge variant="accent">E-Mail</Badge>
-              <span>{team.email}</span>
-              <CopyButton
-                value={team.email}
-                variant="ghost"
-                className="size-5"
-              />
+    <>
+      <Card className={className}>
+        <CardHeader>
+          <CardTitle>Information</CardTitle>
+          <CardDescription>
+            Additional information about this team.
+          </CardDescription>
+        </CardHeader>
+        <CardContent>
+          {team ? (
+            <div className="flex flex-col gap-2">
+              <div className="flex items-center gap-2">
+                <Badge variant="accent">E-Mail</Badge>
+                <span>{team.email}</span>
+                <Button
+                  variant="ghost"
+                  size="icon"
+                  className="size-5"
+                  onClick={() => setIsEmailChangeDialogOpen(true)}
+                >
+                  <Pencil className="size-4" />
+                </Button>
+                <CopyButton
+                  value={team.email}
+                  variant="ghost"
+                  className="size-5"
+                />
+              </div>
+              <div className="flex items-center gap-2">
+                <Badge variant="muted">Team ID</Badge>
+                <span className="text-fg-500">{team.id}</span>
+                <CopyButton
+                  value={team.id}
+                  variant="ghost"
+                  className="text-fg-500 size-5"
+                />
+              </div>
             </div>
-            <div className="flex items-center gap-2">
-              <Badge variant="muted">Team ID</Badge>
-              <span className="text-fg-500">{team.id}</span>
-              <CopyButton
-                value={team.id}
-                variant="ghost"
-                className="text-fg-500 size-5"
-              />
-            </div>
-          </div>
-        ) : (
-          <Skeleton className="h-10 w-[17rem]" />
-        )}
-      </CardContent>
-    </Card>
+          ) : (
+            <Skeleton className="h-10 w-[17rem]" />
+          )}
+        </CardContent>
+      </Card>
+      <EmailChangeDialog
+        open={isEmailChangeDialogOpen}
+        onOpenChange={setIsEmailChangeDialogOpen}
+        teamId={team?.id ?? ''}
+        currentEmail={team?.email ?? ''}
+      />
+    </>
   )
 }

--- a/src/server/team/types.ts
+++ b/src/server/team/types.ts
@@ -38,4 +38,9 @@ const CreateTeamSchema = z.object({
   name: TeamNameSchema,
 })
 
-export { UpdateTeamNameSchema, CreateTeamSchema }
+const UpdateTeamEmailSchema = z.object({
+  teamId: z.string().uuid(),
+  email: z.string().email({ message: 'Invalid email address' }),
+})
+
+export { UpdateTeamNameSchema, CreateTeamSchema, UpdateTeamEmailSchema }


### PR DESCRIPTION
This pr enables teams to change their team e-mail by: 
- adding a new server action `updateTeamEmailAction`
- adding a new dialog with a form to change the e-mail
- adding a pencil icon button to the team e-mail field under `/dashboard/[slug]/team`

<img width="314" alt="Screenshot 2025-06-26 at 12 18 07 AM" src="https://github.com/user-attachments/assets/8dc907bf-0acc-49e8-944b-b9eb7338e1d5" />
<img width="641" alt="Screenshot 2025-06-26 at 12 18 37 AM" src="https://github.com/user-attachments/assets/bc94d75b-8ce4-43a4-9415-b8f0453b11f7" />
