### PR TITLE
Feat: Add Campaigns redirects + Expose new proxy route

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -72,6 +72,17 @@ const config = {
       destination: '/',
       permanent: true,
     },
+    // Campaigns
+    {
+      source: '/start',
+      destination: 'https://e2bdev.notion.site/Careers-at-E2B-2163f176991f43f69b0984bf2a142920',
+      permanent: true,
+    },
+    {
+      source: '/(humans|machines)',
+      destination: 'https://e2b.dev/enterprise?utm_source=billboard&utm_medium=outdoor&utm_campaign=launch_2025&utm_content=machines_ooh',
+      permanent: true,
+    }
   ],
   skipTrailingSlashRedirect: true,
 }

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -76,12 +76,14 @@ const config = {
     {
       source: '/start',
       destination: 'https://e2bdev.notion.site/Careers-at-E2B-2163f176991f43f69b0984bf2a142920',
-      permanent: true,
+      permanent: false,
+      statusCode: 302,
     },
     {
       source: '/(humans|machines)',
       destination: 'https://e2b.dev/enterprise?utm_source=billboard&utm_medium=outdoor&utm_campaign=launch_2025&utm_content=machines_ooh',
-      permanent: true,
+      permanent: false,
+      statusCode: 302,
     }
   ],
   skipTrailingSlashRedirect: true,

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -75,13 +75,13 @@ const config = {
     // Campaigns
     {
       source: '/start',
-      destination: 'https://e2bdev.notion.site/Careers-at-E2B-2163f176991f43f69b0984bf2a142920',
+      destination: '/careers',
       permanent: false,
       statusCode: 302,
     },
     {
       source: '/(humans|machines)',
-      destination: 'https://e2b.dev/enterprise?utm_source=billboard&utm_medium=outdoor&utm_campaign=launch_2025&utm_content=machines_ooh',
+      destination: '/enterprise?utm_source=billboard&utm_medium=outdoor&utm_campaign=launch_2025&utm_content=machines_ooh',
       permanent: false,
       statusCode: 302,
     }

--- a/src/configs/rewrites.ts
+++ b/src/configs/rewrites.ts
@@ -23,6 +23,7 @@ export const ROUTE_REWRITE_CONFIG: DomainConfig[] = [
       { path: '/contact' },
       { path: '/research' },
       { path: '/startups' },
+      { path: '/enterprise' },
       {
         path: '/blog/category',
         pathPreprocessor: (path) => path.replace('/blog', ''),

--- a/src/configs/rewrites.ts
+++ b/src/configs/rewrites.ts
@@ -24,6 +24,7 @@ export const ROUTE_REWRITE_CONFIG: DomainConfig[] = [
       { path: '/research' },
       { path: '/startups' },
       { path: '/enterprise' },
+      { path: '/careers' },
       {
         path: '/blog/category',
         pathPreprocessor: (path) => path.replace('/blog', ''),

--- a/vercel.json
+++ b/vercel.json
@@ -5,11 +5,6 @@
   "trailingSlash": false,
   "redirects": [
     {
-      "source": "/careers",
-      "destination": "https://e2bdev.notion.site/Careers-at-E2B-2163f176991f43f69b0984bf2a142920",
-      "permanent": true
-    },
-    {
       "source": "/docs",
       "has": [
         {


### PR DESCRIPTION
This pr adds a new redirection section inside the next apps config, for campaign redirects to campaign resources. Also this pr exposes `/enterprise` and /`careers` inside the catch-all rewrite handler, to rewrite from the landing page.