### PR TITLE
Fix: improve y-axis scaling when data exceeds chart limits

### DIFF
--- a/src/__test__/unit/chart-utils.test.ts
+++ b/src/__test__/unit/chart-utils.test.ts
@@ -35,17 +35,17 @@ describe('chart-utils', () => {
   describe('calculateYAxisMax', () => {
     it('should round to nice numbers without limit', () => {
       const data = [{ y: 80 }, { y: 100 }, { y: 60 }]
-      expect(calculateYAxisMax(data)).toBe(150) // rounds to nearest 50
+      expect(calculateYAxisMax(data)).toBe(150)
     })
 
-    it('should show limit with padding when data reaches 80%', () => {
+    it('should show limit with padding when data is at or below limit', () => {
       const data = [{ y: 80 }, { y: 100 }, { y: 60 }]
-      expect(calculateYAxisMax(data, 125)).toBe(138) // 125 * 1.1
+      expect(calculateYAxisMax(data, 100, undefined, 1.1)).toBe(110)
     })
 
-    it('should show limit with padding at 80% threshold', () => {
-      const data = [{ y: 70 }, { y: 80 }, { y: 60 }]
-      expect(calculateYAxisMax(data, 100)).toBe(110)
+    it('should apply limit padding when data exceeds limit', () => {
+      const data = [{ y: 120 }, { y: 140 }, { y: 130 }]
+      expect(calculateYAxisMax(data, 100, 1.25, 1.1)).toBe(200)
     })
 
     it('should use custom scale factor', () => {

--- a/src/features/dashboard/sandboxes/monitoring/charts/concurrent-chart.client.tsx
+++ b/src/features/dashboard/sandboxes/monitoring/charts/concurrent-chart.client.tsx
@@ -339,9 +339,7 @@ export default function ConcurrentChartClient({
           }),
           yAxis: {
             splitNumber: 2,
-            max: concurrentInstancesLimit
-              ? concurrentInstancesLimit * 1.1
-              : calculateYAxisMax(lineData),
+            max: calculateYAxisMax(lineData, concurrentInstancesLimit),
             axisLabel: {
               formatter: (value: number) => {
                 // Hide labels that are too close to the limit line

--- a/src/features/dashboard/sandboxes/monitoring/charts/utils.tsx
+++ b/src/features/dashboard/sandboxes/monitoring/charts/utils.tsx
@@ -84,29 +84,29 @@ export function calculateYAxisMax(
   const maxDataValue = Math.max(...data.map((d) => d.y || 0))
 
   if (limit !== undefined) {
-    const limitVisibilityThreshold = limit * 0.8
+    // when data exceeds limit, show max data value with padding and snapping
+    if (maxDataValue > limit) {
+      const scaledValue = maxDataValue * limitPadding
 
-    if (maxDataValue >= limitVisibilityThreshold) {
-      return Math.round(limit * limitPadding)
+      // apply snapping for clean axis values
+      if (scaledValue < 10) {
+        return Math.ceil(scaledValue)
+      } else if (scaledValue < 100) {
+        return Math.ceil(scaledValue / 10) * 10
+      } else if (scaledValue < 1000) {
+        return Math.ceil(scaledValue / 50) * 50
+      } else if (scaledValue < 10000) {
+        return Math.ceil(scaledValue / 100) * 100
+      } else {
+        return Math.ceil(scaledValue / 1000) * 1000
+      }
     }
 
-    // snap to fine-grained divisions for clean axis values
-    const scaledValue = maxDataValue * scaleFactor
-
-    // use 1/20th of limit for more granular steps
-    const divisionValue = limit / 20
-    const numberOfDivisions = Math.ceil(scaledValue / divisionValue)
-    const snappedValue = numberOfDivisions * divisionValue
-
-    // never snap exactly to limit - apply padding instead
-    // this prevents limit line being cut off by the chart constraints
-    if (snappedValue >= limit) {
-      return Math.round(limit * limitPadding)
-    }
-
-    return snappedValue
+    // when data is below limit, always show limit with padding
+    return Math.round(limit * limitPadding)
   }
 
+  // no limit defined - use scaling value with snapping
   const scaledValue = maxDataValue * scaleFactor
 
   if (scaledValue < 10) {

--- a/src/features/dashboard/sandboxes/monitoring/charts/utils.tsx
+++ b/src/features/dashboard/sandboxes/monitoring/charts/utils.tsx
@@ -83,23 +83,18 @@ export function calculateYAxisMax(
 
   const maxDataValue = Math.max(...data.map((d) => d.y || 0))
 
+  const snapToAxis = (value: number): number => {
+    if (value < 10) return Math.ceil(value)
+    if (value < 100) return Math.ceil(value / 10) * 10
+    if (value < 1000) return Math.ceil(value / 50) * 50
+    if (value < 10000) return Math.ceil(value / 100) * 100
+    return Math.ceil(value / 1000) * 1000
+  }
+
   if (limit !== undefined) {
     // when data exceeds limit, show max data value with padding and snapping
     if (maxDataValue > limit) {
-      const scaledValue = maxDataValue * limitPadding
-
-      // apply snapping for clean axis values
-      if (scaledValue < 10) {
-        return Math.ceil(scaledValue)
-      } else if (scaledValue < 100) {
-        return Math.ceil(scaledValue / 10) * 10
-      } else if (scaledValue < 1000) {
-        return Math.ceil(scaledValue / 50) * 50
-      } else if (scaledValue < 10000) {
-        return Math.ceil(scaledValue / 100) * 100
-      } else {
-        return Math.ceil(scaledValue / 1000) * 1000
-      }
+      return snapToAxis(maxDataValue * limitPadding)
     }
 
     // when data is below limit, always show limit with padding
@@ -107,19 +102,7 @@ export function calculateYAxisMax(
   }
 
   // no limit defined - use scaling value with snapping
-  const scaledValue = maxDataValue * scaleFactor
-
-  if (scaledValue < 10) {
-    return Math.ceil(scaledValue)
-  } else if (scaledValue < 100) {
-    return Math.ceil(scaledValue / 10) * 10
-  } else if (scaledValue < 1000) {
-    return Math.ceil(scaledValue / 50) * 50
-  } else if (scaledValue < 10000) {
-    return Math.ceil(scaledValue / 100) * 100
-  } else {
-    return Math.ceil(scaledValue / 1000) * 1000
-  }
+  return snapToAxis(maxDataValue * scaleFactor)
 }
 
 export function createMonitoringChartOptions({


### PR DESCRIPTION
Fixed an issue where charts would cap the y-axis at the limit line even when actual data exceeded it, potentially cutting off data points.

### Changes
- Y-axis now scales to `maxValue * 1.1` when data exceeds the defined limit
- When data is below limit, y-axis shows `limit * 1.1` to keep the limit line visible
- Maintains clean axis values through snapping (10s, 50s, 100s, etc)

### Before
Data points above limits could be cut off or squished against the top of charts

### After  
Charts properly scale to show all data while keeping limit lines as visual reference points

Fixes chart readability when sandboxes spike above configured limits.