### PR TITLE
Fix: Use team limits from db to show team limits in billing

### DIFF
--- a/src/app/dashboard/[teamIdOrSlug]/billing/plan/page.tsx
+++ b/src/app/dashboard/[teamIdOrSlug]/billing/plan/page.tsx
@@ -10,7 +10,7 @@ export default async function BillingPlanPage({
   const { teamIdOrSlug } = await params
 
   prefetch(trpc.billing.getItems.queryOptions({ teamIdOrSlug }))
-  prefetch(trpc.billing.getTeamConcurrentLimit.queryOptions({ teamIdOrSlug }))
+  prefetch(trpc.billing.getTeamLimits.queryOptions({ teamIdOrSlug }))
 
   return (
     <HydrateClient>

--- a/src/features/dashboard/billing/addons.tsx
+++ b/src/features/dashboard/billing/addons.tsx
@@ -19,7 +19,7 @@ import { useState } from 'react'
 import { useDashboard } from '../context'
 import { ConcurrentSandboxAddOnPurchaseDialog } from './concurrent-sandboxes-addon-dialog'
 import { ADDON_500_SANDBOXES_ID, TIER_PRO_ID } from './constants'
-import { useBillingItems, useTeamConcurrentLimit } from './hooks'
+import { useBillingItems, useTeamLimits } from './hooks'
 import { formatAddonQuantity } from './utils'
 
 interface AddonItemProps {
@@ -193,8 +193,8 @@ export default function Addons() {
   const trpc = useTRPC()
   const [isDialogOpen, setIsDialogOpen] = useState(false)
   const { tierData, addonData, isLoading } = useBillingItems()
-  const { concurrentSandboxes: currentConcurrentSandboxesLimit } =
-    useTeamConcurrentLimit()
+  const { teamLimits } = useTeamLimits()
+  const currentConcurrentSandboxesLimit = teamLimits?.concurrentInstances ?? 0
 
   const selectedTierId = tierData?.selected?.id
   const currentAddon = addonData?.current

--- a/src/features/dashboard/billing/concurrent-sandboxes-addon-dialog.tsx
+++ b/src/features/dashboard/billing/concurrent-sandboxes-addon-dialog.tsx
@@ -95,15 +95,14 @@ function DialogContent_Inner({
   const itemsQueryKey = trpc.billing.getItems.queryOptions({
     teamIdOrSlug,
   }).queryKey
-  const concurrentLimitQueryKey =
-    trpc.billing.getTeamConcurrentLimit.queryOptions({
-      teamIdOrSlug,
-    }).queryKey
+  const teamLimitsQueryKey = trpc.billing.getTeamLimits.queryOptions({
+    teamIdOrSlug,
+  }).queryKey
 
   const { confirmPayment, isConfirming } = usePaymentConfirmation({
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: itemsQueryKey })
-      queryClient.invalidateQueries({ queryKey: concurrentLimitQueryKey })
+      queryClient.invalidateQueries({ queryKey: teamLimitsQueryKey })
       onOpenChange(false)
     },
     onFallbackToPaymentElement: handleSwitchToPaymentElement,

--- a/src/features/dashboard/billing/hooks.ts
+++ b/src/features/dashboard/billing/hooks.ts
@@ -319,17 +319,17 @@ export function useInvoices() {
   }
 }
 
-export function useTeamConcurrentLimit() {
+export function useTeamLimits() {
   const { teamIdOrSlug } = useRouteParams<'/dashboard/[teamIdOrSlug]/billing'>()
   const trpc = useTRPC()
 
-  const { data, isLoading } = useQuery({
-    ...trpc.billing.getTeamConcurrentLimit.queryOptions({ teamIdOrSlug }),
+  const { data: teamLimits, isLoading } = useQuery({
+    ...trpc.billing.getTeamLimits.queryOptions({ teamIdOrSlug }),
     throwOnError: true,
   })
 
   return {
-    concurrentSandboxes: data?.concurrentSandboxes ?? 0,
+    teamLimits,
     isLoading,
   }
 }

--- a/src/server/api/routers/billing.ts
+++ b/src/server/api/routers/billing.ts
@@ -215,11 +215,8 @@ export const billingRouter = createTRPCRouter({
     return limits
   }),
 
-  getTeamConcurrentLimit: protectedTeamProcedure.query(async ({ ctx }) => {
-    const limits = await getTeamLimitsMemo(ctx.teamId, ctx.user.id)
-    return {
-      concurrentSandboxes: limits?.concurrentInstances ?? 0,
-    }
+  getTeamLimits: protectedTeamProcedure.query(async ({ ctx }) => {
+    return await getTeamLimitsMemo(ctx.teamId, ctx.user.id)
   }),
 
   setLimit: protectedTeamProcedure


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Touches billing UX and the data source for displayed limits; incorrect mapping/refresh could show wrong entitlements, but it’s mostly a query/typing swap with limited behavioral complexity.
> 
> **Overview**
> Billing plan pages now prefetch and consume a single `trpc.billing.getTeamLimits` query instead of the old concurrent-limit-only endpoint.
> 
> UI components (`SelectedPlan`, add-ons, and the purchase dialog) were updated to derive displayed limits (including concurrency and other plan stats) from the returned `TeamLimits` object, and to invalidate `getTeamLimits` after add-on purchases so the displayed values refresh.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 963ff0ca6055c6d88fae65843893e77039baa573. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->