### PR TITLE
Add referral source question for new signups

### DIFF
--- a/src/app/api/referral-source/route.ts
+++ b/src/app/api/referral-source/route.ts
@@ -1,0 +1,38 @@
+import { NextRequest, NextResponse } from 'next/server'
+
+export async function POST(req: NextRequest) {
+  const webhookUrl = process.env.SLACK_USER_SIGNUP_WEBHOOK_URL
+  if (!webhookUrl) {
+    return NextResponse.json(
+      { error: 'Slack webhook not configured' },
+      { status: 500 }
+    )
+  }
+
+  const { email, source } = await req.json()
+
+  if (!email) {
+    return NextResponse.json({ error: 'Missing email' }, { status: 400 })
+  }
+
+  const message = `:mag: *Referral Source*\n*User:* ${email}\n*Source:* ${source || 'Skipped'}`
+
+  try {
+    await fetch(webhookUrl, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        channel: 'user-signups',
+        text: message,
+      }),
+    })
+
+    return NextResponse.json({ ok: true })
+  } catch (error) {
+    console.error('Failed to send Slack message:', error)
+    return NextResponse.json(
+      { error: 'Failed to send Slack message' },
+      { status: 500 }
+    )
+  }
+}

--- a/src/app/api/referral-source/route.ts
+++ b/src/app/api/referral-source/route.ts
@@ -1,4 +1,4 @@
-import { NextRequest, NextResponse } from 'next/server'
+import { type NextRequest, NextResponse } from 'next/server'
 
 export async function POST(req: NextRequest) {
   const webhookUrl = process.env.SLACK_USER_SIGNUP_WEBHOOK_URL

--- a/src/features/dashboard/context.tsx
+++ b/src/features/dashboard/context.tsx
@@ -1,7 +1,13 @@
 'use client'
 
 import type { User } from '@supabase/supabase-js'
-import { createContext, type ReactNode, useContext, useEffect, useState } from 'react'
+import {
+  createContext,
+  type ReactNode,
+  useContext,
+  useEffect,
+  useState,
+} from 'react'
 import type { ClientTeam } from '@/types/dashboard.types'
 import { ReferralSourceDialog } from './referral-source-dialog'
 

--- a/src/features/dashboard/context.tsx
+++ b/src/features/dashboard/context.tsx
@@ -1,8 +1,9 @@
 'use client'
 
 import type { User } from '@supabase/supabase-js'
-import { createContext, type ReactNode, useContext, useState } from 'react'
+import { createContext, type ReactNode, useContext, useEffect, useState } from 'react'
 import type { ClientTeam } from '@/types/dashboard.types'
+import { ReferralSourceDialog } from './referral-source-dialog'
 
 interface DashboardContextValue {
   team: ClientTeam
@@ -29,6 +30,14 @@ export function DashboardContextProvider({
 }: DashboardContextProviderProps) {
   const [team, setTeam] = useState(initialTeam)
   const [user, setUser] = useState(initialUser)
+  const [showReferralDialog, setShowReferralDialog] = useState(false)
+
+  useEffect(() => {
+    const referralAsked = user?.user_metadata?.referral_asked
+    if (user && !referralAsked) {
+      setShowReferralDialog(true)
+    }
+  }, [user])
 
   const value = {
     team,
@@ -41,6 +50,11 @@ export function DashboardContextProvider({
   return (
     <DashboardContext.Provider value={value}>
       {children}
+      <ReferralSourceDialog
+        userEmail={user.email ?? ''}
+        open={showReferralDialog}
+        onOpenChange={setShowReferralDialog}
+      />
     </DashboardContext.Provider>
   )
 }

--- a/src/features/dashboard/referral-source-dialog.tsx
+++ b/src/features/dashboard/referral-source-dialog.tsx
@@ -1,6 +1,7 @@
 'use client'
 
 import { useState } from 'react'
+import { supabase } from '@/lib/clients/supabase/client'
 import { Button } from '@/ui/primitives/button'
 import {
   Dialog,
@@ -11,7 +12,6 @@ import {
   DialogTitle,
 } from '@/ui/primitives/dialog'
 import { Input } from '@/ui/primitives/input'
-import { supabase } from '@/lib/clients/supabase/client'
 
 interface ReferralSourceDialogProps {
   userEmail: string

--- a/src/features/dashboard/referral-source-dialog.tsx
+++ b/src/features/dashboard/referral-source-dialog.tsx
@@ -1,0 +1,108 @@
+'use client'
+
+import { useState } from 'react'
+import { Button } from '@/ui/primitives/button'
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/ui/primitives/dialog'
+import { Input } from '@/ui/primitives/input'
+import { supabase } from '@/lib/clients/supabase/client'
+
+interface ReferralSourceDialogProps {
+  userEmail: string
+  open: boolean
+  onOpenChange: (open: boolean) => void
+}
+
+export function ReferralSourceDialog({
+  userEmail,
+  open,
+  onOpenChange,
+}: ReferralSourceDialogProps) {
+  const [source, setSource] = useState('')
+  const [isSubmitting, setIsSubmitting] = useState(false)
+
+  async function updateUserMetadata(referralSource: string | null) {
+    await supabase.auth.updateUser({
+      data: {
+        referral_source: referralSource,
+        referral_asked: true,
+      },
+    })
+  }
+
+  async function notifySlack(referralSource: string | null) {
+    try {
+      await fetch('/api/referral-source', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          email: userEmail,
+          source: referralSource,
+        }),
+      })
+    } catch {
+      // Non-critical, don't block the user
+    }
+  }
+
+  async function handleSubmit() {
+    if (!source.trim()) return
+    setIsSubmitting(true)
+
+    await Promise.all([
+      updateUserMetadata(source.trim()),
+      notifySlack(source.trim()),
+    ])
+
+    onOpenChange(false)
+  }
+
+  async function handleSkip() {
+    await updateUserMetadata(null)
+    onOpenChange(false)
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={handleSkip}>
+      <DialogContent hideClose>
+        <DialogHeader>
+          <DialogTitle>Welcome!</DialogTitle>
+          <DialogDescription>
+            How did you first hear about E2B?
+          </DialogDescription>
+        </DialogHeader>
+
+        <Input
+          type="text"
+          value={source}
+          onChange={(e) => setSource(e.target.value)}
+          placeholder="e.g. X demo video, E2B hackathon, my colleague..."
+          autoFocus
+          onKeyDown={(e) => {
+            if (e.key === 'Enter' && source.trim()) handleSubmit()
+          }}
+        />
+
+        <DialogFooter>
+          <Button variant="ghost" onClick={handleSkip}>
+            Skip
+          </Button>
+          <Button
+            variant="accent"
+            onClick={handleSubmit}
+            disabled={!source.trim()}
+            loading={isSubmitting}
+          >
+            Submit
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  )
+}


### PR DESCRIPTION
## Summary
- Shows a "How did you first hear about E2B?" dialog when a new user first lands on the dashboard
- Users can type a freeform answer and submit, or skip
- Response is saved to Supabase `user_metadata` (`referral_source` + `referral_asked` flag)
- Submitting also posts the answer to Slack `#user-signups` via a new API route
- Dialog never appears again once dismissed (submit or skip)

## Files changed
- `src/features/dashboard/referral-source-dialog.tsx` — new dialog component using existing `Dialog`, `Input`, `Button` primitives
- `src/features/dashboard/context.tsx` — checks `user_metadata.referral_asked` and renders dialog
- `src/app/api/referral-source/route.ts` — server-side API route to forward answer to Slack

## Setup needed
- `SLACK_USER_SIGNUP_WEBHOOK_URL` env variable must be available to the Next.js app (not just Supabase edge functions)

## Test plan
- [ ] Sign up with a new account → dialog should appear on dashboard
- [ ] Type an answer and click Submit → check Supabase user_metadata and Slack
- [ ] Click Skip → dialog closes, `referral_asked: true` is set, no Slack message
- [ ] Refresh dashboard → dialog should NOT reappear
- [ ] Existing users → dialog should NOT appear

🤖 Generated with [Claude Code](https://claude.com/claude-code)