### PR TITLE
fix: inspect page layout

### DIFF
--- a/src/app/dashboard/[teamIdOrSlug]/sandboxes/[sandboxId]/inspect/page.tsx
+++ b/src/app/dashboard/[teamIdOrSlug]/sandboxes/[sandboxId]/inspect/page.tsx
@@ -42,8 +42,8 @@ export default async function SandboxInspectPage({
     >
       <ClientOnly
         className={cn(
-          'sticky top-0 flex flex-1 gap-4 overflow-hidden p-3 md:p-6 max-md:min-h-[calc(100vh-var(--protected-navbar-height))]',
-          'md:relative md:!max-h-[100%]'
+          'flex flex-1 gap-4 overflow-hidden p-3 md:p-6',
+          'max-md:sticky max-md:top-0 max-md:min-h-[calc(100vh-var(--protected-navbar-height))]'
         )}
       >
         <SandboxInspectFilesystem rootPath={rootPath} />

--- a/src/features/dashboard/sandbox/layout.tsx
+++ b/src/features/dashboard/sandbox/layout.tsx
@@ -33,11 +33,15 @@ export default function SandboxLayout({
   }
 
   return (
-    <div className="flex max-h-svh min-h-0 flex-1 flex-col max-md:overflow-y-auto h-full">
+    <div className="flex max-h-svh h-full min-h-0 flex-1 flex-col max-md:overflow-y-auto">
       {header}
 
       <DashboardTabs type="path" layoutKey="tabs-indicator-sandbox">
-        <DashboardTab id="inspect" label="Inspect">
+        <DashboardTab
+          id="inspect"
+          label="Inspect"
+          className="flex flex-col max-h-full"
+        >
           {isEnvdVersionCompatibleForInspect ? (
             children
           ) : (


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Refines Inspect page responsive sticky behavior and sets the Inspect tab to a flex column with constrained height.
> 
> - **Inspect page layout** (`src/app/.../inspect/page.tsx`):
>   - Make sticky header behavior mobile-only (`max-md:sticky max-md:top-0`), remove `md:relative md:!max-h-[100%]`, and simplify container classes.
> - **Sandbox layout** (`src/features/dashboard/sandbox/layout.tsx`):
>   - Set `DashboardTab` "inspect" to `className="flex flex-col max-h-full"` to better constrain and stack content.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit db51698c1bb879ee0b1f5fadf72d041c40733766. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->