### PR TITLE
Monitoring dashboard design tweaks

### DIFF
--- a/src/features/dashboard/sandboxes/monitoring/charts/concurrent-chart.client.tsx
+++ b/src/features/dashboard/sandboxes/monitoring/charts/concurrent-chart.client.tsx
@@ -189,7 +189,7 @@ export default function ConcurrentChartClient({
             show={isPolling}
           />
         </div>
-        <div className="flex justify-between">
+        <div className="flex justify-between max-md:flex-col max-md:gap-2">
           <div className="inline-flex items-end gap-2">
             <span className="prose-value-big max-md:text-2xl">
               {formatAxisNumber(centralTendency.value)}
@@ -199,7 +199,7 @@ export default function ConcurrentChartClient({
               <span className="md:hidden">avg over range</span>
             </span>
           </div>
-          <div className="flex items-end gap-2">
+          <div className="flex items-end gap-2 max-md:flex-col max-md:items-start">
             {/* Date range label - full width on mobile */}
             {customRangeLabel && customRangeCopyValue && (
               <div className="flex items-center gap-2 max-md:w-full max-md:min-w-0">

--- a/src/features/dashboard/sandboxes/monitoring/charts/concurrent-chart.client.tsx
+++ b/src/features/dashboard/sandboxes/monitoring/charts/concurrent-chart.client.tsx
@@ -192,7 +192,7 @@ export default function ConcurrentChartClient({
         <div className="flex justify-between">
           <div className="inline-flex items-end gap-2">
             <span className="prose-value-big max-md:text-2xl">
-              {formatDecimal(centralTendency.value, 1)}
+              {formatAxisNumber(centralTendency.value)}
             </span>
             <span className="label-tertiary max-md:text-xs">
               <span className="max-md:hidden">average over range</span>

--- a/src/features/dashboard/sandboxes/monitoring/charts/concurrent-chart.client.tsx
+++ b/src/features/dashboard/sandboxes/monitoring/charts/concurrent-chart.client.tsx
@@ -182,16 +182,15 @@ export default function ConcurrentChartClient({
 
   return (
     <div className="p-3 md:p-6 border-b w-full flex flex-col flex-1 md:min-h-0">
-      <div className="flex max-md:flex-col md:justify-between gap-2 md:gap-6 md:min-h-[60px]">
-        <div className="flex flex-col justify-end">
-          <span className="prose-label-highlight uppercase max-md:text-sm">
-            Concurrent sandboxes
-            <ReactiveLiveBadge
-              show={isPolling}
-              className="ml-3 transform -translate-y-0.5"
-            />
-          </span>
-          <div className="inline-flex items-end gap-2 md:gap-3 mt-1 md:mt-2">
+      <div className="flex flex-col gap-2">
+        <div className="prose-label-highlight uppercase max-md:text-sm flex justify-between items-center">
+          <span>Concurrent sandboxes</span>
+          <ReactiveLiveBadge
+            show={isPolling}
+          />
+        </div>
+        <div className="flex justify-between">
+          <div className="inline-flex items-end gap-2">
             <span className="prose-value-big max-md:text-2xl">
               {formatDecimal(centralTendency.value, 1)}
             </span>
@@ -200,96 +199,95 @@ export default function ConcurrentChartClient({
               <span className="md:hidden">avg over range</span>
             </span>
           </div>
-        </div>
+          <div className="flex items-end gap-2">
+            {/* Date range label - full width on mobile */}
+            {customRangeLabel && customRangeCopyValue && (
+              <div className="flex items-center gap-2 max-md:w-full max-md:min-w-0">
+                <CopyButton
+                  value={customRangeCopyValue}
+                  variant="ghost"
+                  size="slate"
+                  className="size-4 max-md:hidden"
+                  title="Copy ISO 8601 time interval"
+                />
+                <span
+                  className="text-fg py-0.5 max-md:text-[11px] md:text-xs prose-label-highlight truncate min-w-0"
+                  style={{ letterSpacing: '0%' }}
+                  title={customRangeCopyValue}
+                >
+                  {customRangeLabel}
+                </span>
+                <CopyButton
+                  value={customRangeCopyValue}
+                  variant="ghost"
+                  size="slate"
+                  className="size-4 md:hidden flex-shrink-0"
+                  title="Copy ISO 8601 time interval"
+                />
+              </div>
+            )}
 
-        <div className="flex flex-col md:flex-row md:items-end gap-2">
-          {/* Date range label - full width on mobile */}
-          {customRangeLabel && customRangeCopyValue && (
-            <div className="flex items-center gap-2 max-md:w-full max-md:min-w-0">
-              <CopyButton
-                value={customRangeCopyValue}
-                variant="ghost"
-                size="slate"
-                className="size-4 max-md:hidden"
-                title="Copy ISO 8601 time interval"
-              />
-              <span
-                className="text-fg py-0.5 max-md:text-[11px] md:text-xs prose-label-highlight truncate min-w-0"
-                style={{ letterSpacing: '0%' }}
-                title={customRangeCopyValue}
-              >
-                {customRangeLabel}
-              </span>
-              <CopyButton
-                value={customRangeCopyValue}
-                variant="ghost"
-                size="slate"
-                className="size-4 md:hidden flex-shrink-0"
-                title="Copy ISO 8601 time interval"
-              />
-            </div>
-          )}
+            {/* Time selector buttons - single row on mobile */}
+            <div className="flex items-center gap-2 md:gap-4 max-md:-ml-1.5 max-md:pr-3 max-md:-mr-3 max-md:-mt-0.5 max-md:overflow-x-auto [&::-webkit-scrollbar]:hidden">
+              <TimePicker
+                value={{
+                  mode: syncedTimeframe.isLive ? 'live' : 'static',
+                  range: syncedTimeframe.duration,
+                  start: syncedTimeframe.start,
+                  end: syncedTimeframe.end,
+                }}
+                onValueChange={(value) => {
+                  if (value.mode === 'static' && value.start && value.end) {
+                    setStaticMode(value.start, value.end)
+                  } else if (value.mode === 'live' && value.range) {
+                    const matchingRange = Object.entries(TIME_RANGES).find(
+                      ([_, rangeMs]) => rangeMs === value.range
+                    )
 
-          {/* Time selector buttons - single row on mobile */}
-          <div className="flex items-center gap-2 md:gap-4 max-md:-ml-1.5 max-md:pr-3 max-md:-mr-3 max-md:-mt-0.5 max-md:overflow-x-auto [&::-webkit-scrollbar]:hidden">
-            <TimePicker
-              value={{
-                mode: syncedTimeframe.isLive ? 'live' : 'static',
-                range: syncedTimeframe.duration,
-                start: syncedTimeframe.start,
-                end: syncedTimeframe.end,
-              }}
-              onValueChange={(value) => {
-                if (value.mode === 'static' && value.start && value.end) {
-                  setStaticMode(value.start, value.end)
-                } else if (value.mode === 'live' && value.range) {
-                  const matchingRange = Object.entries(TIME_RANGES).find(
-                    ([_, rangeMs]) => rangeMs === value.range
-                  )
-
-                  if (matchingRange) {
-                    setTimeRange(matchingRange[0] as TimeRangeKey)
-                  } else {
-                    const now = Date.now()
-                    setCustomRange(now - value.range, now)
+                    if (matchingRange) {
+                      setTimeRange(matchingRange[0] as TimeRangeKey)
+                    } else {
+                      const now = Date.now()
+                      setCustomRange(now - value.range, now)
+                    }
                   }
-                }
-              }}
-            >
-              <Button
-                variant="ghost"
-                size="slate"
-                className={cn(
-                  'text-fg-tertiary hover:text-fg-secondary py-0.5 max-md:text-[11px] max-md:px-1.5 flex-shrink-0 prose-label',
-                  {
-                    'text-fg prose-label-highlight': currentRange === 'custom',
-                  }
-                )}
+                }}
               >
-                custom
-              </Button>
-            </TimePicker>
-
-            {CHART_RANGE_MAP_KEYS.filter((key) => key !== 'custom').map(
-              (key) => (
                 <Button
-                  key={key}
                   variant="ghost"
                   size="slate"
                   className={cn(
                     'text-fg-tertiary hover:text-fg-secondary py-0.5 max-md:text-[11px] max-md:px-1.5 flex-shrink-0 prose-label',
                     {
-                      'text-fg prose-label-highlight': currentRange === key,
+                      'text-fg prose-label-highlight': currentRange === 'custom',
                     }
                   )}
-                  onClick={() =>
-                    handleRangeChange(key as keyof typeof CHART_RANGE_MAP)
-                  }
                 >
-                  {key}
+                  custom
                 </Button>
-              )
-            )}
+              </TimePicker>
+
+              {CHART_RANGE_MAP_KEYS.filter((key) => key !== 'custom').map(
+                (key) => (
+                  <Button
+                    key={key}
+                    variant="ghost"
+                    size="slate"
+                    className={cn(
+                      'text-fg-tertiary hover:text-fg-secondary py-0.5 max-md:text-[11px] max-md:px-1.5 flex-shrink-0 prose-label',
+                      {
+                        'text-fg prose-label-highlight': currentRange === key,
+                      }
+                    )}
+                    onClick={() =>
+                      handleRangeChange(key as keyof typeof CHART_RANGE_MAP)
+                    }
+                  >
+                    {key}
+                  </Button>
+                )
+              )}
+            </div>
           </div>
         </div>
       </div>

--- a/src/features/dashboard/sandboxes/monitoring/charts/concurrent-chart.client.tsx
+++ b/src/features/dashboard/sandboxes/monitoring/charts/concurrent-chart.client.tsx
@@ -185,7 +185,7 @@ export default function ConcurrentChartClient({
       <div className="flex max-md:flex-col md:justify-between gap-2 md:gap-6 md:min-h-[60px]">
         <div className="flex flex-col justify-end">
           <span className="prose-label-highlight uppercase max-md:text-sm">
-            Concurrent
+            Concurrent sandboxes
             <ReactiveLiveBadge
               show={isPolling}
               className="ml-3 transform -translate-y-0.5"

--- a/src/features/dashboard/sandboxes/monitoring/charts/start-rate-chart.client.tsx
+++ b/src/features/dashboard/sandboxes/monitoring/charts/start-rate-chart.client.tsx
@@ -102,15 +102,14 @@ export default function StartRateChartClient({
 
   return (
     <div className="p-3 md:p-6 border-b w-full h-full flex flex-col flex-1 md:min-h-0">
-      <div className="md:min-h-[60px] flex flex-col justify-end">
-        <span className="prose-label-highlight uppercase max-md:text-sm">
-          Start Rate per Second
+      <div className="flex flex-col gap-2">
+        <div className="prose-label-highlight uppercase max-md:text-sm flex justify-between items-center w-full">
+          <span>Start Rate per Second</span>
           <ReactiveLiveBadge
             show={isPolling}
-            className="ml-3 transform -translate-y-0.5"
           />
-        </span>
-        <div className="inline-flex items-end gap-2 md:gap-3 mt-1 md:mt-2">
+        </div>
+        <div className="inline-flex items-end gap-2 md:gap-3">
           <span className="prose-value-big max-md:text-2xl">
             {formatDecimal(centralTendency.value, 3)}
           </span>

--- a/src/features/dashboard/sandboxes/monitoring/header.client.tsx
+++ b/src/features/dashboard/sandboxes/monitoring/header.client.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { formatNumber } from '@/lib/utils/formatting'
+import { formatDecimal, formatNumber } from '@/lib/utils/formatting'
 import { getTeamMetrics } from '@/server/sandboxes/get-team-metrics'
 import { InferSafeActionFnResult } from 'next-safe-action'
 import { useMemo } from 'react'
@@ -45,7 +45,7 @@ export function SandboxesStartRateClient({
   const lastSandboxesStartRate = useMemo(() => {
     const rate =
       data?.metrics?.[(data?.metrics?.length ?? 0) - 1]?.sandboxStartRate ?? 0
-    return Math.round(rate * 100) / 100
+    return formatDecimal(rate, 3)
   }, [data])
 
   return <span className="prose-value-big mt-4">{lastSandboxesStartRate}</span>

--- a/src/features/dashboard/sandboxes/monitoring/header.client.tsx
+++ b/src/features/dashboard/sandboxes/monitoring/header.client.tsx
@@ -29,7 +29,7 @@ export function ConcurrentSandboxesClient({
         {formatNumber(lastConcurrentSandboxes)}
       </span>
       {limit && (
-        <span className="absolute right-3 bottom-3 text-fg-tertiary prose-label">
+        <span className="absolute right-3 bottom-3 md:right-6 md:bottom-4 text-fg-tertiary prose-label">
           LIMIT: {formatNumber(limit)}
         </span>
       )}

--- a/src/features/dashboard/sandboxes/monitoring/header.client.tsx
+++ b/src/features/dashboard/sandboxes/monitoring/header.client.tsx
@@ -25,7 +25,7 @@ export function ConcurrentSandboxesClient({
 
   return (
     <>
-      <span className="prose-value-big mt-4">
+      <span className="prose-value-big mt-1">
         {formatNumber(lastConcurrentSandboxes)}
       </span>
       {limit && (
@@ -48,5 +48,5 @@ export function SandboxesStartRateClient({
     return formatDecimal(rate, 3)
   }, [data])
 
-  return <span className="prose-value-big mt-4">{lastSandboxesStartRate}</span>
+  return <span className="prose-value-big mt-1">{lastSandboxesStartRate}</span>
 }

--- a/src/features/dashboard/sandboxes/monitoring/header.tsx
+++ b/src/features/dashboard/sandboxes/monitoring/header.tsx
@@ -17,7 +17,7 @@ import {
 
 function BaseCard({ children }: { children: React.ReactNode }) {
   return (
-    <div className="p-4 md:p-6 max-md:not-last:border-b md:not-last:border-r h-full flex-1 w-full flex flex-col justify-center items-center gap-2 md:gap-3 relative max-md:min-h-[100px] md:min-h-[200px]">
+    <div className="p-4 md:p-6 max-md:not-last:border-b md:not-last:border-r flex-1 w-full flex flex-col justify-center items-center gap-2 md:gap-3 relative min-h-[100px] md:h-45">
       {children}
     </div>
   )
@@ -50,7 +50,7 @@ export default function SandboxesMonitoringHeader({
   params: Promise<SandboxesMonitoringPageParams>
 }) {
   return (
-    <div className="flex md:flex-row flex-col items-center border-b w-full md:min-h-52 max-md:py-2">
+    <div className="flex md:flex-row flex-col items-center border-b w-full max-md:py-2">
       <BaseCard>
         <SemiLiveBadge className="absolute left-3 top-3 md:left-6 md:top-6" />
         <Suspense fallback={<Skeleton className="w-16 h-8" />}>
@@ -219,7 +219,7 @@ export const MaxConcurrentSandboxes = async ({
 
   return (
     <>
-      <span className="prose-value-big mt-4">
+      <span className="prose-value-big mt-1">
         {formatNumber(concurrentSandboxes)}
       </span>
       {limit && (

--- a/src/features/dashboard/sandboxes/monitoring/header.tsx
+++ b/src/features/dashboard/sandboxes/monitoring/header.tsx
@@ -57,7 +57,7 @@ export default function SandboxesMonitoringHeader({
           <ConcurrentSandboxes params={params} />
         </Suspense>
         <BaseSubtitle>
-          Concurrent <span className="max-md:hidden">Sandboxes</span>{' '}
+          Concurrent Sandboxes{' '}
           <br className="max-md:hidden" />
           <span className="max-md:hidden">(5-sec avg)</span>
         </BaseSubtitle>
@@ -70,7 +70,6 @@ export default function SandboxesMonitoringHeader({
         </Suspense>
         <BaseSubtitle>
           Start Rate per Second <br className="max-md:hidden" />
-          <span className="md:hidden">per sec</span>
           <span className="max-md:hidden">(5-sec avg)</span>
         </BaseSubtitle>
       </BaseCard>
@@ -80,8 +79,7 @@ export default function SandboxesMonitoringHeader({
           <MaxConcurrentSandboxes params={params} />
         </Suspense>
         <BaseSubtitle>
-          Max<span className="max-md:hidden"> Concurrent Sandboxes</span>
-          <span className="md:hidden"> Concurrent</span>
+          Max Concurrent Sandboxes
           <br className="max-md:hidden" />
           <span className="max-md:hidden">(30-day max)</span>
         </BaseSubtitle>
@@ -223,7 +221,7 @@ export const MaxConcurrentSandboxes = async ({
         {formatNumber(concurrentSandboxes)}
       </span>
       {limit && (
-        <span className="absolute right-6 bottom-4 prose-label text-fg-tertiary ">
+        <span className="absolute right-3 bottom-1 md:right-6 md:bottom-4 prose-label text-fg-tertiary ">
           LIMIT: {formatNumber(limit)}
         </span>
       )}

--- a/src/features/dashboard/sandboxes/monitoring/header.tsx
+++ b/src/features/dashboard/sandboxes/monitoring/header.tsx
@@ -57,8 +57,7 @@ export default function SandboxesMonitoringHeader({
           <ConcurrentSandboxes params={params} />
         </Suspense>
         <BaseSubtitle>
-          Concurrent Sandboxes{' '}
-          <br className="max-md:hidden" />
+          Concurrent Sandboxes <br className="max-md:hidden" />
           <span className="max-md:hidden">(5-sec avg)</span>
         </BaseSubtitle>
       </BaseCard>
@@ -79,7 +78,7 @@ export default function SandboxesMonitoringHeader({
           <MaxConcurrentSandboxes params={params} />
         </Suspense>
         <BaseSubtitle>
-          Max Concurrent Sandboxes
+          Peak Concurrent Sandboxes
           <br className="max-md:hidden" />
           <span className="max-md:hidden">(30-day max)</span>
         </BaseSubtitle>

--- a/src/features/dashboard/sandboxes/monitoring/header.tsx
+++ b/src/features/dashboard/sandboxes/monitoring/header.tsx
@@ -53,26 +53,25 @@ export default function SandboxesMonitoringHeader({
     <div className="flex md:flex-row flex-col items-center border-b w-full md:min-h-52 max-md:py-2">
       <BaseCard>
         <SemiLiveBadge className="absolute left-3 top-3 md:left-6 md:top-6" />
-
-        <Suspense fallback={<Skeleton className="w-16 h-8" />}>
-          <SandboxesStartRate params={params} />
-        </Suspense>
-        <BaseSubtitle>
-          Start Rate per Second <br className="max-md:hidden" />
-          <span className="md:hidden">per sec</span>
-          <span className="max-md:hidden">(5 sec average)</span>
-        </BaseSubtitle>
-      </BaseCard>
-
-      <BaseCard>
-        <SemiLiveBadge className="absolute left-3 top-3 md:left-6 md:top-6" />
         <Suspense fallback={<Skeleton className="w-16 h-8" />}>
           <ConcurrentSandboxes params={params} />
         </Suspense>
         <BaseSubtitle>
           Concurrent <span className="max-md:hidden">Sandboxes</span>{' '}
           <br className="max-md:hidden" />
-          <span className="max-md:hidden">(5 sec average)</span>
+          <span className="max-md:hidden">(5-sec avg)</span>
+        </BaseSubtitle>
+      </BaseCard>
+
+      <BaseCard>
+        <SemiLiveBadge className="absolute left-3 top-3 md:left-6 md:top-6" />
+        <Suspense fallback={<Skeleton className="w-16 h-8" />}>
+          <SandboxesStartRate params={params} />
+        </Suspense>
+        <BaseSubtitle>
+          Start Rate per Second <br className="max-md:hidden" />
+          <span className="md:hidden">per sec</span>
+          <span className="max-md:hidden">(5-sec avg)</span>
         </BaseSubtitle>
       </BaseCard>
 
@@ -84,7 +83,7 @@ export default function SandboxesMonitoringHeader({
           Max<span className="max-md:hidden"> Concurrent Sandboxes</span>
           <span className="md:hidden"> Concurrent</span>
           <br className="max-md:hidden" />
-          <span className="max-md:hidden">(Last 30 Days)</span>
+          <span className="max-md:hidden">(30-day max)</span>
         </BaseSubtitle>
       </BaseCard>
     </div>


### PR DESCRIPTION
1. Copy on all labels made consistent
2. Moved the live label to the right
3. Unified the number formatting on graphs & cards
4. Reduced the height of cards
5. Switched the order of the two base cards (concurrent vs start rate) to make it consistent with the graphs below

Before:
<img width="4112" height="2490" alt="Arc - 2025-09-24 at 12 13 45@2x" src="https://github.com/user-attachments/assets/6d5abcfa-922a-4ef4-95bf-7364c03e45dc" />

After:
<img width="4112" height="2494" alt="Arc - 2025-09-24 at 12 12 14@2x" src="https://github.com/user-attachments/assets/973f64fa-7e8f-4e58-a8e3-250722dd140b" />

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Updates monitoring dashboard UI with consistent labels/number formatting, right-aligned live badges, reduced card height, swapped card order, and tweaked chart/header layouts.
> 
> - **Monitoring Header**:
>   - **Card order**: Swap positions so `ConcurrentSandboxes` appears before `SandboxesStartRate`.
>   - **Copy**: Update subtitles to "(5-sec avg)" and rename to `Peak Concurrent Sandboxes` with "(30-day max)".
>   - **Layout**: Reduce card height (`min-h` tweaks) and adjust LIMIT label positioning for responsiveness.
> - **Charts**:
>   - **Concurrent chart (`concurrent-chart.client.tsx`)**:
>     - Header rewritten: explicit "Concurrent sandboxes" with `ReactiveLiveBadge` aligned to the right.
>     - Display value uses `formatAxisNumber` (was `formatDecimal(..., 1)`); header/time controls layout simplified and made responsive.
>   - **Start rate chart (`start-rate-chart.client.tsx`)**:
>     - Header aligns with concurrent chart: label + right-aligned `ReactiveLiveBadge`; spacing simplified.
> - **Number formatting**:
>   - Use `formatDecimal(..., 3)` for start rate in header client and adjust margins (`mt-1`), keeping values consistent across charts and cards.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9e5fb3e8cd46d5e659e27d27044c9faac20dd2c3. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->