### PR TITLE
Add: Docker MCP campaign redirects

### DIFF
--- a/src/configs/redirects.ts
+++ b/src/configs/redirects.ts
@@ -28,18 +28,20 @@ export const MIDDLEWARE_REDIRECTS: MiddlewareRedirect[] = [
     },
   },
   {
-    source: '/start',
+    source: '/machines',
     destination:
-      '/careers?utm_source=billboard&utm_medium=outdoor&utm_campaign=prague_ooh_2025&utm_content=start',
+      '/careers?utm_source=billboard&utm_medium=outdoor&utm_campaign=prague_ooh_2025&utm_content=machines',
     statusCode: 302,
     headers: {
       'X-Robots-Tag': 'noindex',
     },
   },
+
+  // Docker MCP Campaign
   {
-    source: '/machines',
+    source: '/start',
     destination:
-      '/careers?utm_source=billboard&utm_medium=outdoor&utm_campaign=prague_ooh_2025&utm_content=machines',
+      '/docs/mcp?utm_source=billboard&utm_medium=outdoor&utm_campaign=docker_2025&utm_content=ooh',
     statusCode: 302,
     headers: {
       'X-Robots-Tag': 'noindex',


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Route `/start` to `/docs/mcp` with Docker 2025 UTM params; preserve `/machines` redirect to careers with machines UTM.
> 
> - **Redirects** (`src/configs/redirects.ts`):
>   - Add Docker MCP campaign redirect: `'/start' -> '/docs/mcp?...docker_2025...'` with 302 and `X-Robots-Tag: noindex`.
>   - Ensure `'/machines' -> '/careers?...utm_content=machines'` remains with same headers/status.
>   - Add in-file comment for Docker MCP campaign grouping.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 181303cf47ef0f054df7aa1f89d2f2388873910c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->