### PR TITLE
Remove: confirmation_url schema validation

### DIFF
--- a/src/app/api/auth/confirm/route.ts
+++ b/src/app/api/auth/confirm/route.ts
@@ -16,7 +16,6 @@ const confirmSchema = z.object({
     'email',
     'email_change',
   ]),
-  confirmation_url: z.string().url(),
   next: z.string().url(),
 })
 


### PR DESCRIPTION
This pr removes "confirmation_url" from /api/auth/confirm schema validation