### PR TITLE
fix: prevent secret update on webhook edits

### DIFF
--- a/src/features/dashboard/settings/webhooks/add-edit-dialog-steps.tsx
+++ b/src/features/dashboard/settings/webhooks/add-edit-dialog-steps.tsx
@@ -35,6 +35,7 @@ type WebhookAddEditDialogStepsProps = {
   allEventsSelected: boolean
   handleAllToggle: () => void
   handleEventToggle: (event: string) => void
+  mode: 'add' | 'edit'
 }
 
 export function WebhookAddEditDialogSteps({
@@ -45,6 +46,7 @@ export function WebhookAddEditDialogSteps({
   allEventsSelected,
   handleAllToggle,
   handleEventToggle,
+  mode,
 }: WebhookAddEditDialogStepsProps) {
   const shikiTheme = useShikiTheme()
   const [secretType, setSecretType] = useState<'pre-generated' | 'custom'>(
@@ -61,8 +63,11 @@ export function WebhookAddEditDialogSteps({
 
   const [copied, setCopied] = useState(false)
 
-  // sync secret with form state and validation
+  // sync secret with form state and validation - only in 'add' mode
+  // in 'edit' mode, we should never touch the signature secret
   useEffect(() => {
+    if (mode !== 'add') return
+
     if (secretType === 'pre-generated') {
       // set pre-generated secret and trigger validation to clear any errors
       form.setValue('signatureSecret', preGeneratedSecret, {
@@ -78,7 +83,7 @@ export function WebhookAddEditDialogSteps({
         shouldDirty: false,
       })
     }
-  }, [secretType, preGeneratedSecret, form])
+  }, [mode, secretType, preGeneratedSecret, form])
 
   const handleCopy = async () => {
     try {

--- a/src/features/dashboard/settings/webhooks/add-edit-dialog.tsx
+++ b/src/features/dashboard/settings/webhooks/add-edit-dialog.tsx
@@ -209,6 +209,7 @@ export default function WebhookAddEditDialog({
                 allEventsSelected={allEventsSelected}
                 handleAllToggle={handleAllToggle}
                 handleEventToggle={handleEventToggle}
+                mode={mode}
               />
             </div>
 

--- a/src/server/webhooks/webhooks-actions.ts
+++ b/src/server/webhooks/webhooks-actions.ts
@@ -44,7 +44,6 @@ export const upsertWebhookAction = authActionClient
             url,
             events,
             enabled,
-            ...(signatureSecret ? { signatureSecret } : {}),
           },
         })
       : await infra.POST('/events/webhooks', {


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Prevents accidental webhook secret changes during edits and confines secret handling to the create flow.
> 
> - UI: Adds `mode` to `WebhookAddEditDialogSteps`; in `edit` mode the effect no longer sets/clears `form.signatureSecret`, and the dialog passes `mode` down. Add flow retains 2-step creation with secret entry; edit flow remains single-step without secret changes.
> - Server: `upsertWebhookAction` removes `signatureSecret` from PATCH body and only includes it on POST; dedicated `updateWebhookSecretAction` remains for explicit secret rotations.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 939eed2a07c210cb7d3df00c43c928dc3d45c9f9. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->