### PR TITLE
Fix: miss-configured layout config which results in wrong titles

### DIFF
--- a/src/configs/layout.ts
+++ b/src/configs/layout.ts
@@ -34,8 +34,16 @@ const DASHBOARD_LAYOUT_CONFIGS: Record<string, DashboardLayoutConfig> = {
   },
 
   // team
-  '/dashboard/*/(general|keys|members)': {
+  '/dashboard/*/general': {
     title: 'General',
+    type: 'default',
+  },
+  '/dashboard/*/keys': {
+    title: 'API Keys',
+    type: 'default',
+  },
+  '/dashboard/*/members': {
+    title: 'Members',
     type: 'default',
   },
 
@@ -47,8 +55,12 @@ const DASHBOARD_LAYOUT_CONFIGS: Record<string, DashboardLayoutConfig> = {
       includeHeaderBottomStyles: true,
     },
   },
-  '/dashboard/*/(budget|billing)': {
+  '/dashboard/*/budget': {
     title: 'Budget',
+    type: 'default',
+  },
+  '/dashboard/*/billing': {
+    title: 'Billing',
     type: 'default',
   },
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Define explicit layout configs for general/keys/members and budget/billing dashboard routes.
> 
> - **Configs (`src/configs/layout.ts`)**:
>   - Split grouped patterns into explicit routes with titles:
>     - `'/dashboard/*/general'` → `General`
>     - `'/dashboard/*/keys'` → `API Keys`
>     - `'/dashboard/*/members'` → `Members`
>     - `'/dashboard/*/budget'` → `Budget`
>     - `'/dashboard/*/billing'` → `Billing`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 51376003cd91cd6b7cf7953f575addf1e71ce322. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->