### PR TITLE
Fix: Replace z.httpUrl() with z.url() for localhost compatibility

### DIFF
--- a/src/__test__/unit/url-schema.test.ts
+++ b/src/__test__/unit/url-schema.test.ts
@@ -1,0 +1,75 @@
+import { httpUrlSchema } from '@/lib/schemas/url'
+import { describe, expect, it } from 'vitest'
+
+describe('httpUrlSchema', () => {
+  describe('accepts valid http/https URLs', () => {
+    it('accepts https production URLs', () => {
+      expect(httpUrlSchema.safeParse('https://e2b.dev/dashboard').success).toBe(
+        true
+      )
+    })
+
+    it('accepts https URLs with paths and query params', () => {
+      expect(
+        httpUrlSchema.safeParse('https://e2b.dev/dashboard?tab=settings')
+          .success
+      ).toBe(true)
+    })
+
+    it('accepts http localhost URLs', () => {
+      expect(
+        httpUrlSchema.safeParse('http://localhost:3000/dashboard').success
+      ).toBe(true)
+    })
+
+    it('accepts http localhost without port', () => {
+      expect(httpUrlSchema.safeParse('http://localhost').success).toBe(true)
+    })
+
+    it('accepts http 127.0.0.1 URLs', () => {
+      expect(
+        httpUrlSchema.safeParse('http://127.0.0.1:3000').success
+      ).toBe(true)
+    })
+
+    it('accepts https URLs with subdomains', () => {
+      expect(
+        httpUrlSchema.safeParse('https://app.e2b.dev/dashboard').success
+      ).toBe(true)
+    })
+  })
+
+  describe('rejects non-http(s) schemes', () => {
+    it('rejects mailto URLs', () => {
+      expect(
+        httpUrlSchema.safeParse('mailto:user@example.com').success
+      ).toBe(false)
+    })
+
+    it('rejects ftp URLs', () => {
+      expect(httpUrlSchema.safeParse('ftp://files.example.com').success).toBe(
+        false
+      )
+    })
+
+    it('rejects file URLs', () => {
+      expect(httpUrlSchema.safeParse('file:///etc/passwd').success).toBe(false)
+    })
+
+    it('rejects javascript URLs', () => {
+      expect(httpUrlSchema.safeParse('javascript:alert(1)').success).toBe(
+        false
+      )
+    })
+  })
+
+  describe('rejects invalid inputs', () => {
+    it('rejects plain strings', () => {
+      expect(httpUrlSchema.safeParse('not-a-url').success).toBe(false)
+    })
+
+    it('rejects empty strings', () => {
+      expect(httpUrlSchema.safeParse('').success).toBe(false)
+    })
+  })
+})

--- a/src/app/api/auth/confirm/route.ts
+++ b/src/app/api/auth/confirm/route.ts
@@ -1,6 +1,7 @@
 import { AUTH_URLS } from '@/configs/urls'
 import { l } from '@/lib/clients/logger/logger'
 import { encodedRedirect, isExternalOrigin } from '@/lib/utils/auth'
+import { httpUrlSchema } from '@/lib/schemas/url'
 import { OtpTypeSchema } from '@/server/api/models/auth.models'
 import { redirect } from 'next/navigation'
 import { NextRequest } from 'next/server'
@@ -9,7 +10,7 @@ import { z } from 'zod'
 const confirmSchema = z.object({
   token_hash: z.string().min(1),
   type: OtpTypeSchema,
-  next: z.url({ protocol: /^https?$/ }),
+  next: httpUrlSchema,
 })
 
 /**

--- a/src/app/api/auth/confirm/route.ts
+++ b/src/app/api/auth/confirm/route.ts
@@ -9,7 +9,7 @@ import { z } from 'zod'
 const confirmSchema = z.object({
   token_hash: z.string().min(1),
   type: OtpTypeSchema,
-  next: z.httpUrl(),
+  next: z.url({ protocol: /^https?$/ }),
 })
 
 /**

--- a/src/lib/schemas/url.ts
+++ b/src/lib/schemas/url.ts
@@ -1,5 +1,11 @@
 import { z } from 'zod'
 
+/**
+ * Validates that a string is a well-formed HTTP or HTTPS URL.
+ * Unlike z.httpUrl(), this also accepts localhost URLs for local development.
+ */
+export const httpUrlSchema = z.url({ protocol: /^https?$/ })
+
 export const relativeUrlSchema = z
   .string()
   .trim()

--- a/src/server/api/models/auth.models.ts
+++ b/src/server/api/models/auth.models.ts
@@ -14,7 +14,7 @@ export type OtpType = z.infer<typeof OtpTypeSchema>
 export const ConfirmEmailInputSchema = z.object({
   token_hash: z.string().min(1),
   type: OtpTypeSchema,
-  next: z.httpUrl(),
+  next: z.url({ protocol: /^https?$/ }),
 })
 
 export type ConfirmEmailInput = z.infer<typeof ConfirmEmailInputSchema>

--- a/src/server/api/models/auth.models.ts
+++ b/src/server/api/models/auth.models.ts
@@ -1,4 +1,5 @@
 import z from 'zod'
+import { httpUrlSchema } from '@/lib/schemas/url'
 
 export const OtpTypeSchema = z.enum([
   'signup',
@@ -14,7 +15,7 @@ export type OtpType = z.infer<typeof OtpTypeSchema>
 export const ConfirmEmailInputSchema = z.object({
   token_hash: z.string().min(1),
   type: OtpTypeSchema,
-  next: z.url({ protocol: /^https?$/ }),
+  next: httpUrlSchema,
 })
 
 export type ConfirmEmailInput = z.infer<typeof ConfirmEmailInputSchema>


### PR DESCRIPTION
## Summary

- Replaces `z.httpUrl()` with `z.url()` in the auth confirm route and shared `ConfirmEmailInputSchema`
- `z.httpUrl()` rejects `localhost` URLs, causing Zod validation errors during local development email verification
- `z.url()` validates URL structure while accepting `localhost` — production URLs (`https://e2b.dev/...`) continue to pass

## Why this is safe

The Zod schema is only responsible for validating that `next` is a syntactically valid URL. The actual redirect security is handled downstream:

- `isExternalOrigin()` checks reject or reroute requests with a different origin
- `buildRedirectUrl()` reconstructs the redirect using the dashboard's own origin, only preserving pathname and search params

So switching from `z.httpUrl()` to `z.url()` does not weaken security.

## Validation

| URL | `z.httpUrl()` (before) | `z.url()` (after) |
|---|---|---|
| `http://localhost:3000/dashboard` | FAIL | PASS |
| `https://e2b.dev/dashboard` | PASS | PASS |
| `not-a-url` | FAIL | FAIL |
| `(empty)` | FAIL | FAIL |

## Files changed

- `src/server/api/models/auth.models.ts` — `ConfirmEmailInputSchema.next`
- `src/app/api/auth/confirm/route.ts` — `confirmSchema.next`

Closes #241