### PR TITLE
Chore: Remove custom traceFormat from winston logger

### DIFF
--- a/next-logger.config.ts
+++ b/next-logger.config.ts
@@ -1,19 +1,8 @@
-/* eslint-disable @typescript-eslint/no-require-imports */
-const { createLogger, transports, format } = require('winston')
-const { context, trace } = require('@opentelemetry/api')
-const { piiRedact } = require('@niveus/winston-utils').formatters
+// @ts-expect-error no types
+import { formatters } from '@niveus/winston-utils'
+import { createLogger, format, transports } from 'winston'
 
 const { combine, timestamp, json } = format
-
-const traceFormat = format((info) => {
-  const span = trace.getSpan(context.active())
-  if (span) {
-    const { traceId, spanId } = span.spanContext()
-    info.traceId = traceId
-    info.spanId = spanId
-  }
-  return info
-})
 
 const REDACTION_PATHS = [
   'password',
@@ -49,18 +38,17 @@ const REDACTION_PATHS = [
  * - Dynamic `traceId` and `spanId` from the current OpenTelemetry context
  * - Level determined by `LOG_LEVEL` env var (falls back to `debug` in dev, `info` otherwise)
  */
-const logger = (defaultConfig = {}) =>
+export const logger = (defaultConfig = {}) =>
   createLogger({
     level:
       process.env.NEXT_PUBLIC_VERBOSE && process.env.NODE_ENV !== 'production'
         ? 'debug'
         : 'info',
     format: combine(
-      piiRedact({
+      formatters.piiRedact({
         paths: REDACTION_PATHS,
       }),
       timestamp({ format: () => new Date().toISOString() }),
-      traceFormat(),
       json()
     ),
     transports: [
@@ -72,10 +60,4 @@ const logger = (defaultConfig = {}) =>
     ...defaultConfig,
   })
 
-const loggerInstance = logger({})
-
-module.exports = {
-  logger,
-  loggerInstance,
-  REDACTION_PATHS,
-}
+export const loggerInstance = logger({})


### PR DESCRIPTION
It seems that, in the vercel production environment, this mechanism throws silent errors. Hence this pr removes the custom traceFormat. The logger is currently being refactored to be otel / loki ready in #106, which will re-enable correct span context logging.