### PR TITLE
Improve: Cookie TTL's

### DIFF
--- a/src/app/api/sidebar/state/route.ts
+++ b/src/app/api/sidebar/state/route.ts
@@ -1,22 +1,29 @@
 import { cookies } from 'next/headers'
 import { COOKIE_KEYS } from '@/configs/keys'
 import { z } from 'zod'
+import { ResponseCookie } from 'next/dist/compiled/@edge-runtime/cookies'
 
 const SidebarStateSchema = z.object({
   state: z.boolean(),
 })
+
+const COOKIE_SETTINGS: Partial<ResponseCookie> = {
+  path: '/',
+  maxAge: 60 * 60 * 24 * 365,
+  sameSite: 'lax',
+  secure: process.env.NODE_ENV === 'production',
+}
 
 export async function POST(request: Request) {
   try {
     const body = SidebarStateSchema.parse(await request.json())
 
     const cookieStore = await cookies()
-    cookieStore.set(COOKIE_KEYS.SIDEBAR_STATE, body.state.toString(), {
-      path: '/',
-      maxAge: 60 * 60 * 24 * 7, // 7 days
-      sameSite: 'lax',
-      secure: process.env.NODE_ENV === 'production',
-    })
+    cookieStore.set(
+      COOKIE_KEYS.SIDEBAR_STATE,
+      body.state.toString(),
+      COOKIE_SETTINGS
+    )
 
     return Response.json({ state: body.state })
   } catch (error) {

--- a/src/app/api/sidebar/state/route.ts
+++ b/src/app/api/sidebar/state/route.ts
@@ -9,7 +9,7 @@ const SidebarStateSchema = z.object({
 
 const COOKIE_SETTINGS: Partial<ResponseCookie> = {
   path: '/',
-  maxAge: 60 * 60 * 24 * 365,
+  maxAge: 60 * 60 * 24 * 365, // 1 year
   sameSite: 'lax',
   secure: process.env.NODE_ENV === 'production',
 }

--- a/src/app/api/team/state/route.ts
+++ b/src/app/api/team/state/route.ts
@@ -8,16 +8,16 @@ const TeamStateSchema = z.object({
   teamSlug: z.string(),
 })
 
+const COOKIE_SETTINGS: Partial<ResponseCookie> = {
+  path: '/',
+  maxAge: 60 * 60 * 24 * 365, // 1 year
+  sameSite: 'lax',
+  secure: process.env.NODE_ENV === 'production',
+}
+
 export async function POST(request: Request) {
   try {
     const body = TeamStateSchema.parse(await request.json())
-
-    const COOKIE_SETTINGS: Partial<ResponseCookie> = {
-      path: '/',
-      maxAge: 60 * 60 * 24 * 7, // 7 days
-      sameSite: 'lax',
-      secure: process.env.NODE_ENV === 'production',
-    }
 
     const cookieStore = await cookies()
 

--- a/src/server/middleware.ts
+++ b/src/server/middleware.ts
@@ -194,7 +194,7 @@ export function getAuthRedirect(
 }
 
 const COOKIE_OPTIONS = {
-  maxAge: 60 * 60 * 24 * 30, // 30 days
+  maxAge: 60 * 60 * 24 * 365, // 1 year
   path: '/',
   secure: process.env.NODE_ENV === 'production',
   sameSite: 'lax' as const,


### PR DESCRIPTION
This pr improves the following cookies to store UI state, such as the sidebar state:
- Sidebar state from `7 days` to `1 year`
- Selected-Team states from `7 days` to `1 year`