### PR TITLE
Fix: Default Templates Timeouts

### DIFF
--- a/src/server/api/routers/templates.ts
+++ b/src/server/api/routers/templates.ts
@@ -244,7 +244,7 @@ async function getDefaultTemplatesCached() {
     const { data: latestAssignment, error: latestAssignmentError } =
       await supabaseAdmin
         .from('env_build_assignments')
-        .select('build_id, env_builds!inner(status)')
+        .select('build_id, env_id, env_builds!inner(status)')
         .eq('env_id', env.id)
         .eq('env_builds.status', 'uploaded')
         .order('created_at', { ascending: false, nullsFirst: false })
@@ -295,13 +295,13 @@ async function getDefaultTemplatesCached() {
       continue
     }
 
-    if (latestBuild.env_id !== env.id) {
+    if (latestAssignment.env_id !== env.id) {
       l.error(
         {
           key: 'trpc:templates:get_default_templates:env_build_assignment_mismatch',
           template_id: env.id,
           build_id: latestBuildId,
-          build_env_id: latestBuild.env_id,
+          assignment_env_id: latestAssignment.env_id,
         },
         'Build assignment env_id mismatch with template env_id'
       )


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes the query path used to choose the “latest” default template build and adds stricter validation, which could alter which builds are returned or cause templates to be skipped if data is inconsistent.
> 
> **Overview**
> Default template resolution now fetches the latest *uploaded* build via `env_build_assignments` (ordered by `created_at`/`id`) and then loads that specific `env_builds` row by `build_id`, rather than scanning `env_builds` by `env_id`.
> 
> The code adds guardrails and observability: logs and skips templates on missing/errored assignment lookups, checks assignment `env_id` matches, includes `build_id` in build fetch errors, and tightens required-field validation for `total_disk_size_mb` (>0) and non-empty `envd_version`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2f27119e08becf1f837b2b658f5c850cb6b3e327. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->