### PR TITLE
Fix: Add hours display and improve remaining time calculation logic

### DIFF
--- a/src/features/dashboard/sandbox/header/remaining-time.tsx
+++ b/src/features/dashboard/sandbox/header/remaining-time.tsx
@@ -16,13 +16,17 @@ export default function RemainingTime() {
 
   const getRemainingSeconds = useCallback(() => {
     if (!endAt) return 0
+
     const endTs = typeof endAt === 'number' ? endAt : new Date(endAt).getTime()
+
     return Math.max(0, Math.floor((endTs - Date.now()) / 1000))
   }, [endAt])
 
   const [remaining, setRemaining] = useState<number>(getRemainingSeconds)
 
   useEffect(() => {
+    setRemaining(getRemainingSeconds())
+
     const id = setInterval(() => {
       setRemaining(getRemainingSeconds())
     }, 1000)
@@ -30,11 +34,13 @@ export default function RemainingTime() {
     return () => clearInterval(id)
   }, [endAt, getRemainingSeconds])
 
-  const minutes = Math.floor(remaining / 60)
+  const hours = Math.floor(remaining / 3600)
+  const minutes = Math.floor((remaining % 3600) / 60)
   const seconds = remaining % 60
-  const formatted = `${minutes.toString().padStart(2, '0')}:${seconds
+
+  const formatted = `${hours > 0 ? `${hours.toString().padStart(2, '0')}h ` : ''}${minutes
     .toString()
-    .padStart(2, '0')}`
+    .padStart(2, '0')}m ${seconds.toString().padStart(2, '0')}s`
 
   if (!isRunning) {
     return (


### PR DESCRIPTION
This pr refactors / fixes the "Timeout In" header on the sandbox details page, to make sure sandbox timeouts that exceed 1 hour are counted and displayed correctly.

<img width="688" height="216" alt="Screenshot 2025-08-04 at 5 00 47 PM" src="https://github.com/user-attachments/assets/76fce679-ce53-4cdf-bdcb-f31c79122661" />
