### PR TITLE
feat: add rebuild template option with dialog confirmation

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -67,7 +67,7 @@
         "date-fns": "^4.1.0",
         "date-fns-tz": "^3.2.0",
         "deepmerge": "^4.3.1",
-        "e2b": "^2.7.0",
+        "e2b": "^2.10.2",
         "echarts": "^6.0.0",
         "echarts-for-react": "^3.0.2",
         "fast-xml-parser": "^4.5.1",
@@ -157,11 +157,11 @@
     },
   },
   "overrides": {
-    "@nodelib/fs.scandir": "2.1.5",
-    "@nodelib/fs.stat": "2.0.5",
     "@shikijs/core": "2.3.2",
     "@shikijs/themes": "2.3.2",
     "shiki": "2.3.2",
+    "@nodelib/fs.stat": "2.0.5",
+    "@nodelib/fs.scandir": "2.1.5",
     "whatwg-url": "^13",
   },
   "packages": {
@@ -1617,7 +1617,7 @@
 
     "duplexify": ["duplexify@4.1.3", "", { "dependencies": { "end-of-stream": "^1.4.1", "inherits": "^2.0.3", "readable-stream": "^3.1.1", "stream-shift": "^1.0.2" } }, "sha512-M3BmBhwJRZsSx38lZyhE53Csddgzl5R7xGJNk7CVddZD6CcmwMCH8J+7AprIrQKH7TonKxaCjcv27Qmf+sQ+oA=="],
 
-    "e2b": ["e2b@2.7.0", "", { "dependencies": { "@bufbuild/protobuf": "^2.6.2", "@connectrpc/connect": "2.0.0-rc.3", "@connectrpc/connect-web": "2.0.0-rc.3", "chalk": "^5.3.0", "compare-versions": "^6.1.0", "dockerfile-ast": "^0.7.1", "glob": "^11.0.3", "openapi-fetch": "^0.14.1", "platform": "^1.3.6", "tar": "^7.4.3" } }, "sha512-pbCbkkdkkY+yIhhtdSE7lM/vhIROtHNI0hNpj8lBphDILNH2qmmjhxU7/wam8/xWRbiWbfuQaOsv100lD32nag=="],
+    "e2b": ["e2b@2.10.2", "", { "dependencies": { "@bufbuild/protobuf": "^2.6.2", "@connectrpc/connect": "2.0.0-rc.3", "@connectrpc/connect-web": "2.0.0-rc.3", "chalk": "^5.3.0", "compare-versions": "^6.1.0", "dockerfile-ast": "^0.7.1", "glob": "^11.1.0", "openapi-fetch": "^0.14.1", "platform": "^1.3.6", "tar": "^7.5.2" } }, "sha512-lKwo5NZ+2v0mAWrqKGAEgSMP/ZPftq7uTtSdYVisVZi4JK9iITtS8SEQLKmRcG+T59/46b//JPvLwluFo1Qi7A=="],
 
     "eastasianwidth": ["eastasianwidth@0.2.0", "", {}, "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA=="],
 

--- a/package.json
+++ b/package.json
@@ -104,7 +104,7 @@
     "date-fns": "^4.1.0",
     "date-fns-tz": "^3.2.0",
     "deepmerge": "^4.3.1",
-    "e2b": "^2.7.0",
+    "e2b": "^2.10.2",
     "echarts": "^6.0.0",
     "echarts-for-react": "^3.0.2",
     "fast-xml-parser": "^4.5.1",


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Introduces end-to-end template rebuild functionality and updates deps.
> 
> - Adds a Rebuild action in `templates` table UI (`table-cells.tsx`) with confirmation dialog, loading/disabled states, success/error toasts, and post-start redirect to `PROTECTED_URLS.TEMPLATE_BUILD(...)`
> - Implements `trpc` mutation `templates.rebuildTemplate` in `src/server/api/routers/templates.ts` calling `e2b` `Template.buildInBackground`, returning `{ templateID, buildID }` with structured error handling/logging
> - Bumps `e2b` to `^2.10.2` and refreshes lockfile (e.g., `glob`, `tar`), minor override reorder
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f375181735314b14410c4047e4b82675c022e959. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->