### PR TITLE
fix: fullscreen transition visibility issue

### DIFF
--- a/src/features/dashboard/usage/usage-metric-chart.tsx
+++ b/src/features/dashboard/usage/usage-metric-chart.tsx
@@ -131,39 +131,35 @@ export function UsageMetricChart({
 
   return (
     <>
-      {!isFullscreen && (
-        <Card className={cn('h-full flex flex-col', className)}>
-          <UsageMetricChartContent
-            metric={metric}
-            timeRangeControlsClassName={timeRangeControlsClassName}
-            isFullscreen={isFullscreen}
-          />
-        </Card>
-      )}
+      <Card className={cn('h-full flex flex-col', className)}>
+        <UsageMetricChartContent
+          metric={metric}
+          timeRangeControlsClassName={timeRangeControlsClassName}
+          isFullscreen={false}
+        />
+      </Card>
 
-      {isFullscreen && (
-        <Dialog
-          open={isFullscreen}
-          onOpenChange={(open) => !open && setFullscreenMetric(null)}
+      <Dialog
+        open={isFullscreen}
+        onOpenChange={(open) => !open && setFullscreenMetric(null)}
+      >
+        <DialogContent
+          className="sm:max-w-[min(90svw,2200px)] w-full max-h-[min(70svh,1200px)] h-full p-0"
+          closeButtonClassName="top-7.5 right-6.5"
         >
-          <DialogContent
-            className="sm:max-w-[min(90svw,2200px)] w-full max-h-[min(70svh,1200px)] h-full border-0 p-0"
-            closeButtonClassName="top-7.5 right-6.5"
-          >
-            {/* title just here to avoid accessibility dev error from radix */}
-            <DialogTitle className="sr-only">
-              {METRIC_CONFIGS[metric].title}
-            </DialogTitle>
-            <Card className="h-full flex flex-col border-0">
-              <UsageMetricChartContent
-                metric={metric}
-                timeRangeControlsClassName={timeRangeControlsClassName}
-                isFullscreen={isFullscreen}
-              />
-            </Card>
-          </DialogContent>
-        </Dialog>
-      )}
+          {/* title just here to avoid accessibility dev error from radix */}
+          <DialogTitle className="sr-only">
+            {METRIC_CONFIGS[metric].title}
+          </DialogTitle>
+          <Card className="h-full flex flex-col border-0">
+            <UsageMetricChartContent
+              metric={metric}
+              timeRangeControlsClassName={timeRangeControlsClassName}
+              isFullscreen={true}
+            />
+          </Card>
+        </DialogContent>
+      </Dialog>
     </>
   )
 }


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Always render the chart card and the fullscreen dialog, controlling visibility via Dialog open and passing explicit isFullscreen flags to prevent transition flicker.
> 
> - **Dashboard/Usage Chart (`src/features/dashboard/usage/usage-metric-chart.tsx`)**:
>   - Always render base `Card` with `UsageMetricChartContent` (`isFullscreen: false`); remove conditional non-fullscreen wrapper.
>   - Always render `Dialog` (visibility via `open={isFullscreen}`) with `DialogContent` and nested `Card` containing `UsageMetricChartContent` (`isFullscreen: true`).
>   - Clean up classes on `DialogContent` (drop `border-0`) and inner fullscreen `Card` retains `border-0`.
>   - Simplify fullscreen toggle handling via `onOpenChange` without conditional JSX blocks.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4f290906f0d0d52e27f3a4bc5aae3088d17fb4e8. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->