### PR TITLE
Improve: Enhance auth tests + relative url path validator

### DIFF
--- a/src/app/(auth)/sign-in/page.tsx
+++ b/src/app/(auth)/sign-in/page.tsx
@@ -57,11 +57,9 @@ export default function Login() {
     },
   })
 
-  const returnTo = searchParams.get('returnTo')
+  const returnTo = searchParams.get('returnTo') || undefined
 
   useEffect(() => {
-    if (!returnTo) return
-
     form.setValue('returnTo', returnTo)
   }, [returnTo, form])
 

--- a/src/app/(auth)/sign-in/page.tsx
+++ b/src/app/(auth)/sign-in/page.tsx
@@ -57,9 +57,11 @@ export default function Login() {
     },
   })
 
-  const returnTo = searchParams.get('returnTo') || ''
+  const returnTo = searchParams.get('returnTo')
 
   useEffect(() => {
+    if (!returnTo) return
+
     form.setValue('returnTo', returnTo)
   }, [returnTo, form])
 

--- a/src/app/(auth)/sign-up/page.tsx
+++ b/src/app/(auth)/sign-up/page.tsx
@@ -39,7 +39,7 @@ export default function SignUp() {
     return undefined
   })
 
-  const returnTo = searchParams.get('returnTo')
+  const returnTo = searchParams.get('returnTo') || undefined
 
   const {
     form,
@@ -59,8 +59,6 @@ export default function SignUp() {
   })
 
   useEffect(() => {
-    if (!returnTo) return
-
     form.setValue('returnTo', returnTo)
   }, [returnTo, form])
 

--- a/src/app/(auth)/sign-up/page.tsx
+++ b/src/app/(auth)/sign-up/page.tsx
@@ -35,11 +35,11 @@ export default function SignUp() {
     const success = searchParams.get('success')
     if (error) return { error: decodeURIComponent(error) }
     if (success) return { success: decodeURIComponent(success) }
+
     return undefined
   })
 
-  // Get returnTo URL from search params
-  const returnTo = searchParams.get('returnTo') || ''
+  const returnTo = searchParams.get('returnTo')
 
   const {
     form,
@@ -59,6 +59,8 @@ export default function SignUp() {
   })
 
   useEffect(() => {
+    if (!returnTo) return
+
     form.setValue('returnTo', returnTo)
   }, [returnTo, form])
 

--- a/src/lib/schemas/url.ts
+++ b/src/lib/schemas/url.ts
@@ -5,10 +5,6 @@ export const relativeUrlSchema = z
   .trim()
   .refine(
     (url) => {
-      if (url.length === 0) {
-        return true
-      }
-
       if (!url.startsWith('/')) {
         return false
       }


### PR DESCRIPTION
This pr adds two new auth tests, which both check for the same validation error on sign-in. Also this pr improves the relative path validator and how `returnTo` is handled inside sign-in and sign-up.