### PR TITLE
Fix: Add team authorization to deleteWebhookAction and updateWebhookSecretAction

### DIFF
--- a/src/features/dashboard/settings/webhooks/delete-dialog.tsx
+++ b/src/features/dashboard/settings/webhooks/delete-dialog.tsx
@@ -81,7 +81,7 @@ export default function WebhookDeleteDialog({
       }}
       onConfirm={() => {
         executeDeleteWebhook({
-          teamId: webhook.teamId,
+          teamIdOrSlug: webhook.teamId,
           webhookId: webhook.id,
         })
       }}

--- a/src/features/dashboard/settings/webhooks/edit-secret-dialog.tsx
+++ b/src/features/dashboard/settings/webhooks/edit-secret-dialog.tsx
@@ -58,7 +58,7 @@ export default function WebhookEditSecretDialog({
       formProps: {
         mode: 'onChange',
         defaultValues: {
-          teamId: webhook.teamId,
+          teamIdOrSlug: webhook.teamId,
           webhookId: webhook.id,
           signatureSecret: '',
         },
@@ -135,7 +135,7 @@ export default function WebhookEditSecretDialog({
         <Form {...form}>
           <form onSubmit={handleSubmitWithAction} className="min-w-0">
             {/* Hidden fields */}
-            <input type="hidden" {...form.register('teamId')} />
+            <input type="hidden" {...form.register('teamIdOrSlug')} />
             <input type="hidden" {...form.register('webhookId')} />
 
             <div className="flex flex-col gap-4 pb-6 min-w-0">

--- a/src/server/webhooks/schema.ts
+++ b/src/server/webhooks/schema.ts
@@ -33,12 +33,12 @@ export const UpsertWebhookSchema = z
   )
 
 export const DeleteWebhookSchema = z.object({
-  teamId: z.uuid(),
+  teamIdOrSlug: TeamIdOrSlugSchema,
   webhookId: z.uuid(),
 })
 
 export const UpdateWebhookSecretSchema = z.object({
-  teamId: z.uuid(),
+  teamIdOrSlug: TeamIdOrSlugSchema,
   webhookId: z.uuid(),
   signatureSecret: WebhookSecretSchema,
 })

--- a/src/server/webhooks/webhooks-actions.ts
+++ b/src/server/webhooks/webhooks-actions.ts
@@ -99,9 +99,10 @@ export const upsertWebhookAction = authActionClient
 export const deleteWebhookAction = authActionClient
   .schema(DeleteWebhookSchema)
   .metadata({ actionName: 'deleteWebhook' })
+  .use(withTeamIdResolution)
   .action(async ({ parsedInput, ctx }) => {
-    const { teamId, webhookId } = parsedInput
-    const { session } = ctx
+    const { webhookId } = parsedInput
+    const { session, teamId } = ctx
 
     const accessToken = session.access_token
 
@@ -148,9 +149,10 @@ export const deleteWebhookAction = authActionClient
 export const updateWebhookSecretAction = authActionClient
   .schema(UpdateWebhookSecretSchema)
   .metadata({ actionName: 'updateWebhookSecret' })
+  .use(withTeamIdResolution)
   .action(async ({ parsedInput, ctx }) => {
-    const { teamId, webhookId, signatureSecret } = parsedInput
-    const { session } = ctx
+    const { webhookId, signatureSecret } = parsedInput
+    const { session, teamId } = ctx
 
     const accessToken = session.access_token
 


### PR DESCRIPTION
## Summary

- `deleteWebhookAction` and `updateWebhookSecretAction` accepted a raw `teamId` from client input without verifying the user belongs to that team
- `upsertWebhookAction` already uses `.use(withTeamIdResolution)` for this — the other two were missing it
- This adds the same middleware to both actions for consistent team authorization

## Changes

| File | What changed |
|---|---|
| `src/server/webhooks/schema.ts` | `DeleteWebhookSchema` and `UpdateWebhookSecretSchema` now use `teamIdOrSlug: TeamIdOrSlugSchema` instead of `teamId: z.uuid()` |
| `src/server/webhooks/webhooks-actions.ts` | Added `.use(withTeamIdResolution)` to both actions; `teamId` now comes from `ctx` (middleware-validated) instead of `parsedInput` |
| `src/features/dashboard/settings/webhooks/delete-dialog.tsx` | Updated caller to pass `teamIdOrSlug` |
| `src/features/dashboard/settings/webhooks/edit-secret-dialog.tsx` | Updated caller and hidden form field to use `teamIdOrSlug` |

## Why this matters

The Next.js middleware explicitly excludes `/api/*` routes — server actions must handle their own authorization. `authActionClient` only verifies the user is logged in, not team membership. Without `withTeamIdResolution`, an authenticated user could supply another team's ID to delete their webhooks or overwrite their signing secrets.

Closes #250