### PR TITLE
Add validation for user name max length (100 chars)

### DIFF
--- a/src/features/dashboard/account/name-settings.tsx
+++ b/src/features/dashboard/account/name-settings.tsx
@@ -32,7 +32,7 @@ import { z } from 'zod'
 import { useDashboard } from '../context'
 
 const formSchema = z.object({
-  name: z.string().min(1, 'Name cannot be empty').max(32, 'Max 32 characters'),
+  name: z.string().min(1, 'Name cannot be empty').max(100, 'Max 100 characters'),
 })
 
 type FormValues = z.infer<typeof formSchema>
@@ -108,7 +108,7 @@ export function NameSettings({ className }: NameSettingsProps) {
           </CardContent>
 
           <CardFooter className="bg-bg-1 justify-between">
-            <p className="text-fg-tertiary ">Max 32 characters.</p>
+            <p className="text-fg-tertiary ">Max 100 characters.</p>
             <Button
               loading={isPending}
               disabled={form.watch('name') === user?.user_metadata?.name}

--- a/src/server/user/user-actions.ts
+++ b/src/server/user/user-actions.ts
@@ -11,7 +11,7 @@ const UpdateUserSchema = z
   .object({
     email: z.email().optional(),
     password: z.string().min(8).optional(),
-    name: z.string().min(1).optional(),
+    name: z.string().min(1).max(100).optional(),
   })
   .refine(
     (data) => {


### PR DESCRIPTION
## Summary
- Add `.max(100)` validation to the `name` field in both frontend and backend
- Fixes security vulnerability where backend lacked length validation that frontend enforces
- Increased limit from 32 to 100 characters

## Changes
- `src/server/user/user-actions.ts`: Add `.max(100)` to `UpdateUserSchema`
- `src/features/dashboard/account/name-settings.tsx`: Update frontend validation and UI text

## Test plan
- [ ] Send API request with name > 100 characters - should return validation error
- [ ] Update name via UI with valid input (≤100 chars) - should succeed