### PR TITLE
Improve: Preserve "Tab" search param when switching team

### DIFF
--- a/src/features/dashboard/sidebar/menu-teams.tsx
+++ b/src/features/dashboard/sidebar/menu-teams.tsx
@@ -10,13 +10,16 @@ import {
 } from '@/ui/primitives/dropdown-menu'
 import { Skeleton } from '@/ui/primitives/skeleton'
 import Link from 'next/link'
-import { usePathname } from 'next/navigation'
+import { usePathname, useSearchParams } from 'next/navigation'
 import { useCallback } from 'react'
 import useSWR from 'swr'
 import { useDashboard } from '../context'
 
+const PRESERVED_SEARCH_PARAMS = ['tab'] as const
+
 export default function DashboardSidebarMenuTeams() {
   const pathname = usePathname()
+  const searchParams = useSearchParams()
 
   const { user, team: selectedTeam } = useDashboard()
 
@@ -54,9 +57,20 @@ export default function DashboardSidebarMenuTeams() {
       const splitPath = pathname.split('/')
       splitPath[2] = team.slug
 
-      return splitPath.join('/')
+      const preservedParams = new URLSearchParams()
+      for (const param of PRESERVED_SEARCH_PARAMS) {
+        const value = searchParams.get(param)
+        if (value) {
+          preservedParams.set(param, value)
+        }
+      }
+
+      const queryString = preservedParams.toString()
+      return queryString
+        ? `${splitPath.join('/')}?${queryString}`
+        : splitPath.join('/')
     },
-    [pathname]
+    [pathname, searchParams]
   )
 
   if (isLoading) {


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Preserves the `tab` query param when generating team-switch URLs in the dashboard sidebar.
> 
> - **Dashboard Sidebar**:
>   - Updates `src/features/dashboard/sidebar/menu-teams.tsx` to preserve `tab` query param when switching teams.
>   - Uses `useSearchParams` and `PRESERVED_SEARCH_PARAMS` in `getNextUrl` to append preserved params; updates hook dependencies accordingly.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 67d05ce5bfc3d0c7dc1a805981db6f88279b4d16. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->