### PR TITLE
Fix: Sandbox list capped at 1000 entries

### DIFF
--- a/next-logger.config.ts
+++ b/next-logger.config.ts
@@ -16,6 +16,7 @@ const REDACTION_PATHS = [
   '*.token',
   '*.apiKey',
   '*.key',
+  '*.sandboxIds',
   '*.*.password',
   '*.*.confirmPassword',
   '*.*.accessToken',

--- a/src/app/dashboard/[teamIdOrSlug]/sandboxes/page.tsx
+++ b/src/app/dashboard/[teamIdOrSlug]/sandboxes/page.tsx
@@ -64,14 +64,14 @@ async function PageContent({ teamIdOrSlug }: PageContentProps) {
     )
   }
 
+  const maxSandboxesToFetchInitially = 100
+
   const metricsRes = await getTeamSandboxesMetrics({
     teamId,
-    sandboxIds: sandboxesRes.data.sandboxes.map((sandbox) => sandbox.sandboxID),
+    sandboxIds: sandboxesRes.data.sandboxes
+      .map((sandbox) => sandbox.sandboxID)
+      .slice(0, maxSandboxesToFetchInitially),
   })
-
-  if (metricsRes?.serverError) {
-    console.error(metricsRes.serverError)
-  }
 
   const sandboxes = sandboxesRes.data.sandboxes
   const templates = [

--- a/src/server/sandboxes/get-team-sandboxes.ts
+++ b/src/server/sandboxes/get-team-sandboxes.ts
@@ -36,12 +36,7 @@ export const getTeamSandboxes = authActionClient
         }
       }
 
-      const sandboxesRes = await infra.GET('/v2/sandboxes', {
-        params: {
-          query: {
-            state: ['running'],
-          },
-        },
+      const sandboxesRes = await infra.GET('/sandboxes', {
         headers: {
           ...SUPABASE_AUTH_HEADERS(session.access_token, teamId),
         },
@@ -59,7 +54,7 @@ export const getTeamSandboxes = authActionClient
           user_id: session.user.id,
           context: {
             status,
-            path: '/v2/sandboxes',
+            path: '/sandboxes',
           },
         })
 

--- a/src/server/sandboxes/get-team-sandboxes.ts
+++ b/src/server/sandboxes/get-team-sandboxes.ts
@@ -67,8 +67,8 @@ export const getTeamSandboxes = authActionClient
         team_id: teamId,
         user_id: session.user.id,
         context: {
-          status: 200,
-          path: '/v2/sandboxes',
+          status: sandboxesRes.response.status,
+          path: '/sandboxes',
           sandbox_count: sandboxesRes.data.length,
         },
       })

--- a/src/server/sandboxes/get-team-sandboxes.ts
+++ b/src/server/sandboxes/get-team-sandboxes.ts
@@ -66,6 +66,18 @@ export const getTeamSandboxes = authActionClient
         return handleDefaultInfraError(status)
       }
 
+      l.info({
+        key: 'get_team_sandboxes:success',
+        message: 'Successfully fetched team sandboxes',
+        team_id: teamId,
+        user_id: session.user.id,
+        context: {
+          status: 200,
+          path: '/v2/sandboxes',
+          sandbox_count: sandboxesRes.data.length,
+        },
+      })
+
       return {
         sandboxes: sandboxesRes.data,
       }


### PR DESCRIPTION
The current implementation uses infra api route `/v2/sandboxes` to list the sandboxes, which uses server side pagination. it did not cause unexpected behavior yet, since the default limit for entries on a paginated slice is 1000 sandboxes. Since we officially do not use the pagination in the dashboard implementation, this basically is a hard cap at 1000 concurrent sandboxes.

This pr: 
- reverts this change to use the legacy sandbox list endpoint for now
- adds improvements for the initial sandbox metrics fetching