### PR TITLE
New url redirect config

### DIFF
--- a/src/configs/redirects.ts
+++ b/src/configs/redirects.ts
@@ -48,7 +48,7 @@ export const MIDDLEWARE_REDIRECTS: MiddlewareRedirect[] = [
     },
   },
 
-  // Manus Billboard Campaign
+  // SF 2026 Billboard Campaign
   {
     source: '/computers',
     destination:


### PR DESCRIPTION
Add a temporary redirect for `/computers` to the Manus case study blog post.

completes ENG-3416

---
[Slack Thread](https://e2b-team.slack.com/archives/C087VT2J5HN/p1767613171276289?thread_ts=1767613171.276289&cid=C087VT2J5HN)

<a href="https://cursor.com/background-agent?bcId=bc-85c0a7c0-6f99-4eb9-b182-2a2cf0d5d2ad"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-85c0a7c0-6f99-4eb9-b182-2a2cf0d5d2ad"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds a new marketing redirect for the SF 2026 campaign.
> 
> - Introduces `'/computers' -> '/blog/how-manus-uses-e2b-to-provide-agents-with-virtual-computers'` in `src/configs/redirects.ts`
> - Uses 302 status and includes `X-Robots-Tag: noindex`
> - Appends `utm_*` parameters for `sf_ooh_2026`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0f3b792a116c8799241643843bca2178063566b4. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->