### PR TITLE
Increase the default column size for template name

### DIFF
--- a/src/features/dashboard/templates/list/table-config.tsx
+++ b/src/features/dashboard/templates/list/table-config.tsx
@@ -71,7 +71,7 @@ export const useColumns = (deps: unknown[]) => {
         accessorKey: 'name',
         accessorFn: (row) => row.names.join(', '),
         header: 'Name',
-        size: 180,
+        size: 312,
         minSize: 140,
         maxSize: 400,
         enableResizing: true,

--- a/src/features/dashboard/templates/list/table.tsx
+++ b/src/features/dashboard/templates/list/table.tsx
@@ -78,7 +78,7 @@ export default function TemplatesTable() {
   const [columnFilters, setColumnFilters] = useState<ColumnFiltersState>([])
 
   const [columnSizing, setColumnSizing] = useLocalStorage<ColumnSizingState>(
-    'templates:columnSizing:v2',
+    'templates:columnSizing:v3',
     {},
     {
       deserializer: (value) => JSON.parse(value),


### PR DESCRIPTION
MInor edit. Increases the default template name column width to be twice the width of id. 

[Slack discussion](https://e2b-team.slack.com/archives/C086YA5T4JD/p1770554690150329)