### PR TITLE
Fix: Implement slug validation in TeamIdOrSlugSchema (resolves FIXME)

### DIFF
--- a/src/__test__/unit/team-schema.test.ts
+++ b/src/__test__/unit/team-schema.test.ts
@@ -1,0 +1,75 @@
+import { TeamIdOrSlugSchema } from '@/lib/schemas/team'
+import { describe, expect, it } from 'vitest'
+
+describe('TeamIdOrSlugSchema', () => {
+  describe('accepts valid UUIDs', () => {
+    it('accepts a standard UUID', () => {
+      expect(
+        TeamIdOrSlugSchema.safeParse('550e8400-e29b-41d4-a716-446655440000')
+          .success
+      ).toBe(true)
+    })
+  })
+
+  describe('accepts valid slugs', () => {
+    it('accepts lowercase words separated by hyphens', () => {
+      expect(TeamIdOrSlugSchema.safeParse('acme-inc').success).toBe(true)
+    })
+
+    it('accepts slugs with random suffix from DB', () => {
+      expect(TeamIdOrSlugSchema.safeParse('acme-inc-a3f2').success).toBe(true)
+    })
+
+    it('accepts single word slugs', () => {
+      expect(TeamIdOrSlugSchema.safeParse('singleword').success).toBe(true)
+    })
+
+    it('accepts numeric slugs', () => {
+      expect(TeamIdOrSlugSchema.safeParse('123').success).toBe(true)
+    })
+
+    it('accepts mixed alphanumeric slugs', () => {
+      expect(TeamIdOrSlugSchema.safeParse('team-123').success).toBe(true)
+    })
+  })
+
+  describe('rejects invalid inputs', () => {
+    it('rejects uppercase characters', () => {
+      expect(TeamIdOrSlugSchema.safeParse('UPPERCASE').success).toBe(false)
+    })
+
+    it('rejects strings with spaces', () => {
+      expect(TeamIdOrSlugSchema.safeParse('has spaces').success).toBe(false)
+    })
+
+    it('rejects strings with underscores', () => {
+      expect(TeamIdOrSlugSchema.safeParse('has_underscore').success).toBe(false)
+    })
+
+    it('rejects leading hyphens', () => {
+      expect(TeamIdOrSlugSchema.safeParse('-leading').success).toBe(false)
+    })
+
+    it('rejects trailing hyphens', () => {
+      expect(TeamIdOrSlugSchema.safeParse('trailing-').success).toBe(false)
+    })
+
+    it('rejects double hyphens', () => {
+      expect(TeamIdOrSlugSchema.safeParse('double--hyphen').success).toBe(false)
+    })
+
+    it('rejects empty strings', () => {
+      expect(TeamIdOrSlugSchema.safeParse('').success).toBe(false)
+    })
+
+    it('rejects special characters', () => {
+      expect(TeamIdOrSlugSchema.safeParse('special!chars').success).toBe(false)
+    })
+
+    it('rejects path traversal attempts', () => {
+      expect(TeamIdOrSlugSchema.safeParse('../../etc/passwd').success).toBe(
+        false
+      )
+    })
+  })
+})

--- a/src/lib/schemas/team.ts
+++ b/src/lib/schemas/team.ts
@@ -2,10 +2,10 @@ import { z } from 'zod'
 
 export const TeamIdOrSlugSchema = z.union([
   z.uuid(),
-  z.string(),
-  // FIXME: Add correct team regex as in db slug generation
-  // .regex(
-  //   /^[a-z0-9]+(-[a-z0-9]+)*$/i,
-  //   'Must be a valid slug (words separated by hyphens)'
-  // ),
+  z
+    .string()
+    .regex(
+      /^[a-z0-9]+(-[a-z0-9]+)*$/,
+      'Must be a valid team slug (lowercase alphanumeric, separated by hyphens)'
+    ),
 ])


### PR DESCRIPTION
## Summary

Resolves the `FIXME` in `TeamIdOrSlugSchema` by adding a regex that matches the DB's `generate_team_slug()` output from the migration in `migrations/20250205180205.sql`.

## Change

**`src/lib/schemas/team.ts`:**

```diff
 export const TeamIdOrSlugSchema = z.union([
   z.uuid(),
-  z.string(),
-  // FIXME: Add correct team regex as in db slug generation
-  // .regex(
-  //   /^[a-z0-9]+(-[a-z0-9]+)*$/i,
-  //   'Must be a valid slug (words separated by hyphens)'
-  // ),
+  z
+    .string()
+    .regex(
+      /^[a-z0-9]+(-[a-z0-9]+)*$/,
+      'Must be a valid team slug (lowercase alphanumeric, separated by hyphens)'
+    ),
 ])
```

Note: removed the `i` flag from the original commented regex since `generate_team_slug()` produces lowercase-only output via `LOWER()`.

## Tests

Added 15 unit tests in `src/__test__/unit/team-schema.test.ts`:

| Input | Expected |
|---|---|
| Valid UUID | Pass |
| `acme-inc` | Pass |
| `acme-inc-a3f2` (DB suffix) | Pass |
| `singleword` | Pass |
| `team-123` | Pass |
| `UPPERCASE` | Fail |
| `has spaces` | Fail |
| `has_underscore` | Fail |
| `-leading` | Fail |
| `trailing-` | Fail |
| `double--hyphen` | Fail |
| `../../etc/passwd` | Fail |

All unit tests pass (`bun run test:unit` — 95/95).

Closes #257