### PR TITLE
Capture signup IP and user agent in app_metadata

### DIFF
--- a/src/core/server/actions/auth-actions.ts
+++ b/src/core/server/actions/auth-actions.ts
@@ -170,7 +170,8 @@ export const signUpAction = actionClient
       }
 
       const userAgent = headerStore.get('user-agent') ?? undefined
-      const ip = headerStore.get('x-forwarded-for') ?? undefined
+      const ip =
+        headerStore.get('x-forwarded-for')?.split(',')[0]?.trim() ?? undefined
 
       // basic security check, that password does not equal e-mail
       if (password && email && password.toLowerCase() === email.toLowerCase()) {

--- a/src/core/server/actions/auth-actions.ts
+++ b/src/core/server/actions/auth-actions.ts
@@ -218,9 +218,11 @@ export const signUpAction = actionClient
         }
       }
 
-      const isNewUser =
-        signUpData.user && signUpData.user.identities?.length !== 0
-      if (isNewUser && (ip || userAgent)) {
+      if (
+        signUpData.user &&
+        signUpData.user.identities?.length !== 0 &&
+        (ip || userAgent)
+      ) {
         try {
           await supabaseAdmin.auth.admin.updateUserById(signUpData.user.id, {
             app_metadata: {

--- a/src/core/server/actions/auth-actions.ts
+++ b/src/core/server/actions/auth-actions.ts
@@ -9,6 +9,7 @@ import { AUTH_URLS, PROTECTED_URLS } from '@/configs/urls'
 import { USER_MESSAGES } from '@/configs/user-messages'
 import { actionClient } from '@/core/server/actions/client'
 import { returnServerError } from '@/core/server/actions/utils'
+import { supabaseAdmin } from '@/core/shared/clients/supabase/admin'
 import {
   forgotPasswordSchema,
   signInSchema,
@@ -168,6 +169,9 @@ export const signUpAction = actionClient
         throw new Error('Origin not found')
       }
 
+      const userAgent = headerStore.get('user-agent') ?? undefined
+      const ip = headerStore.get('x-forwarded-for') ?? undefined
+
       // basic security check, that password does not equal e-mail
       if (password && email && password.toLowerCase() === email.toLowerCase()) {
         return returnValidationErrors(signUpSchema, {
@@ -191,15 +195,13 @@ export const signUpAction = actionClient
         }
       }
 
-      const { error } = await supabase.auth.signUp({
+      const { data: signUpData, error } = await supabase.auth.signUp({
         email,
         password,
         options: {
           emailRedirectTo: `${origin}${AUTH_URLS.CALLBACK}${returnTo ? `?returnTo=${encodeURIComponent(returnTo)}` : ''}`,
           data: validationResult?.data
-            ? {
-                email_validation: validationResult?.data,
-              }
+            ? { email_validation: validationResult.data }
             : undefined,
         },
       })
@@ -213,6 +215,15 @@ export const signUpAction = actionClient
           default:
             throw error
         }
+      }
+
+      if (signUpData.user && (ip || userAgent)) {
+        await supabaseAdmin.auth.admin.updateUserById(signUpData.user.id, {
+          app_metadata: {
+            signup_ip: ip,
+            signup_user_agent: userAgent,
+          },
+        })
       }
     }
   )

--- a/src/core/server/actions/auth-actions.ts
+++ b/src/core/server/actions/auth-actions.ts
@@ -9,7 +9,6 @@ import { AUTH_URLS, PROTECTED_URLS } from '@/configs/urls'
 import { USER_MESSAGES } from '@/configs/user-messages'
 import { actionClient } from '@/core/server/actions/client'
 import { returnServerError } from '@/core/server/actions/utils'
-import { supabaseAdmin } from '@/core/shared/clients/supabase/admin'
 import {
   forgotPasswordSchema,
   signInSchema,
@@ -20,6 +19,7 @@ import {
   validateEmail,
 } from '@/core/server/functions/auth/validate-email'
 import { l } from '@/core/shared/clients/logger/logger'
+import { supabaseAdmin } from '@/core/shared/clients/supabase/admin'
 import { createClient } from '@/core/shared/clients/supabase/server'
 import { relativeUrlSchema } from '@/core/shared/schemas/url'
 import { verifyTurnstileToken } from '@/lib/captcha/turnstile'

--- a/src/core/server/actions/auth-actions.ts
+++ b/src/core/server/actions/auth-actions.ts
@@ -218,13 +218,22 @@ export const signUpAction = actionClient
         }
       }
 
-      if (signUpData.user && (ip || userAgent)) {
-        await supabaseAdmin.auth.admin.updateUserById(signUpData.user.id, {
-          app_metadata: {
-            signup_ip: ip,
-            signup_user_agent: userAgent,
-          },
-        })
+      const isNewUser =
+        signUpData.user && signUpData.user.identities?.length !== 0
+      if (isNewUser && (ip || userAgent)) {
+        try {
+          await supabaseAdmin.auth.admin.updateUserById(signUpData.user.id, {
+            app_metadata: {
+              signup_ip: ip,
+              signup_user_agent: userAgent,
+            },
+          })
+        } catch (metaError) {
+          l.error(
+            { key: 'sign_up_action:metadata_update_error', error: metaError },
+            'sign_up_action: failed to write signup metadata to app_metadata'
+          )
+        }
       }
     }
   )


### PR DESCRIPTION
## Problem

No caller context is captured at sign-up time, making it impossible to
audit new registrations or flag suspicious sign-ups (bot traffic,
credential stuffing) after the fact.

An earlier iteration stored these values in raw_user_meta_data, which is
writable by the authenticated user — allowing them to erase or falsify
their own audit trail. Two additional issues existed in the admin write:
Supabase returns a fake user object (with the real user's ID) on
duplicate-email signup when email confirmation is enabled, which would
have caused the metadata update to overwrite an existing user's record.
And an uncaught error from updateUserById would surface as a signup
failure to the user even though their account had already been created.

## Solution

Extract user-agent and the first entry of x-forwarded-for from request
headers in signUpAction. After a confirmed successful signup, write them
into app_metadata via supabaseAdmin.auth.admin.updateUserById as
signup_ip and signup_user_agent.

app_metadata (raw_app_meta_data) is only writable by the service role —
the user cannot tamper with it via supabase.auth.updateUser.

The admin write is guarded by identities.length !== 0 to skip fake user
objects returned by Supabase on duplicate-email attempts. It is also
wrapped in try/catch: a failure logs the error but does not propagate,
so a metadata write failure never blocks a successful registration.

x-forwarded-for is split on comma and the first entry taken, as the
header may contain a full proxy chain; only the leftmost value
represents the original client address.

## Testing

Manually verified signup_ip and signup_user_agent appear on the Supabase
user record in app_metadata after sign-up and cannot be modified by the
user. No automated test added — the logic is a direct header read with
no branching worth unit-testing independently.