### PR TITLE
Improve: allow dots as team name separators

### DIFF
--- a/src/server/team/types.ts
+++ b/src/server/team/types.ts
@@ -22,7 +22,7 @@ export const TeamNameSchema = z
   .trim()
   .min(1, { message: 'Team name cannot be empty' })
   .max(32, { message: 'Team name cannot be longer than 32 characters' })
-  .regex(/^[a-zA-Z0-9]+(?:[ _.-][a-zA-Z0-9]+)*$/, {
+  .regex(/^[a-zA-Z0-9]+(?:[ _.\-][a-zA-Z0-9]+)*$/, {
     message:
       'Names can only contain letters and numbers, separated by spaces, underscores, hyphens, or dots',
   })


### PR DESCRIPTION
This pr allows team names to include dots as separators

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Allow '.' as a valid team-name separator by updating `TeamNameSchema` regex and messages.
> 
> - **Validation**:
>   - Update `TeamNameSchema` in `src/server/team/types.ts` to accept dots as separators (regex `^[a-zA-Z0-9]+(?:[ _.\-][a-zA-Z0-9]+)*$`).
>   - Adjust examples and validation message to include dot support.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6f511279a84fddf97e52be5d4fa5ff38caa8a75c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->