### PR TITLE
Fix password-reset rate-limit UX & add robust email-confirm route

### DIFF
--- a/src/app/api/auth/confirm/route.ts
+++ b/src/app/api/auth/confirm/route.ts
@@ -1,5 +1,5 @@
 import { AUTH_URLS, PROTECTED_URLS } from '@/configs/urls'
-import { logInfo } from '@/lib/clients/logger'
+import { logInfo, logError } from '@/lib/clients/logger'
 import { createRouteClient } from '@/lib/clients/supabase/server'
 import { encodedRedirect } from '@/lib/utils/auth'
 import { type EmailOtpType } from '@supabase/supabase-js'
@@ -15,23 +15,27 @@ export async function GET(request: NextRequest) {
   const signInUrl = new URL(request.nextUrl.origin + AUTH_URLS.SIGN_IN)
 
   const nextParam = searchParams.get('next')
-  const isAbsoluteNext = !!nextParam && /^https?:\/\//i.test(nextParam)
   const isDifferentOrigin =
-    isAbsoluteNext && new URL(nextParam).origin !== request.nextUrl.origin
+    nextParam && new URL(nextParam).hostname !== request.nextUrl.hostname
 
   let next: string
   let redirectUrl: URL
 
-  logInfo('AUTH_CONFIRM', {
-    token_hash: token_hash?.slice(0, 10) + '...',
+  logInfo('AUTH_CONFIRM_INIT', {
+    token_hash: token_hash ? `${token_hash.slice(0, 10)}...` : null,
     type,
-    isAbsoluteNext,
     nextParam,
+    isDifferentOrigin,
     confirmationUrl,
+    requestUrl: request.url,
+    origin: request.nextUrl.origin,
   })
 
   if (isDifferentOrigin) {
     if (confirmationUrl) {
+      logInfo('AUTH_CONFIRM_REDIRECT_CONFIRMATION', {
+        confirmationUrl,
+      })
       throw redirect(confirmationUrl)
     }
     next = nextParam as string
@@ -45,15 +49,24 @@ export async function GET(request: NextRequest) {
     try {
       redirectUrl = new URL(next)
     } catch (e) {
+      logInfo('AUTH_CONFIRM_URL_FALLBACK', {
+        next,
+        error: e instanceof Error ? e.message : String(e),
+      })
       redirectUrl = new URL(request.nextUrl.origin + next)
     }
   }
 
-  if (!token_hash || !type)
+  if (!token_hash || !type) {
+    logError('AUTH_CONFIRM_INVALID_PARAMS', {
+      token_hash: !!token_hash,
+      type: !!type,
+    })
     return encodedRedirect('error', signInUrl.toString(), 'Invalid Request')
+  }
 
-  logInfo('AUTH_CONFIRM', {
-    token_hash: token_hash.slice(0, 10) + '...',
+  logInfo('AUTH_CONFIRM_VERIFY', {
+    token_hash: `${token_hash.slice(0, 10)}...`,
     type,
     next,
     redirectUrl: redirectUrl.toString(),
@@ -65,16 +78,15 @@ export async function GET(request: NextRequest) {
   const { error } = await supabase.auth.verifyOtp({ type, token_hash })
 
   if (error) {
-    console.error(
-      'AUTH_CONFIRM',
-      {
-        token_hash: token_hash.slice(0, 10) + '...',
-        type,
-        next,
-        redirectUrl: redirectUrl.toString(),
-      },
-      error
-    )
+    logError('AUTH_CONFIRM_ERROR', {
+      token_hash: `${token_hash.slice(0, 10)}...`,
+      type,
+      next,
+      redirectUrl: redirectUrl.toString(),
+      errorCode: error.code,
+      errorStatus: error.status,
+      errorMessage: error.message,
+    })
 
     let errorMessage = 'Invalid Token'
     if (error.status === 403 && error.code === 'otp_expired') {
@@ -83,6 +95,11 @@ export async function GET(request: NextRequest) {
 
     return encodedRedirect('error', signInUrl.toString(), errorMessage)
   }
+
+  logInfo('AUTH_CONFIRM_SUCCESS', {
+    type,
+    redirectUrl: redirectUrl.toString(),
+  })
 
   return response
 }

--- a/src/app/api/auth/confirm/route.ts
+++ b/src/app/api/auth/confirm/route.ts
@@ -1,4 +1,4 @@
-import { AUTH_URLS, PROTECTED_URLS } from '@/configs/urls'
+import { AUTH_URLS, PROTECTED_URLS, BASE_URL } from '@/configs/urls'
 import { logInfo, logError } from '@/lib/clients/logger'
 import { createRouteClient } from '@/lib/clients/supabase/server'
 import { encodedRedirect } from '@/lib/utils/auth'
@@ -15,8 +15,9 @@ export async function GET(request: NextRequest) {
   const signInUrl = new URL(request.nextUrl.origin + AUTH_URLS.SIGN_IN)
 
   const nextParam = searchParams.get('next')
+  const baseHostname = new URL(BASE_URL).hostname
   const isDifferentOrigin =
-    nextParam && new URL(nextParam).hostname !== request.nextUrl.hostname
+    nextParam && new URL(nextParam).hostname !== baseHostname
 
   let next: string
   let redirectUrl: URL

--- a/src/app/api/auth/confirm/route.ts
+++ b/src/app/api/auth/confirm/route.ts
@@ -14,10 +14,14 @@ export async function GET(request: NextRequest) {
 
   const signInUrl = new URL(request.nextUrl.origin + AUTH_URLS.SIGN_IN)
 
+  const normalizeOrigin = (origin: string) => origin.replace('www.', '')
+
   const nextParam = searchParams.get('next')
-  const baseHostname = new URL(BASE_URL).hostname
+
   const isDifferentOrigin =
-    nextParam && new URL(nextParam).hostname !== baseHostname
+    nextParam &&
+    normalizeOrigin(new URL(nextParam).origin) !==
+      normalizeOrigin(request.nextUrl.origin)
 
   let next: string
   let redirectUrl: URL

--- a/src/app/api/auth/confirm/route.ts
+++ b/src/app/api/auth/confirm/route.ts
@@ -68,17 +68,10 @@ export async function GET(request: NextRequest) {
   }
 
   if (isAbsoluteNext) {
-    const baseDomain = (() => {
-      const hostParts = redirectUrl.hostname.split('.')
-      return hostParts.length > 2
-        ? hostParts.slice(-2).join('.')
-        : redirectUrl.hostname
-    })()
-
     response.cookies.getAll().forEach(({ name, value, ...options }) => {
       response.cookies.set(name, value, {
         ...options,
-        domain: `.${baseDomain}`,
+        domain: request.nextUrl.origin,
       })
     })
   }


### PR DESCRIPTION
This PR refactors our authentication flow to improve both user experience and security.

Key changes
- Added `GET /api/auth/confirm` handler that verifies OTP tokens (signup / recovery), normalises origins, and safely redirects users.  
- Shows a clear “Please wait before requesting another password reset” message when Supabase rate-limits the reset endpoint (resolves e2b-2619).  
- Hardened redirect logic in the auth callback & confirm routes (origin checks, graceful fallbacks).  
- Enhanced server-side logging for easier debugging of auth issues.  