### PR TITLE
Fix: Encode message param in email callback redirect

### DIFF
--- a/src/app/api/auth/email-callback/route.tsx
+++ b/src/app/api/auth/email-callback/route.tsx
@@ -14,7 +14,7 @@ export async function GET(request: Request) {
   if (!code && message) {
     // E-Mail updates can be validated on both e-mails. This case is for the first validation link press.
     // `message` should inform the user that he has to validate on the other e-mail address as well for successful update.
-    redirect(`${next}?message=${message}&type=update_email`)
+    redirect(`${next}?message=${encodeURIComponent(message)}&type=update_email`)
   }
 
   if (!code && !message) {
@@ -24,7 +24,7 @@ export async function GET(request: Request) {
   }
 
   if (message) {
-    redirect(`${next}?message=${message}&type=update_email`)
+    redirect(`${next}?message=${encodeURIComponent(message)}&type=update_email`)
   }
 
   const supabase = await createClient()


### PR DESCRIPTION
## Summary

The `message` query parameter in `/api/auth/email-callback` was interpolated into the redirect URL without encoding, enabling query parameter injection.

## Change

**`src/app/api/auth/email-callback/route.tsx`** — lines 17 and 27:

```diff
- redirect(`${next}?message=${message}&type=update_email`)
+ redirect(`${next}?message=${encodeURIComponent(message)}&type=update_email`)
```

This is consistent with `encodedRedirect()` used elsewhere in the same file (line 21), which already encodes values properly.

## Example

Before: `/api/auth/email-callback?message=foo%26error%3Dinjected`
→ redirects to `/dashboard/account?message=foo&error=injected&type=update_email`

After: same input
→ redirects to `/dashboard/account?message=foo%26error%3Dinjected&type=update_email`

Closes #255