### PR TITLE
Add: sandbox creation route under /sbx/new

### DIFF
--- a/src/app/sbx/new/route.ts
+++ b/src/app/sbx/new/route.ts
@@ -23,8 +23,6 @@ export const GET = async (req: NextRequest) => {
       )
     }
 
-    const defaultTeam = await getDefaultTeam(data.user.id)
-
     const session = await getSessionInsecure(supabase)
 
     if (!session) {
@@ -36,6 +34,8 @@ export const GET = async (req: NextRequest) => {
         new URL(`${AUTH_URLS.SIGN_IN}?${params.toString()}`, req.url)
       )
     }
+
+    const defaultTeam = await getDefaultTeam(data.user.id)
 
     const sbx = await Sandbox.create('base', {
       domain: process.env.NEXT_PUBLIC_E2B_DOMAIN,


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Adds an authenticated GET route at `/sbx/new` that creates an E2B sandbox and redirects to its inspect page, with error handling and sign-in redirects.
> 
> - **Routes**:
>   - **New GET** `src/app/sbx/new/route.ts`
>     - Auth guard via Supabase (`createClient`, `auth.getUser`) and `getSessionInsecure`; redirects to `AUTH_URLS.SIGN_IN` with `returnTo` if unauthenticated.
>     - Fetches default team with `getDefaultTeam` and creates E2B sandbox via `Sandbox.create('base', { domain: env, headers: SUPABASE_AUTH_HEADERS(token, teamId) })`.
>     - Redirects to `PROTECTED_URLS.SANDBOX_INSPECT(teamSlug, sandboxId)` on success.
>     - On error: logs (`l.warn` with `serializeError`) and redirects to request origin.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d322ab9d9d9e87adf771e1c789091a38fc165dc5. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->