### PR TITLE
Add missing 'general' tab to TAB_URL_MAP

### DIFF
--- a/src/app/dashboard/route.ts
+++ b/src/app/dashboard/route.ts
@@ -14,6 +14,7 @@ export const TAB_URL_MAP: Record<string, (teamId: string) => string> = {
   keys: (teamId) => PROTECTED_URLS.KEYS(teamId),
   settings: (teamId) => PROTECTED_URLS.GENERAL(teamId),
   team: (teamId) => PROTECTED_URLS.GENERAL(teamId),
+  general: (teamId) => PROTECTED_URLS.GENERAL(teamId),
   members: (teamId) => PROTECTED_URLS.MEMBERS(teamId),
   account: (_) => PROTECTED_URLS.ACCOUNT_SETTINGS,
   personal: (_) => PROTECTED_URLS.ACCOUNT_SETTINGS,


### PR DESCRIPTION
## Summary
- Adds the missing `general` tab mapping to `TAB_URL_MAP` in the dashboard route

## Test plan
- Navigate to dashboard with `?tab=general` parameter
- Verify it correctly redirects to the general settings page