### PR TITLE
Improve: prevent password sign up with e mail as password

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,5 +44,3 @@ CLAUDE.md
 
 # tooling
 /template
-# Sentry Config File
-.env.sentry-build-plugin

--- a/.gitignore
+++ b/.gitignore
@@ -40,6 +40,8 @@ next-env.d.ts
 # fuma-docs
 /.source
 
+CLAUDE.md
+
 # tooling
 /template
 # Sentry Config File

--- a/src/server/auth/auth-actions.ts
+++ b/src/server/auth/auth-actions.ts
@@ -13,6 +13,7 @@ import {
   validateEmail,
 } from '@/server/auth/validate-email'
 import { Provider } from '@supabase/supabase-js'
+import { returnValidationErrors } from 'next-safe-action'
 import { headers } from 'next/headers'
 import { redirect } from 'next/navigation'
 import { z } from 'zod'
@@ -80,8 +81,12 @@ export const signUpAction = actionClient
     const origin = (await headers()).get('origin') || ''
 
     // basic security check, that password does not equal e-mail
-    if (password.toLowerCase() === email.toLowerCase()) {
-      return returnServerError(USER_MESSAGES.passwordWeak.message)
+    if (password && email && password.toLowerCase() === email.toLowerCase()) {
+      return returnValidationErrors(signUpSchema, {
+        password: {
+          _errors: ['Password is too weak.'],
+        },
+      })
     }
 
     const validationResult = await validateEmail(email)

--- a/src/server/auth/auth-actions.ts
+++ b/src/server/auth/auth-actions.ts
@@ -79,6 +79,11 @@ export const signUpAction = actionClient
     const supabase = await createClient()
     const origin = (await headers()).get('origin') || ''
 
+    // basic security check, that password does not equal e-mail
+    if (password.toLowerCase() === email.toLowerCase()) {
+      return returnServerError(USER_MESSAGES.passwordWeak.message)
+    }
+
     const validationResult = await validateEmail(email)
 
     if (validationResult?.data) {

--- a/src/server/user/user-actions.ts
+++ b/src/server/user/user-actions.ts
@@ -31,7 +31,12 @@ export const updateUserAction = authActionClient
   .action(async ({ parsedInput, ctx }) => {
     const { supabase } = ctx
 
-    if (parsedInput.password === parsedInput.email) {
+    // basic security check, that password does not equal e-mail
+    if (
+      parsedInput.password &&
+      parsedInput.email &&
+      parsedInput.password.toLowerCase() === parsedInput.email.toLowerCase()
+    ) {
       return returnValidationErrors(UpdateUserSchema, {
         password: {
           _errors: ['Password is too weak.'],

--- a/src/server/user/user-actions.ts
+++ b/src/server/user/user-actions.ts
@@ -29,13 +29,13 @@ export const updateUserAction = authActionClient
   .schema(UpdateUserSchema)
   .metadata({ actionName: 'updateUser' })
   .action(async ({ parsedInput, ctx }) => {
-    const { supabase } = ctx
+    const { supabase, user } = ctx
 
     // basic security check, that password does not equal e-mail
     if (
       parsedInput.password &&
-      parsedInput.email &&
-      parsedInput.password.toLowerCase() === parsedInput.email.toLowerCase()
+      user.email &&
+      parsedInput.password.toLowerCase() === user.email.toLowerCase()
     ) {
       return returnValidationErrors(UpdateUserSchema, {
         password: {

--- a/src/server/user/user-actions.ts
+++ b/src/server/user/user-actions.ts
@@ -31,6 +31,14 @@ export const updateUserAction = authActionClient
   .action(async ({ parsedInput, ctx }) => {
     const { supabase } = ctx
 
+    if (parsedInput.password === parsedInput.email) {
+      return returnValidationErrors(UpdateUserSchema, {
+        password: {
+          _errors: ['Password is too weak.'],
+        },
+      })
+    }
+
     const origin = (await headers()).get('origin')
 
     const { data: updateData, error } = await supabase.auth.updateUser(

--- a/src/server/user/user-actions.ts
+++ b/src/server/user/user-actions.ts
@@ -32,16 +32,19 @@ export const updateUserAction = authActionClient
     const { supabase, user } = ctx
 
     // basic security check, that password does not equal e-mail
-    if (
-      parsedInput.password &&
-      user.email &&
-      parsedInput.password.toLowerCase() === user.email.toLowerCase()
-    ) {
-      return returnValidationErrors(UpdateUserSchema, {
-        password: {
-          _errors: ['Password is too weak.'],
-        },
-      })
+    if (parsedInput.password) {
+      const passwordAsUserEmail =
+        parsedInput.password.toLowerCase() === user?.email?.toLowerCase()
+      const passwordAsEmail =
+        parsedInput.password.toLowerCase() === parsedInput.email?.toLowerCase()
+
+      if (passwordAsUserEmail || passwordAsEmail) {
+        return returnValidationErrors(UpdateUserSchema, {
+          password: {
+            _errors: ['Password is too weak.'],
+          },
+        })
+      }
     }
 
     const origin = (await headers()).get('origin')

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -12,7 +12,7 @@
     "moduleResolution": "bundler",
     "noUncheckedIndexedAccess": true,
     "resolveJsonModule": true,
-    "jsx": "preserve",
+    "jsx": "react-jsx",
     "incremental": true,
     "plugins": [
       {


### PR DESCRIPTION
This pr add's validation, to ensure that the password a user is trying to sign-up with is not set to his e-mail address. The same validation applies when the user is trying to change his password. 