### PR TITLE
Improve: Sandboxes Usage Prose

### DIFF
--- a/src/features/dashboard/usage/sandboxes-card.tsx
+++ b/src/features/dashboard/usage/sandboxes-card.tsx
@@ -20,9 +20,9 @@ export function SandboxesCard({
   return (
     <Card className={className}>
       <CardHeader>
-        <CardTitle className="font-mono">Sandboxes Started</CardTitle>
+        <CardTitle className="font-mono">Sandboxes Usage</CardTitle>
         <CardDescription>
-          The number of sandboxes your team started over time.
+          Total sandboxes started and resumed over time.
         </CardDescription>
       </CardHeader>
       <CardContent className="flex flex-col gap-4">


### PR DESCRIPTION
Changes the sandboxes usage chart description, to inform users that this includes started and resumed sandboxes.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Updates the dashboard sandboxes card title and description to indicate it shows total started and resumed sandboxes over time.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c63a29813e2330341f3699ad7d6df6d39764d290. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->