### PR TITLE
Chore: Add version to reset sandbox list column storage

### DIFF
--- a/src/features/dashboard/sandboxes/list/table.tsx
+++ b/src/features/dashboard/sandboxes/list/table.tsx
@@ -87,7 +87,7 @@ export default function SandboxesTable() {
   const trpc = useTRPC()
 
   const [columnSizing, setColumnSizing] = useLocalStorage<ColumnSizingState>(
-    'sandboxes:columnSizing',
+    'sandboxes:columnSizing:v2',
     {},
     {
       deserializer: (value) => JSON.parse(value),
@@ -197,8 +197,8 @@ export default function SandboxesTable() {
                     sorting={tableSorting.find((s) => s.id === header.id)?.desc}
                     align={
                       header.id === 'cpuUsage' ||
-                      header.id === 'ramUsage' ||
-                      header.id === 'diskUsage'
+                        header.id === 'ramUsage' ||
+                        header.id === 'diskUsage'
                         ? 'right'
                         : 'left'
                     }
@@ -207,9 +207,9 @@ export default function SandboxesTable() {
                       {header.isPlaceholder
                         ? null
                         : flexRender(
-                            header.column.columnDef.header,
-                            header.getContext()
-                          )}
+                          header.column.columnDef.header,
+                          header.getContext()
+                        )}
                     </span>
                   </DataTableHead>
                 ))}


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Changes are limited to client-side localStorage persistence for table column sizing; impact is a one-time reset of user-saved widths.
> 
> **Overview**
> Updates the sandbox list table to persist column sizing under a new localStorage key (`sandboxes:columnSizing:v2`), effectively resetting previously saved column widths.
> 
> Includes minor header-rendering formatting adjustments with no functional behavior change beyond the storage key bump.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e18efdcc42db076422555abb2f1fa555a4170dd5. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->