### PR TITLE
Improve: timestamp formatting in logs and adjust column width in dashboard

### DIFF
--- a/src/features/dashboard/build/logs-cells.tsx
+++ b/src/features/dashboard/build/logs-cells.tsx
@@ -3,6 +3,7 @@ import { BuildLogDTO } from '@/server/api/models/builds.models'
 import CopyButtonInline from '@/ui/copy-button-inline'
 import { Badge, BadgeProps } from '@/ui/primitives/badge'
 import { format } from 'date-fns'
+import { enUS } from 'date-fns/locale/en-US'
 
 interface LogLevelProps {
   level: BuildLogDTO['level']
@@ -49,7 +50,9 @@ export const Timestamp = ({
     >
       {formatDurationCompact(millisAfterStart, true)}{' '}
       <span className="group-hover:text-current transition-colors text-fg-tertiary">
-        {format(date, 'HH:mm:ss.SS')}
+        {format(date, 'hh:mm:ss.SS a', {
+          locale: enUS,
+        })}
       </span>
     </CopyButtonInline>
   )

--- a/src/features/dashboard/build/logs.tsx
+++ b/src/features/dashboard/build/logs.tsx
@@ -42,7 +42,7 @@ import { type LogLevelFilter } from './logs-filter-params'
 import { useBuildLogs } from './use-build-logs'
 import useLogFilters from './use-log-filters'
 
-const COLUMN_WIDTHS_PX = { timestamp: 164, level: 92 } as const
+const COLUMN_WIDTHS_PX = { timestamp: 192, level: 92 } as const
 const ROW_HEIGHT_PX = 26
 const VIRTUAL_OVERSCAN = 16
 const SCROLL_LOAD_THRESHOLD_PX = 200


### PR DESCRIPTION
- Updated the timestamp format in logs to display in 12-hour format with AM/PM using `date-fns` locale support.
- Increased the column width for the timestamp in the dashboard logs for better readability.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Switch logs to 12-hour timestamp with AM/PM and widen the timestamp column for readability.
> 
> - **Dashboard Logs**:
>   - **Timestamp formatting**: Switch to 12-hour format `hh:mm:ss.SS a` using `date-fns` with `enUS` locale in `src/features/dashboard/build/logs-cells.tsx`.
>   - **Layout**: Increase `timestamp` column width from `164px` to `192px` in `src/features/dashboard/build/logs.tsx`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 54fa7080f2804ff01be4385845e1c1927914e15f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->