### PR TITLE
refactor: replace `<img>` with `next/image` in logo components

### DIFF
--- a/src/ui/logo-without-text.tsx
+++ b/src/ui/logo-without-text.tsx
@@ -3,6 +3,7 @@
 import { cn } from '@/lib/utils'
 import { useTheme } from 'next-themes'
 import ClientOnly from './client-only'
+import Image from 'next/image'
 
 export default function LogoWithoutText({ className }: { className?: string }) {
   const { resolvedTheme } = useTheme()
@@ -12,13 +13,16 @@ export default function LogoWithoutText({ className }: { className?: string }) {
 
   return (
     <ClientOnly>
-      <img
-        key={`logo-without-text-${resolvedTheme}`}
-        src={logo}
-        alt="logo"
-        className={cn('h-10 w-10', className)}
-        suppressHydrationWarning
-      />
+      <div className={cn('relative h-10 w-10', className)}>
+        <Image
+          key={`logo-without-text-${resolvedTheme}`}
+          src={logo}
+          alt="logo"
+          fill
+          className="object-contain"
+          suppressHydrationWarning
+        />
+      </div>
     </ClientOnly>
   )
 }

--- a/src/ui/logo.tsx
+++ b/src/ui/logo.tsx
@@ -3,6 +3,7 @@
 import { cn } from '@/lib/utils'
 import { useTheme } from 'next-themes'
 import ClientOnly from './client-only'
+import Image from 'next/image'
 
 export default function Logo({ className }: { className?: string }) {
   const { resolvedTheme } = useTheme()
@@ -14,7 +15,7 @@ export default function Logo({ className }: { className?: string }) {
 
   return (
     <ClientOnly>
-      <img
+      <Image
         src={logo}
         alt="logo with text"
         className={cn('h-9 w-auto', className)}


### PR DESCRIPTION
I change the `<img>` for using `next/image`, it's should resolve the linting warning bellow

```bash
./src/ui/logo-without-text.tsx
17:7  Warning: Using `<img>` could result in slower LCP and higher bandwidth. Consider using `<Image />` from `next/image` or a custom image loader to automatically optimize images. This may incur additional usage or cost from your provider. See: https://nextjs.org/docs/messages/no-img-element  @next/next/no-img-element

./src/ui/logo.tsx
17:7  Warning: Using `<img>` could result in slower LCP and higher bandwidth. Consider using `<Image />` from `next/image` or a custom image loader to automatically optimize images. This may incur additional usage or cost from your provider. See: https://nextjs.org/docs/messages/no-img-element  @next/next/no-img-element
```