### PR TITLE
Update: Adjust SANDBOXES_METRICS_POLLING_MS to 5 seconds

### DIFF
--- a/src/configs/intervals.ts
+++ b/src/configs/intervals.ts
@@ -1,2 +1,1 @@
-// 5.25 seconds - to account for sandbox metrics collection + network latency
-export const SANDBOXES_METRICS_POLLING_MS = 5_250
+export const SANDBOXES_METRICS_POLLING_MS = 5_000


### PR DESCRIPTION
Currently the metrics collection interval inside Sandboxes is 5 seconds, in order to adjust to this, this pr bumps the polling interval to 5.25 seconds.