### PR TITLE
refactor: route team bootstrap through dashboard admin API

### DIFF
--- a/spec/openapi.dashboard-api.yaml
+++ b/spec/openapi.dashboard-api.yaml
@@ -214,7 +214,7 @@ components:
         nextCursor:
           type: string
           nullable: true
-          description: Cursor to pass to the next list request, or `null` if there is no next page. 
+          description: Cursor to pass to the next list request, or `null` if there is no next page.
 
     BuildStatusItem:
       type: object
@@ -757,13 +757,14 @@ paths:
         "500":
           $ref: "#/components/responses/500"
 
-  /admin/users/bootstrap:
+  /admin/users/{userId}/bootstrap:
     post:
       summary: Bootstrap user
       tags: [teams]
       security:
         - AdminTokenAuth: []
-          Supabase1TokenAuth: []
+      parameters:
+        - $ref: "#/components/parameters/userId"
       responses:
         "200":
           description: Successfully bootstrapped user.

--- a/spec/openapi.dashboard-api.yaml
+++ b/spec/openapi.dashboard-api.yaml
@@ -493,6 +493,16 @@ components:
           type: string
           format: email
 
+    CreateTeamRequest:
+      type: object
+      required:
+        - name
+      properties:
+        name:
+          type: string
+          minLength: 1
+          maxLength: 255
+
     DefaultTemplateAlias:
       type: object
       required:
@@ -710,6 +720,48 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/UserTeamsResponse"
+        "401":
+          $ref: "#/components/responses/401"
+        "500":
+          $ref: "#/components/responses/500"
+    post:
+      summary: Create team
+      tags: [teams]
+      security:
+        - Supabase1TokenAuth: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/CreateTeamRequest"
+      responses:
+        "200":
+          description: Successfully created team.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/TeamResolveResponse"
+        "400":
+          $ref: "#/components/responses/400"
+        "401":
+          $ref: "#/components/responses/401"
+        "500":
+          $ref: "#/components/responses/500"
+
+  /users/bootstrap:
+    post:
+      summary: Bootstrap user
+      tags: [teams]
+      security:
+        - Supabase1TokenAuth: []
+      responses:
+        "200":
+          description: Successfully bootstrapped user.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/TeamResolveResponse"
         "401":
           $ref: "#/components/responses/401"
         "500":

--- a/spec/openapi.dashboard-api.yaml
+++ b/spec/openapi.dashboard-api.yaml
@@ -6,6 +6,10 @@ info:
 
 components:
   securitySchemes:
+    AdminTokenAuth:
+      type: apiKey
+      in: header
+      name: X-Admin-Token
     Supabase1TokenAuth:
       type: apiKey
       in: header
@@ -386,6 +390,7 @@ components:
         - blockedReason
         - isDefault
         - limits
+        - createdAt
       properties:
         id:
           type: string
@@ -412,6 +417,9 @@ components:
           type: boolean
         limits:
           $ref: "#/components/schemas/UserTeamLimits"
+        createdAt:
+          type: string
+          format: date-time
 
     UserTeamsResponse:
       type: object
@@ -749,12 +757,13 @@ paths:
         "500":
           $ref: "#/components/responses/500"
 
-  /users/bootstrap:
+  /admin/users/bootstrap:
     post:
       summary: Bootstrap user
       tags: [teams]
       security:
-        - Supabase1TokenAuth: []
+        - AdminTokenAuth: []
+          Supabase1TokenAuth: []
       responses:
         "200":
           description: Successfully bootstrapped user.

--- a/src/__test__/integration/auth-callback-route.test.ts
+++ b/src/__test__/integration/auth-callback-route.test.ts
@@ -1,0 +1,99 @@
+import { redirect } from 'next/navigation'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { AUTH_URLS } from '@/configs/urls'
+
+const {
+  mockFlags,
+  mockCreateAdminUsersRepository,
+  mockBootstrapUser,
+  mockSupabaseClient,
+} = vi.hoisted(() => ({
+  mockFlags: {
+    enableUserBootstrap: true,
+  },
+  mockCreateAdminUsersRepository: vi.fn(),
+  mockBootstrapUser: vi.fn(),
+  mockSupabaseClient: {
+    auth: {
+      exchangeCodeForSession: vi.fn(),
+    },
+  },
+}))
+
+vi.mock('next/navigation', () => ({
+  redirect: vi.fn((url) => ({ destination: url })),
+}))
+
+vi.mock('@/configs/flags', () => ({
+  get ENABLE_USER_BOOTSTRAP() {
+    return mockFlags.enableUserBootstrap
+  },
+}))
+
+vi.mock('@/core/shared/clients/supabase/server', () => ({
+  createClient: vi.fn(() => mockSupabaseClient),
+}))
+
+vi.mock('@/core/modules/users/admin-repository.server', () => ({
+  createAdminUsersRepository: mockCreateAdminUsersRepository,
+}))
+
+vi.mock('@/lib/utils/auth', () => ({
+  encodedRedirect: vi.fn((type, url, message) => ({
+    type,
+    destination: `${url}?${type}=${encodeURIComponent(message)}`,
+    message,
+  })),
+}))
+
+import { GET } from '@/app/api/auth/callback/route'
+
+describe('Auth Callback Route', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockFlags.enableUserBootstrap = true
+    mockCreateAdminUsersRepository.mockReturnValue({
+      bootstrapUser: mockBootstrapUser,
+    })
+  })
+
+  it('continues login when bootstrap fails', async () => {
+    mockSupabaseClient.auth.exchangeCodeForSession.mockResolvedValue({
+      data: {
+        user: { id: 'user-123' },
+        session: { access_token: 'access-token' },
+      },
+      error: null,
+    })
+    mockBootstrapUser.mockResolvedValue({
+      ok: false,
+      error: new Error('DASHBOARD_API_ADMIN_TOKEN is not configured'),
+    })
+
+    const result = await GET(
+      new Request('https://dashboard.e2b.dev/api/auth/callback?code=test')
+    )
+
+    expect(mockBootstrapUser).toHaveBeenCalledWith('user-123')
+    expect(redirect).toHaveBeenCalledWith('/dashboard')
+    expect(result).toEqual({ destination: '/dashboard' })
+  })
+
+  it('redirects cleanly when the exchanged session has no user id', async () => {
+    mockSupabaseClient.auth.exchangeCodeForSession.mockResolvedValue({
+      data: {
+        user: null,
+        session: { access_token: 'access-token' },
+      },
+      error: null,
+    })
+
+    await expect(
+      GET(new Request('https://dashboard.e2b.dev/api/auth/callback?code=test'))
+    ).rejects.toEqual({
+      type: 'error',
+      destination: `${AUTH_URLS.SIGN_IN}?error=${encodeURIComponent('Missing session after auth callback')}`,
+      message: 'Missing session after auth callback',
+    })
+  })
+})

--- a/src/__test__/integration/dashboard-route.test.ts
+++ b/src/__test__/integration/dashboard-route.test.ts
@@ -121,8 +121,11 @@ describe('Dashboard Route - Team Resolution Integration Tests', () => {
       // execute
       const response = await GET(request)
 
-      // verify: resolveUserTeam was called with session access token
-      expect(mockResolveUserTeam).toHaveBeenCalledWith('session-token')
+      // verify: resolveUserTeam was called with authenticated user id and session access token
+      expect(mockResolveUserTeam).toHaveBeenCalledWith(
+        'user-123',
+        'session-token'
+      )
 
       // verify: redirects to sandboxes page
       expect(response.status).toBe(307) // temporary redirect

--- a/src/__test__/integration/resolve-user-team.test.ts
+++ b/src/__test__/integration/resolve-user-team.test.ts
@@ -4,6 +4,7 @@ import { COOKIE_KEYS } from '@/configs/cookies'
 const {
   mockCookieStore,
   mockListUserTeams,
+  mockBootstrapUser,
   mockResolveTeamBySlug,
   mockCreateUserTeamsRepository,
 } = vi.hoisted(() => ({
@@ -11,6 +12,7 @@ const {
     get: vi.fn(),
   },
   mockListUserTeams: vi.fn(),
+  mockBootstrapUser: vi.fn(),
   mockResolveTeamBySlug: vi.fn(),
   mockCreateUserTeamsRepository: vi.fn(),
 }))
@@ -48,6 +50,7 @@ describe('resolveUserTeam', () => {
     vi.clearAllMocks()
     mockCreateUserTeamsRepository.mockReturnValue({
       listUserTeams: mockListUserTeams,
+      bootstrapUser: mockBootstrapUser,
       resolveTeamBySlug: mockResolveTeamBySlug,
     })
   })
@@ -195,6 +198,46 @@ describe('resolveUserTeam', () => {
     expect(result).toBeNull()
   })
 
+  it('bootstraps once when the user has no teams', async () => {
+    setupCookies({})
+    mockListUserTeams.mockResolvedValue({
+      ok: true,
+      data: [],
+    })
+    mockBootstrapUser.mockResolvedValue({
+      ok: true,
+      data: {
+        id: 'bootstrapped-team',
+        slug: 'bootstrapped-team',
+      },
+    })
+
+    const result = await resolveUserTeam('access-token')
+
+    expect(result).toEqual({
+      id: 'bootstrapped-team',
+      slug: 'bootstrapped-team',
+    })
+    expect(mockBootstrapUser).toHaveBeenCalledTimes(1)
+  })
+
+  it('returns null when bootstrap fails after empty team lookup', async () => {
+    setupCookies({})
+    mockListUserTeams.mockResolvedValue({
+      ok: true,
+      data: [],
+    })
+    mockBootstrapUser.mockResolvedValue({
+      ok: false,
+      error: new Error('Failed to bootstrap user'),
+    })
+
+    const result = await resolveUserTeam('access-token')
+
+    expect(result).toBeNull()
+    expect(mockBootstrapUser).toHaveBeenCalledTimes(1)
+  })
+
   it('returns null when listing teams fails', async () => {
     setupCookies({})
     mockListUserTeams.mockResolvedValue({
@@ -205,5 +248,6 @@ describe('resolveUserTeam', () => {
     const result = await resolveUserTeam('access-token')
 
     expect(result).toBeNull()
+    expect(mockBootstrapUser).not.toHaveBeenCalled()
   })
 })

--- a/src/__test__/integration/resolve-user-team.test.ts
+++ b/src/__test__/integration/resolve-user-team.test.ts
@@ -2,6 +2,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { COOKIE_KEYS } from '@/configs/cookies'
 
 const {
+  mockFlags,
   mockCookieStore,
   mockListUserTeams,
   mockBootstrapUser,
@@ -9,6 +10,9 @@ const {
   mockCreateUserTeamsRepository,
   mockCreateAdminUsersRepository,
 } = vi.hoisted(() => ({
+  mockFlags: {
+    enableUserBootstrap: true,
+  },
   mockCookieStore: {
     get: vi.fn(),
   },
@@ -29,6 +33,12 @@ vi.mock('@/core/modules/teams/user-teams-repository.server', () => ({
 
 vi.mock('@/core/modules/users/admin-repository.server', () => ({
   createAdminUsersRepository: mockCreateAdminUsersRepository,
+}))
+
+vi.mock('@/configs/flags', () => ({
+  get ENABLE_USER_BOOTSTRAP() {
+    return mockFlags.enableUserBootstrap
+  },
 }))
 
 import { resolveUserTeam } from '@/core/server/functions/team/resolve-user-team'
@@ -57,6 +67,7 @@ function createTeam(overrides: Record<string, unknown> = {}) {
 describe('resolveUserTeam', () => {
   beforeEach(() => {
     vi.clearAllMocks()
+    mockFlags.enableUserBootstrap = true
     mockCreateUserTeamsRepository.mockReturnValue({
       listUserTeams: mockListUserTeams,
       resolveTeamBySlug: mockResolveTeamBySlug,
@@ -251,6 +262,21 @@ describe('resolveUserTeam', () => {
     expect(mockCreateAdminUsersRepository).toHaveBeenCalledTimes(1)
     expect(mockBootstrapUser).toHaveBeenCalledTimes(1)
     expect(mockBootstrapUser).toHaveBeenCalledWith(TEST_USER_ID)
+  })
+
+  it('returns null without bootstrapping when bootstrap is disabled', async () => {
+    mockFlags.enableUserBootstrap = false
+    setupCookies({})
+    mockListUserTeams.mockResolvedValue({
+      ok: true,
+      data: [],
+    })
+
+    const result = await resolveUserTeam(TEST_USER_ID, TEST_ACCESS_TOKEN)
+
+    expect(result).toBeNull()
+    expect(mockCreateAdminUsersRepository).not.toHaveBeenCalled()
+    expect(mockBootstrapUser).not.toHaveBeenCalled()
   })
 
   it('returns null when listing teams fails', async () => {

--- a/src/__test__/integration/resolve-user-team.test.ts
+++ b/src/__test__/integration/resolve-user-team.test.ts
@@ -7,6 +7,7 @@ const {
   mockBootstrapUser,
   mockResolveTeamBySlug,
   mockCreateUserTeamsRepository,
+  mockCreateAdminUsersRepository,
 } = vi.hoisted(() => ({
   mockCookieStore: {
     get: vi.fn(),
@@ -15,6 +16,7 @@ const {
   mockBootstrapUser: vi.fn(),
   mockResolveTeamBySlug: vi.fn(),
   mockCreateUserTeamsRepository: vi.fn(),
+  mockCreateAdminUsersRepository: vi.fn(),
 }))
 
 vi.mock('next/headers', () => ({
@@ -25,7 +27,14 @@ vi.mock('@/core/modules/teams/user-teams-repository.server', () => ({
   createUserTeamsRepository: mockCreateUserTeamsRepository,
 }))
 
+vi.mock('@/core/modules/users/admin-repository.server', () => ({
+  createAdminUsersRepository: mockCreateAdminUsersRepository,
+}))
+
 import { resolveUserTeam } from '@/core/server/functions/team/resolve-user-team'
+
+const TEST_USER_ID = 'user-123'
+const TEST_ACCESS_TOKEN = 'access-token'
 
 function setupCookies(cookieValues: Record<string, string | undefined>) {
   mockCookieStore.get.mockImplementation((key: string) => {
@@ -50,8 +59,10 @@ describe('resolveUserTeam', () => {
     vi.clearAllMocks()
     mockCreateUserTeamsRepository.mockReturnValue({
       listUserTeams: mockListUserTeams,
-      bootstrapUser: mockBootstrapUser,
       resolveTeamBySlug: mockResolveTeamBySlug,
+    })
+    mockCreateAdminUsersRepository.mockReturnValue({
+      bootstrapUser: mockBootstrapUser,
     })
   })
 
@@ -72,7 +83,7 @@ describe('resolveUserTeam', () => {
       },
     })
 
-    const result = await resolveUserTeam('access-token')
+    const result = await resolveUserTeam(TEST_USER_ID, TEST_ACCESS_TOKEN)
 
     expect(result).toEqual({
       id: 'team-cookie-id',
@@ -95,7 +106,7 @@ describe('resolveUserTeam', () => {
       },
     })
 
-    const result = await resolveUserTeam('access-token')
+    const result = await resolveUserTeam(TEST_USER_ID, TEST_ACCESS_TOKEN)
 
     expect(result).toEqual({
       id: 'team-cookie-id',
@@ -114,14 +125,14 @@ describe('resolveUserTeam', () => {
       ],
     })
 
-    const result = await resolveUserTeam('access-token')
+    const result = await resolveUserTeam(TEST_USER_ID, TEST_ACCESS_TOKEN)
 
     expect(result).toEqual({
       id: 'team-b',
       slug: 'team-b',
     })
     expect(mockCreateUserTeamsRepository).toHaveBeenCalledWith({
-      accessToken: 'access-token',
+      accessToken: TEST_ACCESS_TOKEN,
     })
   })
 
@@ -135,7 +146,7 @@ describe('resolveUserTeam', () => {
       ],
     })
 
-    const result = await resolveUserTeam('access-token')
+    const result = await resolveUserTeam(TEST_USER_ID, TEST_ACCESS_TOKEN)
 
     expect(result).toEqual({
       id: 'team-slugged',
@@ -157,7 +168,7 @@ describe('resolveUserTeam', () => {
       data: [createTeam({ id: 'team-db', slug: 'team-db', isDefault: true })],
     })
 
-    const result = await resolveUserTeam('access-token')
+    const result = await resolveUserTeam(TEST_USER_ID, TEST_ACCESS_TOKEN)
 
     expect(result).toEqual({
       id: 'team-db',
@@ -174,7 +185,7 @@ describe('resolveUserTeam', () => {
       data: [createTeam({ id: 'team-db', slug: 'team-db', isDefault: true })],
     })
 
-    const result = await resolveUserTeam('access-token')
+    const result = await resolveUserTeam(TEST_USER_ID, TEST_ACCESS_TOKEN)
 
     expect(result).toEqual({
       id: 'team-db',
@@ -193,7 +204,7 @@ describe('resolveUserTeam', () => {
       ],
     })
 
-    const result = await resolveUserTeam('access-token')
+    const result = await resolveUserTeam(TEST_USER_ID, TEST_ACCESS_TOKEN)
 
     expect(result).toBeNull()
   })
@@ -212,13 +223,15 @@ describe('resolveUserTeam', () => {
       },
     })
 
-    const result = await resolveUserTeam('access-token')
+    const result = await resolveUserTeam(TEST_USER_ID, TEST_ACCESS_TOKEN)
 
     expect(result).toEqual({
       id: 'bootstrapped-team',
       slug: 'bootstrapped-team',
     })
+    expect(mockCreateAdminUsersRepository).toHaveBeenCalledTimes(1)
     expect(mockBootstrapUser).toHaveBeenCalledTimes(1)
+    expect(mockBootstrapUser).toHaveBeenCalledWith(TEST_USER_ID)
   })
 
   it('returns null when bootstrap fails after empty team lookup', async () => {
@@ -232,10 +245,12 @@ describe('resolveUserTeam', () => {
       error: new Error('Failed to bootstrap user'),
     })
 
-    const result = await resolveUserTeam('access-token')
+    const result = await resolveUserTeam(TEST_USER_ID, TEST_ACCESS_TOKEN)
 
     expect(result).toBeNull()
+    expect(mockCreateAdminUsersRepository).toHaveBeenCalledTimes(1)
     expect(mockBootstrapUser).toHaveBeenCalledTimes(1)
+    expect(mockBootstrapUser).toHaveBeenCalledWith(TEST_USER_ID)
   })
 
   it('returns null when listing teams fails', async () => {
@@ -245,7 +260,7 @@ describe('resolveUserTeam', () => {
       error: new Error('Failed to fetch user teams'),
     })
 
-    const result = await resolveUserTeam('access-token')
+    const result = await resolveUserTeam(TEST_USER_ID, TEST_ACCESS_TOKEN)
 
     expect(result).toBeNull()
     expect(mockBootstrapUser).not.toHaveBeenCalled()

--- a/src/__test__/unit/teams-repository.test.ts
+++ b/src/__test__/unit/teams-repository.test.ts
@@ -1,0 +1,88 @@
+import { describe, expect, it, vi } from 'vitest'
+import { createTeamsRepository } from '@/core/modules/teams/teams-repository.server'
+import type { components as DashboardComponents } from '@/contracts/dashboard-api'
+
+function createApiResponse<T>(input: {
+  ok: boolean
+  status: number
+  data?: T
+  error?: { message?: string } | null
+}) {
+  return {
+    data: input.data,
+    error: input.error ?? null,
+    response: {
+      ok: input.ok,
+      status: input.status,
+    },
+  }
+}
+
+describe('createTeamsRepository', () => {
+  it('returns a validation repo error when createTeam gets a 400 response', async () => {
+    const apiClient = {
+      POST: vi.fn().mockResolvedValue(
+        createApiResponse<
+          DashboardComponents['schemas']['TeamResolveResponse']
+        >({
+          ok: false,
+          status: 400,
+          error: { message: 'Team name is invalid' },
+        })
+      ),
+      GET: vi.fn(),
+      PATCH: vi.fn(),
+      DELETE: vi.fn(),
+    }
+
+    const repository = createTeamsRepository(
+      { accessToken: 'token' },
+      {
+        apiClient:
+          apiClient as unknown as typeof import('@/core/shared/clients/api').api,
+        authHeaders: vi.fn(() => ({ 'X-Supabase-Token': 'token' })),
+        adminClient: {
+          auth: { admin: { getUserById: vi.fn() } },
+        } as unknown as typeof import('@/core/shared/clients/supabase/admin').supabaseAdmin,
+      }
+    )
+
+    const result = await repository.createTeam('bad name')
+
+    expect(result).toEqual({
+      ok: false,
+      error: expect.objectContaining({
+        code: 'validation',
+        status: 400,
+        message: 'Team name is invalid',
+      }),
+    })
+  })
+
+  it('returns a repo error instead of throwing when a team-scoped method has no teamId', async () => {
+    const repository = createTeamsRepository(
+      { accessToken: 'token' },
+      {
+        apiClient: {
+          POST: vi.fn(),
+          GET: vi.fn(),
+          PATCH: vi.fn(),
+          DELETE: vi.fn(),
+        } as unknown as typeof import('@/core/shared/clients/api').api,
+        authHeaders: vi.fn(() => ({ 'X-Supabase-Token': 'token' })),
+        adminClient: {
+          auth: { admin: { getUserById: vi.fn() } },
+        } as unknown as typeof import('@/core/shared/clients/supabase/admin').supabaseAdmin,
+      }
+    )
+
+    await expect(repository.updateTeamName('new name')).resolves.toEqual({
+      ok: false,
+      error: expect.objectContaining({
+        code: 'internal',
+        status: 500,
+        message: 'teamId is required for team-scoped repository operation',
+      }),
+    })
+  })
+})

--- a/src/__test__/unit/teams-repository.test.ts
+++ b/src/__test__/unit/teams-repository.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it, vi } from 'vitest'
-import { createTeamsRepository } from '@/core/modules/teams/teams-repository.server'
 import type { components as DashboardComponents } from '@/contracts/dashboard-api'
+import { createTeamsRepository } from '@/core/modules/teams/teams-repository.server'
 
 function createApiResponse<T>(input: {
   ok: boolean

--- a/src/__test__/unit/teams-repository.test.ts
+++ b/src/__test__/unit/teams-repository.test.ts
@@ -2,6 +2,16 @@ import { describe, expect, it, vi } from 'vitest'
 import type { components as DashboardComponents } from '@/contracts/dashboard-api'
 import { createTeamsRepository } from '@/core/modules/teams/teams-repository.server'
 
+vi.mock('@/core/shared/clients/supabase/admin', () => ({
+  supabaseAdmin: {
+    auth: {
+      admin: {
+        getUserById: vi.fn(),
+      },
+    },
+  },
+}))
+
 function createApiResponse<T>(input: {
   ok: boolean
   status: number

--- a/src/app/api/auth/callback/route.ts
+++ b/src/app/api/auth/callback/route.ts
@@ -1,6 +1,6 @@
 import { redirect } from 'next/navigation'
 import { AUTH_URLS, PROTECTED_URLS } from '@/configs/urls'
-import { createUserTeamsRepository } from '@/core/modules/teams/user-teams-repository.server'
+import { createAdminUsersRepository } from '@/core/modules/users/admin-repository.server'
 import { l, serializeErrorForLog } from '@/core/shared/clients/logger/logger'
 import { createClient } from '@/core/shared/clients/supabase/server'
 import { encodedRedirect } from '@/lib/utils/auth'
@@ -50,20 +50,19 @@ export async function GET(request: Request) {
 
       throw encodedRedirect('error', AUTH_URLS.SIGN_IN, error.message)
     } else {
-      const accessToken = data.session?.access_token
-      if (!accessToken) {
+      const userId = data.user.id
+
+      if (!data.session?.access_token || !userId) {
         throw encodedRedirect(
           'error',
           AUTH_URLS.SIGN_IN,
-          'Missing session access token after auth callback'
+          'Missing session after auth callback'
         )
       }
 
-      const userTeamsRepository = createUserTeamsRepository({
-        accessToken,
-      })
+      const adminUsersRepository = createAdminUsersRepository()
 
-      const bootstrapResult = await userTeamsRepository.bootstrapUser()
+      const bootstrapResult = await adminUsersRepository.bootstrapUser(userId)
 
       if (!bootstrapResult.ok) {
         l.error(

--- a/src/app/api/auth/callback/route.ts
+++ b/src/app/api/auth/callback/route.ts
@@ -1,5 +1,6 @@
 import { redirect } from 'next/navigation'
 import { AUTH_URLS, PROTECTED_URLS } from '@/configs/urls'
+import { createUserTeamsRepository } from '@/core/modules/teams/user-teams-repository.server'
 import { l, serializeErrorForLog } from '@/core/shared/clients/logger/logger'
 import { createClient } from '@/core/shared/clients/supabase/server'
 import { encodedRedirect } from '@/lib/utils/auth'
@@ -49,6 +50,39 @@ export async function GET(request: Request) {
 
       throw encodedRedirect('error', AUTH_URLS.SIGN_IN, error.message)
     } else {
+      const accessToken = data.session?.access_token
+      if (!accessToken) {
+        throw encodedRedirect(
+          'error',
+          AUTH_URLS.SIGN_IN,
+          'Missing session access token after auth callback'
+        )
+      }
+
+      const userTeamsRepository = createUserTeamsRepository({
+        accessToken,
+      })
+
+      const bootstrapResult = await userTeamsRepository.bootstrapUser()
+
+      if (!bootstrapResult.ok) {
+        l.error(
+          {
+            key: 'auth_callback:bootstrap_error',
+            user_id: data.user.id,
+            error: serializeErrorForLog(bootstrapResult.error),
+          },
+          `Auth callback bootstrap error: ${bootstrapResult.error.message || 'Unknown error'}`
+        )
+
+        throw encodedRedirect(
+          'error',
+          AUTH_URLS.SIGN_IN,
+          bootstrapResult.error.message ||
+            'Failed to setup account. Please try again or contact support.'
+        )
+      }
+
       l.info(
         {
           key: 'auth_callback:otp_exchanged',

--- a/src/app/api/auth/callback/route.ts
+++ b/src/app/api/auth/callback/route.ts
@@ -1,4 +1,5 @@
 import { redirect } from 'next/navigation'
+import { ENABLE_USER_BOOTSTRAP } from '@/configs/flags'
 import { AUTH_URLS, PROTECTED_URLS } from '@/configs/urls'
 import { createAdminUsersRepository } from '@/core/modules/users/admin-repository.server'
 import { l, serializeErrorForLog } from '@/core/shared/clients/logger/logger'
@@ -60,26 +61,28 @@ export async function GET(request: Request) {
         )
       }
 
-      const adminUsersRepository = createAdminUsersRepository()
+      if (ENABLE_USER_BOOTSTRAP) {
+        const adminUsersRepository = createAdminUsersRepository()
 
-      const bootstrapResult = await adminUsersRepository.bootstrapUser(userId)
+        const bootstrapResult = await adminUsersRepository.bootstrapUser(userId)
 
-      if (!bootstrapResult.ok) {
-        l.error(
-          {
-            key: 'auth_callback:bootstrap_error',
-            user_id: data.user.id,
-            error: serializeErrorForLog(bootstrapResult.error),
-          },
-          `Auth callback bootstrap error: ${bootstrapResult.error.message || 'Unknown error'}`
-        )
+        if (!bootstrapResult.ok) {
+          l.error(
+            {
+              key: 'auth_callback:bootstrap_error',
+              user_id: data.user.id,
+              error: serializeErrorForLog(bootstrapResult.error),
+            },
+            `Auth callback bootstrap error: ${bootstrapResult.error.message || 'Unknown error'}`
+          )
 
-        throw encodedRedirect(
-          'error',
-          AUTH_URLS.SIGN_IN,
-          bootstrapResult.error.message ||
-            'Failed to setup account. Please try again or contact support.'
-        )
+          throw encodedRedirect(
+            'error',
+            AUTH_URLS.SIGN_IN,
+            bootstrapResult.error.message ||
+              'Failed to setup account. Please try again or contact support.'
+          )
+        }
       }
 
       l.info(

--- a/src/app/api/auth/callback/route.ts
+++ b/src/app/api/auth/callback/route.ts
@@ -51,7 +51,7 @@ export async function GET(request: Request) {
 
       throw encodedRedirect('error', AUTH_URLS.SIGN_IN, error.message)
     } else {
-      const userId = data.user.id
+      const userId = data.user?.id
 
       if (!data.session?.access_token || !userId) {
         throw encodedRedirect(
@@ -67,20 +67,13 @@ export async function GET(request: Request) {
         const bootstrapResult = await adminUsersRepository.bootstrapUser(userId)
 
         if (!bootstrapResult.ok) {
-          l.error(
+          l.warn(
             {
               key: 'auth_callback:bootstrap_error',
-              user_id: data.user.id,
+              user_id: userId,
               error: serializeErrorForLog(bootstrapResult.error),
             },
-            `Auth callback bootstrap error: ${bootstrapResult.error.message || 'Unknown error'}`
-          )
-
-          throw encodedRedirect(
-            'error',
-            AUTH_URLS.SIGN_IN,
-            bootstrapResult.error.message ||
-              'Failed to setup account. Please try again or contact support.'
+            `Auth callback bootstrap failed; continuing with sign-in flow`
           )
         }
       }
@@ -88,7 +81,7 @@ export async function GET(request: Request) {
       l.info(
         {
           key: 'auth_callback:otp_exchanged',
-          user_id: data.user.id,
+          user_id: userId,
         },
         `OTP successfully exchanged for user session`
       )

--- a/src/app/dashboard/account/route.ts
+++ b/src/app/dashboard/account/route.ts
@@ -20,7 +20,7 @@ export async function GET(request: NextRequest) {
     return NextResponse.redirect(new URL(AUTH_URLS.SIGN_IN, request.url))
   }
 
-  const team = await resolveUserTeam(session.access_token)
+  const team = await resolveUserTeam(data.user.id, session.access_token)
 
   if (!team) {
     await supabase.auth.signOut()

--- a/src/app/dashboard/route.ts
+++ b/src/app/dashboard/route.ts
@@ -53,7 +53,7 @@ export async function GET(request: NextRequest) {
     return NextResponse.redirect(new URL('/sign-in', request.url))
   }
 
-  const team = await resolveUserTeam(session.access_token)
+  const team = await resolveUserTeam(data.user.id, session.access_token)
 
   if (!team) {
     await supabase.auth.signOut()

--- a/src/app/sbx/new/route.ts
+++ b/src/app/sbx/new/route.ts
@@ -34,7 +34,7 @@ export const GET = async (req: NextRequest) => {
       )
     }
 
-    const team = await resolveUserTeam(session.access_token)
+    const team = await resolveUserTeam(data.user.id, session.access_token)
 
     if (!team) {
       return NextResponse.redirect(new URL(req.url).origin)

--- a/src/configs/api.ts
+++ b/src/configs/api.ts
@@ -11,7 +11,6 @@ export const SUPABASE_AUTH_HEADERS = (token: string, teamId?: string) => ({
 })
 
 export const ADMIN_AUTH_HEADERS = (token: string) => ({
-  [SUPABASE_TOKEN_HEADER]: 'xxx',
   [ADMIN_TOKEN_HEADER]: token,
 })
 export const CLI_GENERATED_KEY_NAME = 'CLI login/configure'

--- a/src/configs/api.ts
+++ b/src/configs/api.ts
@@ -3,6 +3,7 @@ export const ACCESS_TOKEN_PREFIX = 'sk_e2b_'
 export const SUPABASE_TOKEN_HEADER = 'X-Supabase-Token'
 export const SUPABASE_TEAM_HEADER = 'X-Supabase-Team'
 export const ENVD_ACCESS_TOKEN_HEADER = 'X-Access-Token'
+export const ADMIN_TOKEN_HEADER = 'X-Admin-Token'
 
 export const SUPABASE_AUTH_HEADERS = (token: string, teamId?: string) => ({
   [SUPABASE_TOKEN_HEADER]: token,
@@ -10,6 +11,7 @@ export const SUPABASE_AUTH_HEADERS = (token: string, teamId?: string) => ({
 })
 
 export const ADMIN_AUTH_HEADERS = (token: string) => ({
-  'X-Admin-Token': token,
+  [SUPABASE_TOKEN_HEADER]: 'xxx',
+  [ADMIN_TOKEN_HEADER]: token,
 })
 export const CLI_GENERATED_KEY_NAME = 'CLI login/configure'

--- a/src/configs/api.ts
+++ b/src/configs/api.ts
@@ -9,4 +9,7 @@ export const SUPABASE_AUTH_HEADERS = (token: string, teamId?: string) => ({
   ...(teamId && { [SUPABASE_TEAM_HEADER]: teamId }),
 })
 
+export const ADMIN_AUTH_HEADERS = (token: string) => ({
+  'X-Admin-Token': token,
+})
 export const CLI_GENERATED_KEY_NAME = 'CLI login/configure'

--- a/src/configs/flags.ts
+++ b/src/configs/flags.ts
@@ -1,5 +1,6 @@
 export const ALLOW_SEO_INDEXING = process.env.ALLOW_SEO_INDEXING === '1'
 export const VERBOSE = process.env.NEXT_PUBLIC_VERBOSE === '1'
+export const ENABLE_USER_BOOTSTRAP = process.env.ENABLE_USER_BOOTSTRAP === '1'
 export const INCLUDE_BILLING = process.env.NEXT_PUBLIC_INCLUDE_BILLING === '1'
 export const INCLUDE_ARGUS = process.env.NEXT_PUBLIC_INCLUDE_ARGUS === '1'
 export const INCLUDE_STATUS_INDICATOR =

--- a/src/core/modules/teams/teams-repository.server.ts
+++ b/src/core/modules/teams/teams-repository.server.ts
@@ -5,7 +5,7 @@ import { SUPABASE_AUTH_HEADERS } from '@/configs/api'
 import type { components as DashboardComponents } from '@/contracts/dashboard-api'
 import { api } from '@/core/shared/clients/api'
 import { supabaseAdmin } from '@/core/shared/clients/supabase/admin'
-import { repoErrorFromHttp } from '@/core/shared/errors'
+import { createRepoError, repoErrorFromHttp } from '@/core/shared/errors'
 import type { RequestScope } from '@/core/shared/repository-scope'
 import { err, ok, type RepoResult } from '@/core/shared/result'
 import type { TeamMember } from './models'
@@ -50,12 +50,18 @@ function extractSignInProviders(user: User | null | undefined): string[] {
   return [...new Set([...appProviders, ...identityProviders])]
 }
 
-function requireTeamId(scope: TeamsRequestScope): string {
+function requireTeamId(scope: TeamsRequestScope): RepoResult<string> {
   if (!scope.teamId) {
-    throw new Error('teamId is required for team-scoped repository operation')
+    return err(
+      createRepoError({
+        code: 'internal',
+        status: 500,
+        message: 'teamId is required for team-scoped repository operation',
+      })
+    )
   }
 
-  return scope.teamId
+  return ok(scope.teamId)
 }
 
 export function createTeamsRepository(
@@ -78,6 +84,17 @@ export function createTeamsRepository(
       })
 
       if (!response.ok || error || !data) {
+        if (response.status === 400) {
+          return err(
+            createRepoError({
+              code: 'validation',
+              status: response.status,
+              message: error?.message ?? 'Failed to create team',
+              cause: error,
+            })
+          )
+        }
+
         return err(
           repoErrorFromHttp(
             response.status,
@@ -91,11 +108,15 @@ export function createTeamsRepository(
     },
     async listTeamMembers(): Promise<RepoResult<TeamMember[]>> {
       const teamId = requireTeamId(scope)
+      if (!teamId.ok) {
+        return teamId
+      }
+
       const { data, error, response } = await deps.apiClient.GET(
         '/teams/{teamID}/members',
         {
-          params: { path: { teamID: teamId } },
-          headers: deps.authHeaders(scope.accessToken, teamId),
+          params: { path: { teamID: teamId.data } },
+          headers: deps.authHeaders(scope.accessToken, teamId.data),
         }
       )
 
@@ -140,11 +161,15 @@ export function createTeamsRepository(
       RepoResult<DashboardComponents['schemas']['UpdateTeamResponse']>
     > {
       const teamId = requireTeamId(scope)
+      if (!teamId.ok) {
+        return teamId
+      }
+
       const { data, error, response } = await deps.apiClient.PATCH(
         '/teams/{teamID}',
         {
-          params: { path: { teamID: teamId } },
-          headers: deps.authHeaders(scope.accessToken, teamId),
+          params: { path: { teamID: teamId.data } },
+          headers: deps.authHeaders(scope.accessToken, teamId.data),
           body: { name },
         }
       )
@@ -163,11 +188,15 @@ export function createTeamsRepository(
     },
     async addTeamMember(email): Promise<RepoResult<void>> {
       const teamId = requireTeamId(scope)
+      if (!teamId.ok) {
+        return teamId
+      }
+
       const { error, response } = await deps.apiClient.POST(
         '/teams/{teamID}/members',
         {
-          params: { path: { teamID: teamId } },
-          headers: deps.authHeaders(scope.accessToken, teamId),
+          params: { path: { teamID: teamId.data } },
+          headers: deps.authHeaders(scope.accessToken, teamId.data),
           body: { email },
         }
       )
@@ -186,11 +215,15 @@ export function createTeamsRepository(
     },
     async removeTeamMember(userId): Promise<RepoResult<void>> {
       const teamId = requireTeamId(scope)
+      if (!teamId.ok) {
+        return teamId
+      }
+
       const { error, response } = await deps.apiClient.DELETE(
         '/teams/{teamID}/members/{userId}',
         {
-          params: { path: { teamID: teamId, userId } },
-          headers: deps.authHeaders(scope.accessToken, teamId),
+          params: { path: { teamID: teamId.data, userId } },
+          headers: deps.authHeaders(scope.accessToken, teamId.data),
         }
       )
 
@@ -212,11 +245,15 @@ export function createTeamsRepository(
       RepoResult<DashboardComponents['schemas']['UpdateTeamResponse']>
     > {
       const teamId = requireTeamId(scope)
+      if (!teamId.ok) {
+        return teamId
+      }
+
       const { data, error, response } = await deps.apiClient.PATCH(
         '/teams/{teamID}',
         {
-          params: { path: { teamID: teamId } },
-          headers: deps.authHeaders(scope.accessToken, teamId),
+          params: { path: { teamID: teamId.data } },
+          headers: deps.authHeaders(scope.accessToken, teamId.data),
           body: { profilePictureUrl },
         }
       )

--- a/src/core/modules/teams/teams-repository.server.ts
+++ b/src/core/modules/teams/teams-repository.server.ts
@@ -6,7 +6,7 @@ import type { components as DashboardComponents } from '@/contracts/dashboard-ap
 import { api } from '@/core/shared/clients/api'
 import { supabaseAdmin } from '@/core/shared/clients/supabase/admin'
 import { repoErrorFromHttp } from '@/core/shared/errors'
-import type { TeamRequestScope } from '@/core/shared/repository-scope'
+import type { RequestScope } from '@/core/shared/repository-scope'
 import { err, ok, type RepoResult } from '@/core/shared/result'
 import type { TeamMember } from './models'
 
@@ -16,9 +16,14 @@ type TeamsRepositoryDeps = {
   adminClient: typeof supabaseAdmin
 }
 
-export type TeamsRequestScope = TeamRequestScope
+export type TeamsRequestScope = RequestScope & {
+  teamId?: string
+}
 
 export interface TeamsRepository {
+  createTeam(
+    name: string
+  ): Promise<RepoResult<DashboardComponents['schemas']['TeamResolveResponse']>>
   listTeamMembers(): Promise<RepoResult<TeamMember[]>>
   updateTeamName(
     name: string
@@ -45,6 +50,14 @@ function extractSignInProviders(user: User | null | undefined): string[] {
   return [...new Set([...appProviders, ...identityProviders])]
 }
 
+function requireTeamId(scope: TeamsRequestScope): string {
+  if (!scope.teamId) {
+    throw new Error('teamId is required for team-scoped repository operation')
+  }
+
+  return scope.teamId
+}
+
 export function createTeamsRepository(
   scope: TeamsRequestScope,
   deps: TeamsRepositoryDeps = {
@@ -54,12 +67,35 @@ export function createTeamsRepository(
   }
 ): TeamsRepository {
   return {
+    async createTeam(
+      name
+    ): Promise<
+      RepoResult<DashboardComponents['schemas']['TeamResolveResponse']>
+    > {
+      const { data, error, response } = await deps.apiClient.POST('/teams', {
+        headers: deps.authHeaders(scope.accessToken),
+        body: { name },
+      })
+
+      if (!response.ok || error || !data) {
+        return err(
+          repoErrorFromHttp(
+            response.status,
+            error?.message ?? 'Failed to create team',
+            error
+          )
+        )
+      }
+
+      return ok(data)
+    },
     async listTeamMembers(): Promise<RepoResult<TeamMember[]>> {
+      const teamId = requireTeamId(scope)
       const { data, error, response } = await deps.apiClient.GET(
         '/teams/{teamID}/members',
         {
-          params: { path: { teamID: scope.teamId } },
-          headers: deps.authHeaders(scope.accessToken, scope.teamId),
+          params: { path: { teamID: teamId } },
+          headers: deps.authHeaders(scope.accessToken, teamId),
         }
       )
 
@@ -103,11 +139,12 @@ export function createTeamsRepository(
     ): Promise<
       RepoResult<DashboardComponents['schemas']['UpdateTeamResponse']>
     > {
+      const teamId = requireTeamId(scope)
       const { data, error, response } = await deps.apiClient.PATCH(
         '/teams/{teamID}',
         {
-          params: { path: { teamID: scope.teamId } },
-          headers: deps.authHeaders(scope.accessToken, scope.teamId),
+          params: { path: { teamID: teamId } },
+          headers: deps.authHeaders(scope.accessToken, teamId),
           body: { name },
         }
       )
@@ -125,11 +162,12 @@ export function createTeamsRepository(
       return ok(data)
     },
     async addTeamMember(email): Promise<RepoResult<void>> {
+      const teamId = requireTeamId(scope)
       const { error, response } = await deps.apiClient.POST(
         '/teams/{teamID}/members',
         {
-          params: { path: { teamID: scope.teamId } },
-          headers: deps.authHeaders(scope.accessToken, scope.teamId),
+          params: { path: { teamID: teamId } },
+          headers: deps.authHeaders(scope.accessToken, teamId),
           body: { email },
         }
       )
@@ -147,11 +185,12 @@ export function createTeamsRepository(
       return ok(undefined)
     },
     async removeTeamMember(userId): Promise<RepoResult<void>> {
+      const teamId = requireTeamId(scope)
       const { error, response } = await deps.apiClient.DELETE(
         '/teams/{teamID}/members/{userId}',
         {
-          params: { path: { teamID: scope.teamId, userId } },
-          headers: deps.authHeaders(scope.accessToken, scope.teamId),
+          params: { path: { teamID: teamId, userId } },
+          headers: deps.authHeaders(scope.accessToken, teamId),
         }
       )
 
@@ -172,11 +211,12 @@ export function createTeamsRepository(
     ): Promise<
       RepoResult<DashboardComponents['schemas']['UpdateTeamResponse']>
     > {
+      const teamId = requireTeamId(scope)
       const { data, error, response } = await deps.apiClient.PATCH(
         '/teams/{teamID}',
         {
-          params: { path: { teamID: scope.teamId } },
-          headers: deps.authHeaders(scope.accessToken, scope.teamId),
+          params: { path: { teamID: teamId } },
+          headers: deps.authHeaders(scope.accessToken, teamId),
           body: { profilePictureUrl },
         }
       )

--- a/src/core/modules/teams/user-teams-repository.server.ts
+++ b/src/core/modules/teams/user-teams-repository.server.ts
@@ -1,28 +1,26 @@
-import "server-only";
+import 'server-only'
 
-import { secondsInMinute } from "date-fns/constants";
-import { ADMIN_AUTH_HEADERS, SUPABASE_AUTH_HEADERS } from "@/configs/api";
-import { api } from "@/core/shared/clients/api";
-import { repoErrorFromHttp } from "@/core/shared/errors";
-import type { RequestScope } from "@/core/shared/repository-scope";
-import { err, ok, type RepoResult } from "@/core/shared/result";
-import type { ResolvedTeam, TeamModel } from "./models";
+import { secondsInMinute } from 'date-fns/constants'
+import { SUPABASE_AUTH_HEADERS } from '@/configs/api'
+import { api } from '@/core/shared/clients/api'
+import { repoErrorFromHttp } from '@/core/shared/errors'
+import type { RequestScope } from '@/core/shared/repository-scope'
+import { err, ok, type RepoResult } from '@/core/shared/result'
+import type { ResolvedTeam, TeamModel } from './models'
 
 type UserTeamsRepositoryDeps = {
-  apiClient: typeof api;
-  authHeaders: typeof SUPABASE_AUTH_HEADERS;
-  adminHeaders: typeof ADMIN_AUTH_HEADERS;
-};
+  apiClient: typeof api
+  authHeaders: typeof SUPABASE_AUTH_HEADERS
+}
 
-export type UserTeamsRequestScope = RequestScope;
+export type UserTeamsRequestScope = RequestScope
 
 export interface UserTeamsRepository {
-  listUserTeams(): Promise<RepoResult<TeamModel[]>>;
-  bootstrapUser(): Promise<RepoResult<ResolvedTeam>>;
+  listUserTeams(): Promise<RepoResult<TeamModel[]>>
   resolveTeamBySlug(
     slug: string,
-    next?: { tags?: string[] },
-  ): Promise<RepoResult<ResolvedTeam>>;
+    next?: { tags?: string[] }
+  ): Promise<RepoResult<ResolvedTeam>>
 }
 
 export function createUserTeamsRepository(
@@ -30,79 +28,42 @@ export function createUserTeamsRepository(
   deps: UserTeamsRepositoryDeps = {
     apiClient: api,
     authHeaders: SUPABASE_AUTH_HEADERS,
-    adminHeaders: ADMIN_AUTH_HEADERS,
-  },
+  }
 ): UserTeamsRepository {
   const listApiUserTeams = async (): Promise<RepoResult<TeamModel[]>> => {
-    const { data, error, response } = await deps.apiClient.GET("/teams", {
+    const { data, error, response } = await deps.apiClient.GET('/teams', {
       headers: deps.authHeaders(scope.accessToken),
-    });
+    })
 
     if (!response.ok || error || !data?.teams) {
       return err(
         repoErrorFromHttp(
           response.status,
-          error?.message ?? "Failed to fetch user teams",
-          error,
-        ),
-      );
+          error?.message ?? 'Failed to fetch user teams',
+          error
+        )
+      )
     }
 
-    return ok(data.teams);
-  };
+    return ok(data.teams)
+  }
 
   return {
     async listUserTeams(): Promise<RepoResult<TeamModel[]>> {
-      const teamsResult = await listApiUserTeams();
+      const teamsResult = await listApiUserTeams()
 
       if (!teamsResult.ok) {
-        return teamsResult;
+        return teamsResult
       }
 
-      return ok(teamsResult.data);
-    },
-    async bootstrapUser(): Promise<RepoResult<ResolvedTeam>> {
-      if (!process.env.DASHBOARD_API_ADMIN_TOKEN) {
-        return err(
-          repoErrorFromHttp(
-            500,
-            "DASHBOARD_API_ADMIN_TOKEN is not configured",
-            new Error("DASHBOARD_API_ADMIN_TOKEN is not configured"),
-          ),
-        );
-      }
-
-      const { data, error, response } = await deps.apiClient.POST(
-        "/admin/users/bootstrap",
-        {
-          headers: {
-            ...deps.adminHeaders(process.env.DASHBOARD_API_ADMIN_TOKEN),
-            ...deps.authHeaders(scope.accessToken),
-          },
-        },
-      );
-
-      if (!response.ok || error || !data) {
-        return err(
-          repoErrorFromHttp(
-            response.status,
-            error?.message ?? "Failed to bootstrap user",
-            error,
-          ),
-        );
-      }
-
-      return ok({
-        id: data.id,
-        slug: data.slug,
-      });
+      return ok(teamsResult.data)
     },
     async resolveTeamBySlug(
       slug: string,
-      next?: { tags?: string[] },
+      next?: { tags?: string[] }
     ): Promise<RepoResult<ResolvedTeam>> {
       const { data, error, response } = await deps.apiClient.GET(
-        "/teams/resolve",
+        '/teams/resolve',
         {
           params: { query: { slug } },
           headers: deps.authHeaders(scope.accessToken),
@@ -110,23 +71,23 @@ export function createUserTeamsRepository(
             revalidate: secondsInMinute * 5,
             ...next,
           },
-        },
-      );
+        }
+      )
 
       if (!response.ok || error || !data) {
         return err(
           repoErrorFromHttp(
             response.status,
-            error?.message ?? "Failed to resolve team",
-            error,
-          ),
-        );
+            error?.message ?? 'Failed to resolve team',
+            error
+          )
+        )
       }
 
       return ok({
         id: data.id,
         slug: data.slug,
-      });
+      })
     },
-  };
+  }
 }

--- a/src/core/modules/teams/user-teams-repository.server.ts
+++ b/src/core/modules/teams/user-teams-repository.server.ts
@@ -1,7 +1,7 @@
 import 'server-only'
 
 import { secondsInMinute } from 'date-fns/constants'
-import { SUPABASE_AUTH_HEADERS } from '@/configs/api'
+import { ADMIN_AUTH_HEADERS, SUPABASE_AUTH_HEADERS } from '@/configs/api'
 import { api } from '@/core/shared/clients/api'
 import { repoErrorFromHttp } from '@/core/shared/errors'
 import type { RequestScope } from '@/core/shared/repository-scope'
@@ -11,6 +11,7 @@ import type { ResolvedTeam, TeamModel } from './models'
 type UserTeamsRepositoryDeps = {
   apiClient: typeof api
   authHeaders: typeof SUPABASE_AUTH_HEADERS
+  adminHeaders: typeof ADMIN_AUTH_HEADERS
 }
 
 export type UserTeamsRequestScope = RequestScope
@@ -29,6 +30,7 @@ export function createUserTeamsRepository(
   deps: UserTeamsRepositoryDeps = {
     apiClient: api,
     authHeaders: SUPABASE_AUTH_HEADERS,
+    adminHeaders: ADMIN_AUTH_HEADERS,
   }
 ): UserTeamsRepository {
   const listApiUserTeams = async (): Promise<RepoResult<TeamModel[]>> => {
@@ -60,10 +62,20 @@ export function createUserTeamsRepository(
       return ok(teamsResult.data)
     },
     async bootstrapUser(): Promise<RepoResult<ResolvedTeam>> {
+      if (!process.env.DASHBOARD_API_ADMIN_TOKEN) {
+        return err(
+          repoErrorFromHttp(
+            500,
+            'DASHBOARD_API_ADMIN_TOKEN is not configured',
+            new Error('DASHBOARD_API_ADMIN_TOKEN is not configured')
+          )
+        )
+      }
+
       const { data, error, response } = await deps.apiClient.POST(
-        '/users/bootstrap',
+        '/admin/users/bootstrap',
         {
-          headers: deps.authHeaders(scope.accessToken),
+          headers: deps.adminHeaders(process.env.DASHBOARD_API_ADMIN_TOKEN),
         }
       )
 

--- a/src/core/modules/teams/user-teams-repository.server.ts
+++ b/src/core/modules/teams/user-teams-repository.server.ts
@@ -1,6 +1,6 @@
 import 'server-only'
 
-import { secondsInDay, secondsInMinute } from 'date-fns/constants'
+import { secondsInMinute } from 'date-fns/constants'
 import { SUPABASE_AUTH_HEADERS } from '@/configs/api'
 import { api } from '@/core/shared/clients/api'
 import { repoErrorFromHttp } from '@/core/shared/errors'
@@ -17,6 +17,7 @@ export type UserTeamsRequestScope = RequestScope
 
 export interface UserTeamsRepository {
   listUserTeams(): Promise<RepoResult<TeamModel[]>>
+  bootstrapUser(): Promise<RepoResult<ResolvedTeam>>
   resolveTeamBySlug(
     slug: string,
     next?: { tags?: string[] }
@@ -57,6 +58,29 @@ export function createUserTeamsRepository(
       }
 
       return ok(teamsResult.data)
+    },
+    async bootstrapUser(): Promise<RepoResult<ResolvedTeam>> {
+      const { data, error, response } = await deps.apiClient.POST(
+        '/users/bootstrap',
+        {
+          headers: deps.authHeaders(scope.accessToken),
+        }
+      )
+
+      if (!response.ok || error || !data) {
+        return err(
+          repoErrorFromHttp(
+            response.status,
+            error?.message ?? 'Failed to bootstrap user',
+            error
+          )
+        )
+      }
+
+      return ok({
+        id: data.id,
+        slug: data.slug,
+      })
     },
     async resolveTeamBySlug(
       slug: string,

--- a/src/core/modules/teams/user-teams-repository.server.ts
+++ b/src/core/modules/teams/user-teams-repository.server.ts
@@ -1,28 +1,28 @@
-import 'server-only'
+import "server-only";
 
-import { secondsInMinute } from 'date-fns/constants'
-import { ADMIN_AUTH_HEADERS, SUPABASE_AUTH_HEADERS } from '@/configs/api'
-import { api } from '@/core/shared/clients/api'
-import { repoErrorFromHttp } from '@/core/shared/errors'
-import type { RequestScope } from '@/core/shared/repository-scope'
-import { err, ok, type RepoResult } from '@/core/shared/result'
-import type { ResolvedTeam, TeamModel } from './models'
+import { secondsInMinute } from "date-fns/constants";
+import { ADMIN_AUTH_HEADERS, SUPABASE_AUTH_HEADERS } from "@/configs/api";
+import { api } from "@/core/shared/clients/api";
+import { repoErrorFromHttp } from "@/core/shared/errors";
+import type { RequestScope } from "@/core/shared/repository-scope";
+import { err, ok, type RepoResult } from "@/core/shared/result";
+import type { ResolvedTeam, TeamModel } from "./models";
 
 type UserTeamsRepositoryDeps = {
-  apiClient: typeof api
-  authHeaders: typeof SUPABASE_AUTH_HEADERS
-  adminHeaders: typeof ADMIN_AUTH_HEADERS
-}
+  apiClient: typeof api;
+  authHeaders: typeof SUPABASE_AUTH_HEADERS;
+  adminHeaders: typeof ADMIN_AUTH_HEADERS;
+};
 
-export type UserTeamsRequestScope = RequestScope
+export type UserTeamsRequestScope = RequestScope;
 
 export interface UserTeamsRepository {
-  listUserTeams(): Promise<RepoResult<TeamModel[]>>
-  bootstrapUser(): Promise<RepoResult<ResolvedTeam>>
+  listUserTeams(): Promise<RepoResult<TeamModel[]>>;
+  bootstrapUser(): Promise<RepoResult<ResolvedTeam>>;
   resolveTeamBySlug(
     slug: string,
-    next?: { tags?: string[] }
-  ): Promise<RepoResult<ResolvedTeam>>
+    next?: { tags?: string[] },
+  ): Promise<RepoResult<ResolvedTeam>>;
 }
 
 export function createUserTeamsRepository(
@@ -31,75 +31,78 @@ export function createUserTeamsRepository(
     apiClient: api,
     authHeaders: SUPABASE_AUTH_HEADERS,
     adminHeaders: ADMIN_AUTH_HEADERS,
-  }
+  },
 ): UserTeamsRepository {
   const listApiUserTeams = async (): Promise<RepoResult<TeamModel[]>> => {
-    const { data, error, response } = await deps.apiClient.GET('/teams', {
+    const { data, error, response } = await deps.apiClient.GET("/teams", {
       headers: deps.authHeaders(scope.accessToken),
-    })
+    });
 
     if (!response.ok || error || !data?.teams) {
       return err(
         repoErrorFromHttp(
           response.status,
-          error?.message ?? 'Failed to fetch user teams',
-          error
-        )
-      )
+          error?.message ?? "Failed to fetch user teams",
+          error,
+        ),
+      );
     }
 
-    return ok(data.teams)
-  }
+    return ok(data.teams);
+  };
 
   return {
     async listUserTeams(): Promise<RepoResult<TeamModel[]>> {
-      const teamsResult = await listApiUserTeams()
+      const teamsResult = await listApiUserTeams();
 
       if (!teamsResult.ok) {
-        return teamsResult
+        return teamsResult;
       }
 
-      return ok(teamsResult.data)
+      return ok(teamsResult.data);
     },
     async bootstrapUser(): Promise<RepoResult<ResolvedTeam>> {
       if (!process.env.DASHBOARD_API_ADMIN_TOKEN) {
         return err(
           repoErrorFromHttp(
             500,
-            'DASHBOARD_API_ADMIN_TOKEN is not configured',
-            new Error('DASHBOARD_API_ADMIN_TOKEN is not configured')
-          )
-        )
+            "DASHBOARD_API_ADMIN_TOKEN is not configured",
+            new Error("DASHBOARD_API_ADMIN_TOKEN is not configured"),
+          ),
+        );
       }
 
       const { data, error, response } = await deps.apiClient.POST(
-        '/admin/users/bootstrap',
+        "/admin/users/bootstrap",
         {
-          headers: deps.adminHeaders(process.env.DASHBOARD_API_ADMIN_TOKEN),
-        }
-      )
+          headers: {
+            ...deps.adminHeaders(process.env.DASHBOARD_API_ADMIN_TOKEN),
+            ...deps.authHeaders(scope.accessToken),
+          },
+        },
+      );
 
       if (!response.ok || error || !data) {
         return err(
           repoErrorFromHttp(
             response.status,
-            error?.message ?? 'Failed to bootstrap user',
-            error
-          )
-        )
+            error?.message ?? "Failed to bootstrap user",
+            error,
+          ),
+        );
       }
 
       return ok({
         id: data.id,
         slug: data.slug,
-      })
+      });
     },
     async resolveTeamBySlug(
       slug: string,
-      next?: { tags?: string[] }
+      next?: { tags?: string[] },
     ): Promise<RepoResult<ResolvedTeam>> {
       const { data, error, response } = await deps.apiClient.GET(
-        '/teams/resolve',
+        "/teams/resolve",
         {
           params: { query: { slug } },
           headers: deps.authHeaders(scope.accessToken),
@@ -107,23 +110,23 @@ export function createUserTeamsRepository(
             revalidate: secondsInMinute * 5,
             ...next,
           },
-        }
-      )
+        },
+      );
 
       if (!response.ok || error || !data) {
         return err(
           repoErrorFromHttp(
             response.status,
-            error?.message ?? 'Failed to resolve team',
-            error
-          )
-        )
+            error?.message ?? "Failed to resolve team",
+            error,
+          ),
+        );
       }
 
       return ok({
         id: data.id,
         slug: data.slug,
-      })
+      });
     },
-  }
+  };
 }

--- a/src/core/modules/users/admin-repository.server.ts
+++ b/src/core/modules/users/admin-repository.server.ts
@@ -2,9 +2,9 @@ import 'server-only'
 
 import { ADMIN_AUTH_HEADERS } from '@/configs/api'
 import { api } from '@/core/shared/clients/api'
+import type { ResolvedTeam } from '@/core/modules/teams/models'
 import { repoErrorFromHttp } from '@/core/shared/errors'
 import { err, ok, type RepoResult } from '@/core/shared/result'
-import type { ResolvedTeam } from '../teams/models'
 
 type AdminUsersRepositoryDeps = {
   apiClient: typeof api

--- a/src/core/modules/users/admin-repository.server.ts
+++ b/src/core/modules/users/admin-repository.server.ts
@@ -1,8 +1,8 @@
 import 'server-only'
 
 import { ADMIN_AUTH_HEADERS } from '@/configs/api'
-import { api } from '@/core/shared/clients/api'
 import type { ResolvedTeam } from '@/core/modules/teams/models'
+import { api } from '@/core/shared/clients/api'
 import { repoErrorFromHttp } from '@/core/shared/errors'
 import { err, ok, type RepoResult } from '@/core/shared/result'
 

--- a/src/core/modules/users/admin-repository.server.ts
+++ b/src/core/modules/users/admin-repository.server.ts
@@ -1,0 +1,66 @@
+import 'server-only'
+
+import { ADMIN_AUTH_HEADERS } from '@/configs/api'
+import { api } from '@/core/shared/clients/api'
+import { repoErrorFromHttp } from '@/core/shared/errors'
+import { err, ok, type RepoResult } from '@/core/shared/result'
+import type { ResolvedTeam } from '../teams/models'
+
+type AdminUsersRepositoryDeps = {
+  apiClient: typeof api
+  adminHeaders: typeof ADMIN_AUTH_HEADERS
+  adminToken?: string
+}
+
+export interface AdminUsersRepository {
+  bootstrapUser(userId: string): Promise<RepoResult<ResolvedTeam>>
+}
+
+export function createAdminUsersRepository(
+  deps: AdminUsersRepositoryDeps = {
+    apiClient: api,
+    adminHeaders: ADMIN_AUTH_HEADERS,
+    adminToken: process.env.DASHBOARD_API_ADMIN_TOKEN,
+  }
+): AdminUsersRepository {
+  return {
+    async bootstrapUser(userId) {
+      if (!deps.adminToken) {
+        return err(
+          repoErrorFromHttp(
+            500,
+            'DASHBOARD_API_ADMIN_TOKEN is not configured',
+            new Error('DASHBOARD_API_ADMIN_TOKEN is not configured')
+          )
+        )
+      }
+
+      const { data, error, response } = await deps.apiClient.POST(
+        '/admin/users/{userId}/bootstrap',
+        {
+          params: {
+            path: {
+              userId,
+            },
+          },
+          headers: deps.adminHeaders(deps.adminToken),
+        }
+      )
+
+      if (!response.ok || error || !data) {
+        return err(
+          repoErrorFromHttp(
+            response.status,
+            error?.message ?? 'Failed to bootstrap user',
+            error
+          )
+        )
+      }
+
+      return ok({
+        id: data.id,
+        slug: data.slug,
+      })
+    },
+  }
+}

--- a/src/core/server/actions/team-actions.ts
+++ b/src/core/server/actions/team-actions.ts
@@ -6,8 +6,6 @@ import { after } from 'next/server'
 import { returnValidationErrors } from 'next-safe-action'
 import { z } from 'zod'
 import { zfd } from 'zod-form-data'
-import { SUPABASE_AUTH_HEADERS } from '@/configs/api'
-import type { CreateTeamsResponse } from '@/core/modules/billing/models'
 import {
   CreateTeamSchema,
   UpdateTeamNameSchema,
@@ -15,17 +13,19 @@ import {
 import { createTeamsRepository } from '@/core/modules/teams/teams-repository.server'
 import {
   authActionClient,
+  withAuthedRequestRepository,
   withTeamAuthedRequestRepository,
   withTeamSlugResolution,
 } from '@/core/server/actions/client'
-import {
-  handleDefaultInfraError,
-  returnServerError,
-} from '@/core/server/actions/utils'
 import { toActionErrorFromRepoError } from '@/core/server/adapters/errors'
 import { l, serializeErrorForLog } from '@/core/shared/clients/logger/logger'
 import { deleteFile, getFiles, uploadFile } from '@/core/shared/clients/storage'
 import { TeamSlugSchema } from '@/core/shared/schemas/team'
+
+const withAuthedTeamsRepository = withAuthedRequestRepository(
+  createTeamsRepository,
+  (teamsRepository) => ({ teamsRepository })
+)
 
 const withTeamsRepository = withTeamAuthedRequestRepository(
   createTeamsRepository,
@@ -95,33 +95,16 @@ export const removeTeamMemberAction = authActionClient
 export const createTeamAction = authActionClient
   .schema(CreateTeamSchema)
   .metadata({ actionName: 'createTeam' })
+  .use(withAuthedTeamsRepository)
   .action(async ({ parsedInput, ctx }) => {
     const { name } = parsedInput
-    const { session } = ctx
 
-    const response = await fetch(`${process.env.BILLING_API_URL}/teams`, {
-      method: 'POST',
-      headers: {
-        'Content-Type': 'application/json',
-        ...SUPABASE_AUTH_HEADERS(session.access_token),
-      },
-      body: JSON.stringify({ name }),
-    })
-
-    if (!response.ok) {
-      const status = response.status
-      const error = await response.json()
-
-      if (status === 400) {
-        return returnServerError(error?.message ?? 'Failed to create team')
-      }
-
-      return handleDefaultInfraError(status, error)
+    const result = await ctx.teamsRepository.createTeam(name)
+    if (!result.ok) {
+      return toActionErrorFromRepoError(result.error)
     }
 
-    const data = (await response.json()) as CreateTeamsResponse
-
-    return data
+    return result.data
   })
 
 const UploadTeamProfilePictureSchema = zfd.formData(

--- a/src/core/server/functions/team/resolve-user-team.ts
+++ b/src/core/server/functions/team/resolve-user-team.ts
@@ -1,8 +1,8 @@
 import 'server-only'
 
-import { ENABLE_USER_BOOTSTRAP } from '@/configs/flags'
 import { cookies } from 'next/headers'
 import { COOKIE_KEYS } from '@/configs/cookies'
+import { ENABLE_USER_BOOTSTRAP } from '@/configs/flags'
 import type { ResolvedTeam } from '@/core/modules/teams/models'
 import { createUserTeamsRepository } from '@/core/modules/teams/user-teams-repository.server'
 import { createAdminUsersRepository } from '@/core/modules/users/admin-repository.server'

--- a/src/core/server/functions/team/resolve-user-team.ts
+++ b/src/core/server/functions/team/resolve-user-team.ts
@@ -1,5 +1,6 @@
 import 'server-only'
 
+import { ENABLE_USER_BOOTSTRAP } from '@/configs/flags'
 import { cookies } from 'next/headers'
 import { COOKIE_KEYS } from '@/configs/cookies'
 import type { ResolvedTeam } from '@/core/modules/teams/models'
@@ -15,7 +16,6 @@ export async function resolveUserTeam(
   const userTeamsRepository = createUserTeamsRepository({
     accessToken,
   })
-  const adminUsersRepository = createAdminUsersRepository()
 
   const cookieTeamId = cookieStore.get(COOKIE_KEYS.SELECTED_TEAM_ID)?.value
   const cookieTeamSlug = cookieStore.get(COOKIE_KEYS.SELECTED_TEAM_SLUG)?.value
@@ -67,6 +67,11 @@ export async function resolveUserTeam(
   }
 
   if (teamsResult.data.length === 0) {
+    if (!ENABLE_USER_BOOTSTRAP) {
+      return null
+    }
+
+    const adminUsersRepository = createAdminUsersRepository()
     const bootstrapResult = await adminUsersRepository.bootstrapUser(userId)
 
     if (!bootstrapResult.ok) {

--- a/src/core/server/functions/team/resolve-user-team.ts
+++ b/src/core/server/functions/team/resolve-user-team.ts
@@ -4,15 +4,18 @@ import { cookies } from 'next/headers'
 import { COOKIE_KEYS } from '@/configs/cookies'
 import type { ResolvedTeam } from '@/core/modules/teams/models'
 import { createUserTeamsRepository } from '@/core/modules/teams/user-teams-repository.server'
+import { createAdminUsersRepository } from '@/core/modules/users/admin-repository.server'
 import { l } from '@/core/shared/clients/logger/logger'
 
 export async function resolveUserTeam(
+  userId: string,
   accessToken: string
 ): Promise<ResolvedTeam | null> {
   const cookieStore = await cookies()
   const userTeamsRepository = createUserTeamsRepository({
     accessToken,
   })
+  const adminUsersRepository = createAdminUsersRepository()
 
   const cookieTeamId = cookieStore.get(COOKIE_KEYS.SELECTED_TEAM_ID)?.value
   const cookieTeamSlug = cookieStore.get(COOKIE_KEYS.SELECTED_TEAM_SLUG)?.value
@@ -64,7 +67,7 @@ export async function resolveUserTeam(
   }
 
   if (teamsResult.data.length === 0) {
-    const bootstrapResult = await userTeamsRepository.bootstrapUser()
+    const bootstrapResult = await adminUsersRepository.bootstrapUser(userId)
 
     if (!bootstrapResult.ok) {
       l.error(

--- a/src/core/server/functions/team/resolve-user-team.ts
+++ b/src/core/server/functions/team/resolve-user-team.ts
@@ -10,7 +10,7 @@ export async function resolveUserTeam(
   accessToken: string
 ): Promise<ResolvedTeam | null> {
   const cookieStore = await cookies()
-  const teamsRepository = createUserTeamsRepository({
+  const userTeamsRepository = createUserTeamsRepository({
     accessToken,
   })
 
@@ -19,7 +19,7 @@ export async function resolveUserTeam(
 
   if (cookieTeamSlug) {
     const resolvedCookieTeam =
-      await teamsRepository.resolveTeamBySlug(cookieTeamSlug)
+      await userTeamsRepository.resolveTeamBySlug(cookieTeamSlug)
 
     if (resolvedCookieTeam.ok) {
       if (cookieTeamId && cookieTeamId !== resolvedCookieTeam.data.id) {
@@ -51,7 +51,7 @@ export async function resolveUserTeam(
     )
   }
 
-  const teamsResult = await teamsRepository.listUserTeams()
+  const teamsResult = await userTeamsRepository.listUserTeams()
 
   if (!teamsResult.ok) {
     l.error(
@@ -64,7 +64,19 @@ export async function resolveUserTeam(
   }
 
   if (teamsResult.data.length === 0) {
-    return null
+    const bootstrapResult = await userTeamsRepository.bootstrapUser()
+
+    if (!bootstrapResult.ok) {
+      l.error(
+        {
+          key: 'resolve_user_team:bootstrap_error',
+        },
+        'Failed to bootstrap user team'
+      )
+      return null
+    }
+
+    return bootstrapResult.data
   }
 
   const defaultTeam = teamsResult.data.find(

--- a/src/core/shared/contracts/dashboard-api.types.ts
+++ b/src/core/shared/contracts/dashboard-api.types.ts
@@ -4,866 +4,868 @@
  */
 
 export interface paths {
-  '/health': {
-    parameters: {
-      query?: never
-      header?: never
-      path?: never
-      cookie?: never
-    }
-    /** Health check */
-    get: {
-      parameters: {
-        query?: never
-        header?: never
-        path?: never
-        cookie?: never
-      }
-      requestBody?: never
-      responses: {
-        /** @description Health check successful */
-        200: {
-          headers: {
-            [name: string]: unknown
-          }
-          content: {
-            'application/json': components['schemas']['HealthResponse']
-          }
-        }
-      }
-    }
-    put?: never
-    post?: never
-    delete?: never
-    options?: never
-    head?: never
-    patch?: never
-    trace?: never
-  }
-  '/builds': {
-    parameters: {
-      query?: never
-      header?: never
-      path?: never
-      cookie?: never
-    }
-    /** List team builds */
-    get: {
-      parameters: {
-        query?: {
-          /** @description Optional filter by build identifier, template identifier, or template alias. */
-          build_id_or_template?: components['parameters']['build_id_or_template']
-          /** @description Comma-separated list of build statuses to include. */
-          statuses?: components['parameters']['build_statuses']
-          /** @description Maximum number of items to return per page. */
-          limit?: components['parameters']['builds_limit']
-          /** @description Cursor returned by the previous list response in `created_at|build_id` format. */
-          cursor?: components['parameters']['builds_cursor']
-        }
-        header?: never
-        path?: never
-        cookie?: never
-      }
-      requestBody?: never
-      responses: {
-        /** @description Successfully returned paginated builds. */
-        200: {
-          headers: {
-            [name: string]: unknown
-          }
-          content: {
-            'application/json': components['schemas']['BuildsListResponse']
-          }
-        }
-        400: components['responses']['400']
-        401: components['responses']['401']
-        403: components['responses']['403']
-        500: components['responses']['500']
-      }
-    }
-    put?: never
-    post?: never
-    delete?: never
-    options?: never
-    head?: never
-    patch?: never
-    trace?: never
-  }
-  '/builds/statuses': {
-    parameters: {
-      query?: never
-      header?: never
-      path?: never
-      cookie?: never
-    }
-    /** Get build statuses */
-    get: {
-      parameters: {
-        query: {
-          /** @description Comma-separated list of build IDs to get statuses for. */
-          build_ids: components['parameters']['build_ids']
-        }
-        header?: never
-        path?: never
-        cookie?: never
-      }
-      requestBody?: never
-      responses: {
-        /** @description Successfully returned build statuses */
-        200: {
-          headers: {
-            [name: string]: unknown
-          }
-          content: {
-            'application/json': components['schemas']['BuildsStatusesResponse']
-          }
-        }
-        400: components['responses']['400']
-        401: components['responses']['401']
-        403: components['responses']['403']
-        500: components['responses']['500']
-      }
-    }
-    put?: never
-    post?: never
-    delete?: never
-    options?: never
-    head?: never
-    patch?: never
-    trace?: never
-  }
-  '/builds/{build_id}': {
-    parameters: {
-      query?: never
-      header?: never
-      path?: never
-      cookie?: never
-    }
-    /** Get build details */
-    get: {
-      parameters: {
-        query?: never
-        header?: never
-        path: {
-          /** @description Identifier of the build. */
-          build_id: components['parameters']['build_id']
-        }
-        cookie?: never
-      }
-      requestBody?: never
-      responses: {
-        /** @description Successfully returned build details. */
-        200: {
-          headers: {
-            [name: string]: unknown
-          }
-          content: {
-            'application/json': components['schemas']['BuildInfo']
-          }
-        }
-        401: components['responses']['401']
-        403: components['responses']['403']
-        404: components['responses']['404']
-        500: components['responses']['500']
-      }
-    }
-    put?: never
-    post?: never
-    delete?: never
-    options?: never
-    head?: never
-    patch?: never
-    trace?: never
-  }
-  '/sandboxes/{sandboxID}/record': {
-    parameters: {
-      query?: never
-      header?: never
-      path?: never
-      cookie?: never
-    }
-    /** Get sandbox record */
-    get: {
-      parameters: {
-        query?: never
-        header?: never
-        path: {
-          /** @description Identifier of the sandbox. */
-          sandboxID: components['parameters']['sandboxID']
-        }
-        cookie?: never
-      }
-      requestBody?: never
-      responses: {
-        /** @description Successfully returned sandbox details. */
-        200: {
-          headers: {
-            [name: string]: unknown
-          }
-          content: {
-            'application/json': components['schemas']['SandboxRecord']
-          }
-        }
-        401: components['responses']['401']
-        403: components['responses']['403']
-        404: components['responses']['404']
-        500: components['responses']['500']
-      }
-    }
-    put?: never
-    post?: never
-    delete?: never
-    options?: never
-    head?: never
-    patch?: never
-    trace?: never
-  }
-  '/teams': {
-    parameters: {
-      query?: never
-      header?: never
-      path?: never
-      cookie?: never
-    }
-    /**
-     * List user teams
-     * @description Returns all teams the authenticated user belongs to, with limits and default flag.
-     */
-    get: {
-      parameters: {
-        query?: never
-        header?: never
-        path?: never
-        cookie?: never
-      }
-      requestBody?: never
-      responses: {
-        /** @description Successfully returned user teams. */
-        200: {
-          headers: {
-            [name: string]: unknown
-          }
-          content: {
-            'application/json': components['schemas']['UserTeamsResponse']
-          }
-        }
-        401: components['responses']['401']
-        500: components['responses']['500']
-      }
-    }
-    put?: never
-    /** Create team */
-    post: {
-      parameters: {
-        query?: never
-        header?: never
-        path?: never
-        cookie?: never
-      }
-      requestBody: {
-        content: {
-          'application/json': components['schemas']['CreateTeamRequest']
-        }
-      }
-      responses: {
-        /** @description Successfully created team. */
-        200: {
-          headers: {
-            [name: string]: unknown
-          }
-          content: {
-            'application/json': components['schemas']['TeamResolveResponse']
-          }
-        }
-        400: components['responses']['400']
-        401: components['responses']['401']
-        500: components['responses']['500']
-      }
-    }
-    delete?: never
-    options?: never
-    head?: never
-    patch?: never
-    trace?: never
-  }
-  '/users/bootstrap': {
-    parameters: {
-      query?: never
-      header?: never
-      path?: never
-      cookie?: never
-    }
-    get?: never
-    put?: never
-    /** Bootstrap user */
-    post: {
-      parameters: {
-        query?: never
-        header?: never
-        path?: never
-        cookie?: never
-      }
-      requestBody?: never
-      responses: {
-        /** @description Successfully bootstrapped user. */
-        200: {
-          headers: {
-            [name: string]: unknown
-          }
-          content: {
-            'application/json': components['schemas']['TeamResolveResponse']
-          }
-        }
-        401: components['responses']['401']
-        500: components['responses']['500']
-      }
-    }
-    delete?: never
-    options?: never
-    head?: never
-    patch?: never
-    trace?: never
-  }
-  '/teams/resolve': {
-    parameters: {
-      query?: never
-      header?: never
-      path?: never
-      cookie?: never
-    }
-    /**
-     * Resolve team identity
-     * @description Resolves a team slug to the team's identity, validating the user is a member.
-     */
-    get: {
-      parameters: {
-        query: {
-          /** @description Team slug to resolve. */
-          slug: components['parameters']['teamSlug']
-        }
-        header?: never
-        path?: never
-        cookie?: never
-      }
-      requestBody?: never
-      responses: {
-        /** @description Successfully resolved team. */
-        200: {
-          headers: {
-            [name: string]: unknown
-          }
-          content: {
-            'application/json': components['schemas']['TeamResolveResponse']
-          }
-        }
-        401: components['responses']['401']
-        403: components['responses']['403']
-        404: components['responses']['404']
-        500: components['responses']['500']
-      }
-    }
-    put?: never
-    post?: never
-    delete?: never
-    options?: never
-    head?: never
-    patch?: never
-    trace?: never
-  }
-  '/teams/{teamID}': {
-    parameters: {
-      query?: never
-      header?: never
-      path?: never
-      cookie?: never
-    }
-    get?: never
-    put?: never
-    post?: never
-    delete?: never
-    options?: never
-    head?: never
-    /** Update team */
-    patch: {
-      parameters: {
-        query?: never
-        header?: never
-        path: {
-          /** @description Identifier of the team. */
-          teamID: components['parameters']['teamID']
-        }
-        cookie?: never
-      }
-      requestBody: {
-        content: {
-          'application/json': components['schemas']['UpdateTeamRequest']
-        }
-      }
-      responses: {
-        /** @description Successfully updated team. */
-        200: {
-          headers: {
-            [name: string]: unknown
-          }
-          content: {
-            'application/json': components['schemas']['UpdateTeamResponse']
-          }
-        }
-        400: components['responses']['400']
-        401: components['responses']['401']
-        403: components['responses']['403']
-        500: components['responses']['500']
-      }
-    }
-    trace?: never
-  }
-  '/teams/{teamID}/members': {
-    parameters: {
-      query?: never
-      header?: never
-      path?: never
-      cookie?: never
-    }
-    /** List team members */
-    get: {
-      parameters: {
-        query?: never
-        header?: never
-        path: {
-          /** @description Identifier of the team. */
-          teamID: components['parameters']['teamID']
-        }
-        cookie?: never
-      }
-      requestBody?: never
-      responses: {
-        /** @description Successfully returned team members. */
-        200: {
-          headers: {
-            [name: string]: unknown
-          }
-          content: {
-            'application/json': components['schemas']['TeamMembersResponse']
-          }
-        }
-        401: components['responses']['401']
-        403: components['responses']['403']
-        500: components['responses']['500']
-      }
-    }
-    put?: never
-    /** Add team member */
-    post: {
-      parameters: {
-        query?: never
-        header?: never
-        path: {
-          /** @description Identifier of the team. */
-          teamID: components['parameters']['teamID']
-        }
-        cookie?: never
-      }
-      requestBody: {
-        content: {
-          'application/json': components['schemas']['AddTeamMemberRequest']
-        }
-      }
-      responses: {
-        /** @description Successfully added team member. */
-        201: {
-          headers: {
-            [name: string]: unknown
-          }
-          content?: never
-        }
-        400: components['responses']['400']
-        401: components['responses']['401']
-        403: components['responses']['403']
-        404: components['responses']['404']
-        500: components['responses']['500']
-      }
-    }
-    delete?: never
-    options?: never
-    head?: never
-    patch?: never
-    trace?: never
-  }
-  '/teams/{teamID}/members/{userId}': {
-    parameters: {
-      query?: never
-      header?: never
-      path?: never
-      cookie?: never
-    }
-    get?: never
-    put?: never
-    post?: never
-    /** Remove team member */
-    delete: {
-      parameters: {
-        query?: never
-        header?: never
-        path: {
-          /** @description Identifier of the team. */
-          teamID: components['parameters']['teamID']
-          /** @description Identifier of the user. */
-          userId: components['parameters']['userId']
-        }
-        cookie?: never
-      }
-      requestBody?: never
-      responses: {
-        /** @description Successfully removed team member. */
-        204: {
-          headers: {
-            [name: string]: unknown
-          }
-          content?: never
-        }
-        400: components['responses']['400']
-        401: components['responses']['401']
-        403: components['responses']['403']
-        500: components['responses']['500']
-      }
-    }
-    options?: never
-    head?: never
-    patch?: never
-    trace?: never
-  }
-  '/templates/defaults': {
-    parameters: {
-      query?: never
-      header?: never
-      path?: never
-      cookie?: never
-    }
-    /**
-     * List default templates
-     * @description Returns the list of default templates with their latest build info and aliases.
-     */
-    get: {
-      parameters: {
-        query?: never
-        header?: never
-        path?: never
-        cookie?: never
-      }
-      requestBody?: never
-      responses: {
-        /** @description Successfully returned default templates. */
-        200: {
-          headers: {
-            [name: string]: unknown
-          }
-          content: {
-            'application/json': components['schemas']['DefaultTemplatesResponse']
-          }
-        }
-        401: components['responses']['401']
-        500: components['responses']['500']
-      }
-    }
-    put?: never
-    post?: never
-    delete?: never
-    options?: never
-    head?: never
-    patch?: never
-    trace?: never
-  }
+    "/health": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Health check */
+        get: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description Health check successful */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["HealthResponse"];
+                    };
+                };
+            };
+        };
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/builds": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** List team builds */
+        get: {
+            parameters: {
+                query?: {
+                    /** @description Optional filter by build identifier, template identifier, or template alias. */
+                    build_id_or_template?: components["parameters"]["build_id_or_template"];
+                    /** @description Comma-separated list of build statuses to include. */
+                    statuses?: components["parameters"]["build_statuses"];
+                    /** @description Maximum number of items to return per page. */
+                    limit?: components["parameters"]["builds_limit"];
+                    /** @description Cursor returned by the previous list response in `created_at|build_id` format. */
+                    cursor?: components["parameters"]["builds_cursor"];
+                };
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description Successfully returned paginated builds. */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["BuildsListResponse"];
+                    };
+                };
+                400: components["responses"]["400"];
+                401: components["responses"]["401"];
+                403: components["responses"]["403"];
+                500: components["responses"]["500"];
+            };
+        };
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/builds/statuses": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Get build statuses */
+        get: {
+            parameters: {
+                query: {
+                    /** @description Comma-separated list of build IDs to get statuses for. */
+                    build_ids: components["parameters"]["build_ids"];
+                };
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description Successfully returned build statuses */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["BuildsStatusesResponse"];
+                    };
+                };
+                400: components["responses"]["400"];
+                401: components["responses"]["401"];
+                403: components["responses"]["403"];
+                500: components["responses"]["500"];
+            };
+        };
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/builds/{build_id}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Get build details */
+        get: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path: {
+                    /** @description Identifier of the build. */
+                    build_id: components["parameters"]["build_id"];
+                };
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description Successfully returned build details. */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["BuildInfo"];
+                    };
+                };
+                401: components["responses"]["401"];
+                403: components["responses"]["403"];
+                404: components["responses"]["404"];
+                500: components["responses"]["500"];
+            };
+        };
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/sandboxes/{sandboxID}/record": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Get sandbox record */
+        get: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path: {
+                    /** @description Identifier of the sandbox. */
+                    sandboxID: components["parameters"]["sandboxID"];
+                };
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description Successfully returned sandbox details. */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["SandboxRecord"];
+                    };
+                };
+                401: components["responses"]["401"];
+                403: components["responses"]["403"];
+                404: components["responses"]["404"];
+                500: components["responses"]["500"];
+            };
+        };
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/teams": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * List user teams
+         * @description Returns all teams the authenticated user belongs to, with limits and default flag.
+         */
+        get: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description Successfully returned user teams. */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["UserTeamsResponse"];
+                    };
+                };
+                401: components["responses"]["401"];
+                500: components["responses"]["500"];
+            };
+        };
+        put?: never;
+        /** Create team */
+        post: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody: {
+                content: {
+                    "application/json": components["schemas"]["CreateTeamRequest"];
+                };
+            };
+            responses: {
+                /** @description Successfully created team. */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["TeamResolveResponse"];
+                    };
+                };
+                400: components["responses"]["400"];
+                401: components["responses"]["401"];
+                500: components["responses"]["500"];
+            };
+        };
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/admin/users/bootstrap": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /** Bootstrap user */
+        post: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description Successfully bootstrapped user. */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["TeamResolveResponse"];
+                    };
+                };
+                401: components["responses"]["401"];
+                500: components["responses"]["500"];
+            };
+        };
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/teams/resolve": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Resolve team identity
+         * @description Resolves a team slug to the team's identity, validating the user is a member.
+         */
+        get: {
+            parameters: {
+                query: {
+                    /** @description Team slug to resolve. */
+                    slug: components["parameters"]["teamSlug"];
+                };
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description Successfully resolved team. */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["TeamResolveResponse"];
+                    };
+                };
+                401: components["responses"]["401"];
+                403: components["responses"]["403"];
+                404: components["responses"]["404"];
+                500: components["responses"]["500"];
+            };
+        };
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/teams/{teamID}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        /** Update team */
+        patch: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path: {
+                    /** @description Identifier of the team. */
+                    teamID: components["parameters"]["teamID"];
+                };
+                cookie?: never;
+            };
+            requestBody: {
+                content: {
+                    "application/json": components["schemas"]["UpdateTeamRequest"];
+                };
+            };
+            responses: {
+                /** @description Successfully updated team. */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["UpdateTeamResponse"];
+                    };
+                };
+                400: components["responses"]["400"];
+                401: components["responses"]["401"];
+                403: components["responses"]["403"];
+                500: components["responses"]["500"];
+            };
+        };
+        trace?: never;
+    };
+    "/teams/{teamID}/members": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** List team members */
+        get: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path: {
+                    /** @description Identifier of the team. */
+                    teamID: components["parameters"]["teamID"];
+                };
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description Successfully returned team members. */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["TeamMembersResponse"];
+                    };
+                };
+                401: components["responses"]["401"];
+                403: components["responses"]["403"];
+                500: components["responses"]["500"];
+            };
+        };
+        put?: never;
+        /** Add team member */
+        post: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path: {
+                    /** @description Identifier of the team. */
+                    teamID: components["parameters"]["teamID"];
+                };
+                cookie?: never;
+            };
+            requestBody: {
+                content: {
+                    "application/json": components["schemas"]["AddTeamMemberRequest"];
+                };
+            };
+            responses: {
+                /** @description Successfully added team member. */
+                201: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+                400: components["responses"]["400"];
+                401: components["responses"]["401"];
+                403: components["responses"]["403"];
+                404: components["responses"]["404"];
+                500: components["responses"]["500"];
+            };
+        };
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/teams/{teamID}/members/{userId}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        post?: never;
+        /** Remove team member */
+        delete: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path: {
+                    /** @description Identifier of the team. */
+                    teamID: components["parameters"]["teamID"];
+                    /** @description Identifier of the user. */
+                    userId: components["parameters"]["userId"];
+                };
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description Successfully removed team member. */
+                204: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+                400: components["responses"]["400"];
+                401: components["responses"]["401"];
+                403: components["responses"]["403"];
+                500: components["responses"]["500"];
+            };
+        };
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/templates/defaults": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * List default templates
+         * @description Returns the list of default templates with their latest build info and aliases.
+         */
+        get: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description Successfully returned default templates. */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["DefaultTemplatesResponse"];
+                    };
+                };
+                401: components["responses"]["401"];
+                500: components["responses"]["500"];
+            };
+        };
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
 }
-export type webhooks = Record<string, never>
+export type webhooks = Record<string, never>;
 export interface components {
-  schemas: {
-    Error: {
-      /**
-       * Format: int32
-       * @description Error code.
-       */
-      code: number
-      /** @description Error message. */
-      message: string
-    }
-    /**
-     * @description Build status mapped for dashboard clients.
-     * @enum {string}
-     */
-    BuildStatus: 'building' | 'failed' | 'success'
-    ListedBuild: {
-      /**
-       * Format: uuid
-       * @description Identifier of the build.
-       */
-      id: string
-      /** @description Template alias when present, otherwise template ID. */
-      template: string
-      /** @description Identifier of the template. */
-      templateId: string
-      status: components['schemas']['BuildStatus']
-      /** @description Failure message when status is `failed`, otherwise `null`. */
-      statusMessage: string | null
-      /**
-       * Format: date-time
-       * @description Build creation timestamp in RFC3339 format.
-       */
-      createdAt: string
-      /**
-       * Format: date-time
-       * @description Build completion timestamp in RFC3339 format, if finished.
-       */
-      finishedAt: string | null
-    }
-    BuildsListResponse: {
-      data: components['schemas']['ListedBuild'][]
-      /** @description Cursor to pass to the next list request, or `null` if there is no next page. */
-      nextCursor: string | null
-    }
-    BuildStatusItem: {
-      /**
-       * Format: uuid
-       * @description Identifier of the build.
-       */
-      id: string
-      status: components['schemas']['BuildStatus']
-      /**
-       * Format: date-time
-       * @description Build completion timestamp in RFC3339 format, if finished.
-       */
-      finishedAt: string | null
-      /** @description Failure message when status is `failed`, otherwise `null`. */
-      statusMessage: string | null
-    }
-    BuildsStatusesResponse: {
-      /** @description List of build statuses */
-      buildStatuses: components['schemas']['BuildStatusItem'][]
-    }
-    BuildInfo: {
-      /** @description Template names related to this build, if available. */
-      names?: string[] | null
-      /**
-       * Format: date-time
-       * @description Build creation timestamp in RFC3339 format.
-       */
-      createdAt: string
-      /**
-       * Format: date-time
-       * @description Build completion timestamp in RFC3339 format, if finished.
-       */
-      finishedAt: string | null
-      status: components['schemas']['BuildStatus']
-      /** @description Failure message when status is `failed`, otherwise `null`. */
-      statusMessage: string | null
-    }
-    /**
-     * Format: int64
-     * @description CPU cores for the sandbox
-     */
-    CPUCount: number
-    /**
-     * Format: int64
-     * @description Memory for the sandbox in MiB
-     */
-    MemoryMB: number
-    /**
-     * Format: int64
-     * @description Disk size for the sandbox in MiB
-     */
-    DiskSizeMB: number
-    SandboxRecord: {
-      /** @description Identifier of the template from which is the sandbox created */
-      templateID: string
-      /** @description Alias of the template */
-      alias?: string
-      /** @description Identifier of the sandbox */
-      sandboxID: string
-      /**
-       * Format: date-time
-       * @description Time when the sandbox was started
-       */
-      startedAt: string
-      /**
-       * Format: date-time
-       * @description Time when the sandbox was stopped
-       */
-      stoppedAt?: string | null
-      /** @description Base domain where the sandbox traffic is accessible */
-      domain?: string | null
-      cpuCount: components['schemas']['CPUCount']
-      memoryMB: components['schemas']['MemoryMB']
-      diskSizeMB: components['schemas']['DiskSizeMB']
-    }
-    HealthResponse: {
-      /** @description Human-readable health check result. */
-      message: string
-    }
-    UserTeamLimits: {
-      /** Format: int64 */
-      maxLengthHours: number
-      /** Format: int32 */
-      concurrentSandboxes: number
-      /** Format: int32 */
-      concurrentTemplateBuilds: number
-      /** Format: int32 */
-      maxVcpu: number
-      /** Format: int32 */
-      maxRamMb: number
-      /** Format: int32 */
-      diskMb: number
-    }
-    UserTeam: {
-      /** Format: uuid */
-      id: string
-      name: string
-      slug: string
-      tier: string
-      email: string
-      profilePictureUrl: string | null
-      isBlocked: boolean
-      isBanned: boolean
-      blockedReason: string | null
-      isDefault: boolean
-      limits: components['schemas']['UserTeamLimits']
-    }
-    UserTeamsResponse: {
-      teams: components['schemas']['UserTeam'][]
-    }
-    TeamMember: {
-      /** Format: uuid */
-      id: string
-      email: string
-      isDefault: boolean
-      /** Format: uuid */
-      addedBy?: string | null
-      /** Format: date-time */
-      createdAt: string | null
-    }
-    TeamMembersResponse: {
-      members: components['schemas']['TeamMember'][]
-    }
-    UpdateTeamRequest: {
-      name?: string
-      profilePictureUrl?: string | null
-    }
-    UpdateTeamResponse: {
-      /** Format: uuid */
-      id: string
-      name: string
-      profilePictureUrl?: string | null
-    }
-    AddTeamMemberRequest: {
-      /** Format: email */
-      email: string
-    }
-    CreateTeamRequest: {
-      name: string
-    }
-    DefaultTemplateAlias: {
-      alias: string
-      namespace?: string | null
-    }
-    DefaultTemplate: {
-      id: string
-      aliases: components['schemas']['DefaultTemplateAlias'][]
-      /** Format: uuid */
-      buildId: string
-      /** Format: int64 */
-      ramMb: number
-      /** Format: int64 */
-      vcpu: number
-      /** Format: int64 */
-      totalDiskSizeMb: number | null
-      envdVersion?: string | null
-      /** Format: date-time */
-      createdAt: string
-      public: boolean
-      /** Format: int32 */
-      buildCount: number
-      /** Format: int64 */
-      spawnCount: number
-    }
-    DefaultTemplatesResponse: {
-      templates: components['schemas']['DefaultTemplate'][]
-    }
-    TeamResolveResponse: {
-      /** Format: uuid */
-      id: string
-      slug: string
-    }
-  }
-  responses: {
-    /** @description Bad request */
-    400: {
-      headers: {
-        [name: string]: unknown
-      }
-      content: {
-        'application/json': components['schemas']['Error']
-      }
-    }
-    /** @description Authentication error */
-    401: {
-      headers: {
-        [name: string]: unknown
-      }
-      content: {
-        'application/json': components['schemas']['Error']
-      }
-    }
-    /** @description Forbidden */
-    403: {
-      headers: {
-        [name: string]: unknown
-      }
-      content: {
-        'application/json': components['schemas']['Error']
-      }
-    }
-    /** @description Not found */
-    404: {
-      headers: {
-        [name: string]: unknown
-      }
-      content: {
-        'application/json': components['schemas']['Error']
-      }
-    }
-    /** @description Server error */
-    500: {
-      headers: {
-        [name: string]: unknown
-      }
-      content: {
-        'application/json': components['schemas']['Error']
-      }
-    }
-  }
-  parameters: {
-    /** @description Identifier of the build. */
-    build_id: string
-    /** @description Identifier of the sandbox. */
-    sandboxID: string
-    /** @description Maximum number of items to return per page. */
-    builds_limit: number
-    /** @description Cursor returned by the previous list response in `created_at|build_id` format. */
-    builds_cursor: string
-    /** @description Optional filter by build identifier, template identifier, or template alias. */
-    build_id_or_template: string
-    /** @description Comma-separated list of build statuses to include. */
-    build_statuses: components['schemas']['BuildStatus'][]
-    /** @description Comma-separated list of build IDs to get statuses for. */
-    build_ids: string[]
-    /** @description Identifier of the team. */
-    teamID: string
-    /** @description Identifier of the user. */
-    userId: string
-    /** @description Team slug to resolve. */
-    teamSlug: string
-  }
-  requestBodies: never
-  headers: never
-  pathItems: never
+    schemas: {
+        Error: {
+            /**
+             * Format: int32
+             * @description Error code.
+             */
+            code: number;
+            /** @description Error message. */
+            message: string;
+        };
+        /**
+         * @description Build status mapped for dashboard clients.
+         * @enum {string}
+         */
+        BuildStatus: "building" | "failed" | "success";
+        ListedBuild: {
+            /**
+             * Format: uuid
+             * @description Identifier of the build.
+             */
+            id: string;
+            /** @description Template alias when present, otherwise template ID. */
+            template: string;
+            /** @description Identifier of the template. */
+            templateId: string;
+            status: components["schemas"]["BuildStatus"];
+            /** @description Failure message when status is `failed`, otherwise `null`. */
+            statusMessage: string | null;
+            /**
+             * Format: date-time
+             * @description Build creation timestamp in RFC3339 format.
+             */
+            createdAt: string;
+            /**
+             * Format: date-time
+             * @description Build completion timestamp in RFC3339 format, if finished.
+             */
+            finishedAt: string | null;
+        };
+        BuildsListResponse: {
+            data: components["schemas"]["ListedBuild"][];
+            /** @description Cursor to pass to the next list request, or `null` if there is no next page. */
+            nextCursor: string | null;
+        };
+        BuildStatusItem: {
+            /**
+             * Format: uuid
+             * @description Identifier of the build.
+             */
+            id: string;
+            status: components["schemas"]["BuildStatus"];
+            /**
+             * Format: date-time
+             * @description Build completion timestamp in RFC3339 format, if finished.
+             */
+            finishedAt: string | null;
+            /** @description Failure message when status is `failed`, otherwise `null`. */
+            statusMessage: string | null;
+        };
+        BuildsStatusesResponse: {
+            /** @description List of build statuses */
+            buildStatuses: components["schemas"]["BuildStatusItem"][];
+        };
+        BuildInfo: {
+            /** @description Template names related to this build, if available. */
+            names?: string[] | null;
+            /**
+             * Format: date-time
+             * @description Build creation timestamp in RFC3339 format.
+             */
+            createdAt: string;
+            /**
+             * Format: date-time
+             * @description Build completion timestamp in RFC3339 format, if finished.
+             */
+            finishedAt: string | null;
+            status: components["schemas"]["BuildStatus"];
+            /** @description Failure message when status is `failed`, otherwise `null`. */
+            statusMessage: string | null;
+        };
+        /**
+         * Format: int64
+         * @description CPU cores for the sandbox
+         */
+        CPUCount: number;
+        /**
+         * Format: int64
+         * @description Memory for the sandbox in MiB
+         */
+        MemoryMB: number;
+        /**
+         * Format: int64
+         * @description Disk size for the sandbox in MiB
+         */
+        DiskSizeMB: number;
+        SandboxRecord: {
+            /** @description Identifier of the template from which is the sandbox created */
+            templateID: string;
+            /** @description Alias of the template */
+            alias?: string;
+            /** @description Identifier of the sandbox */
+            sandboxID: string;
+            /**
+             * Format: date-time
+             * @description Time when the sandbox was started
+             */
+            startedAt: string;
+            /**
+             * Format: date-time
+             * @description Time when the sandbox was stopped
+             */
+            stoppedAt?: string | null;
+            /** @description Base domain where the sandbox traffic is accessible */
+            domain?: string | null;
+            cpuCount: components["schemas"]["CPUCount"];
+            memoryMB: components["schemas"]["MemoryMB"];
+            diskSizeMB: components["schemas"]["DiskSizeMB"];
+        };
+        HealthResponse: {
+            /** @description Human-readable health check result. */
+            message: string;
+        };
+        UserTeamLimits: {
+            /** Format: int64 */
+            maxLengthHours: number;
+            /** Format: int32 */
+            concurrentSandboxes: number;
+            /** Format: int32 */
+            concurrentTemplateBuilds: number;
+            /** Format: int32 */
+            maxVcpu: number;
+            /** Format: int32 */
+            maxRamMb: number;
+            /** Format: int32 */
+            diskMb: number;
+        };
+        UserTeam: {
+            /** Format: uuid */
+            id: string;
+            name: string;
+            slug: string;
+            tier: string;
+            email: string;
+            profilePictureUrl: string | null;
+            isBlocked: boolean;
+            isBanned: boolean;
+            blockedReason: string | null;
+            isDefault: boolean;
+            limits: components["schemas"]["UserTeamLimits"];
+            /** Format: date-time */
+            createdAt: string;
+        };
+        UserTeamsResponse: {
+            teams: components["schemas"]["UserTeam"][];
+        };
+        TeamMember: {
+            /** Format: uuid */
+            id: string;
+            email: string;
+            isDefault: boolean;
+            /** Format: uuid */
+            addedBy?: string | null;
+            /** Format: date-time */
+            createdAt: string | null;
+        };
+        TeamMembersResponse: {
+            members: components["schemas"]["TeamMember"][];
+        };
+        UpdateTeamRequest: {
+            name?: string;
+            profilePictureUrl?: string | null;
+        };
+        UpdateTeamResponse: {
+            /** Format: uuid */
+            id: string;
+            name: string;
+            profilePictureUrl?: string | null;
+        };
+        AddTeamMemberRequest: {
+            /** Format: email */
+            email: string;
+        };
+        CreateTeamRequest: {
+            name: string;
+        };
+        DefaultTemplateAlias: {
+            alias: string;
+            namespace?: string | null;
+        };
+        DefaultTemplate: {
+            id: string;
+            aliases: components["schemas"]["DefaultTemplateAlias"][];
+            /** Format: uuid */
+            buildId: string;
+            /** Format: int64 */
+            ramMb: number;
+            /** Format: int64 */
+            vcpu: number;
+            /** Format: int64 */
+            totalDiskSizeMb: number | null;
+            envdVersion?: string | null;
+            /** Format: date-time */
+            createdAt: string;
+            public: boolean;
+            /** Format: int32 */
+            buildCount: number;
+            /** Format: int64 */
+            spawnCount: number;
+        };
+        DefaultTemplatesResponse: {
+            templates: components["schemas"]["DefaultTemplate"][];
+        };
+        TeamResolveResponse: {
+            /** Format: uuid */
+            id: string;
+            slug: string;
+        };
+    };
+    responses: {
+        /** @description Bad request */
+        400: {
+            headers: {
+                [name: string]: unknown;
+            };
+            content: {
+                "application/json": components["schemas"]["Error"];
+            };
+        };
+        /** @description Authentication error */
+        401: {
+            headers: {
+                [name: string]: unknown;
+            };
+            content: {
+                "application/json": components["schemas"]["Error"];
+            };
+        };
+        /** @description Forbidden */
+        403: {
+            headers: {
+                [name: string]: unknown;
+            };
+            content: {
+                "application/json": components["schemas"]["Error"];
+            };
+        };
+        /** @description Not found */
+        404: {
+            headers: {
+                [name: string]: unknown;
+            };
+            content: {
+                "application/json": components["schemas"]["Error"];
+            };
+        };
+        /** @description Server error */
+        500: {
+            headers: {
+                [name: string]: unknown;
+            };
+            content: {
+                "application/json": components["schemas"]["Error"];
+            };
+        };
+    };
+    parameters: {
+        /** @description Identifier of the build. */
+        build_id: string;
+        /** @description Identifier of the sandbox. */
+        sandboxID: string;
+        /** @description Maximum number of items to return per page. */
+        builds_limit: number;
+        /** @description Cursor returned by the previous list response in `created_at|build_id` format. */
+        builds_cursor: string;
+        /** @description Optional filter by build identifier, template identifier, or template alias. */
+        build_id_or_template: string;
+        /** @description Comma-separated list of build statuses to include. */
+        build_statuses: components["schemas"]["BuildStatus"][];
+        /** @description Comma-separated list of build IDs to get statuses for. */
+        build_ids: string[];
+        /** @description Identifier of the team. */
+        teamID: string;
+        /** @description Identifier of the user. */
+        userId: string;
+        /** @description Team slug to resolve. */
+        teamSlug: string;
+    };
+    requestBodies: never;
+    headers: never;
+    pathItems: never;
 }
-export type $defs = Record<string, never>
-export type operations = Record<string, never>
+export type $defs = Record<string, never>;
+export type operations = Record<string, never>;

--- a/src/core/shared/contracts/dashboard-api.types.ts
+++ b/src/core/shared/contracts/dashboard-api.types.ts
@@ -252,7 +252,72 @@ export interface paths {
       }
     }
     put?: never
-    post?: never
+    /** Create team */
+    post: {
+      parameters: {
+        query?: never
+        header?: never
+        path?: never
+        cookie?: never
+      }
+      requestBody: {
+        content: {
+          'application/json': components['schemas']['CreateTeamRequest']
+        }
+      }
+      responses: {
+        /** @description Successfully created team. */
+        200: {
+          headers: {
+            [name: string]: unknown
+          }
+          content: {
+            'application/json': components['schemas']['TeamResolveResponse']
+          }
+        }
+        400: components['responses']['400']
+        401: components['responses']['401']
+        500: components['responses']['500']
+      }
+    }
+    delete?: never
+    options?: never
+    head?: never
+    patch?: never
+    trace?: never
+  }
+  '/users/bootstrap': {
+    parameters: {
+      query?: never
+      header?: never
+      path?: never
+      cookie?: never
+    }
+    get?: never
+    put?: never
+    /** Bootstrap user */
+    post: {
+      parameters: {
+        query?: never
+        header?: never
+        path?: never
+        cookie?: never
+      }
+      requestBody?: never
+      responses: {
+        /** @description Successfully bootstrapped user. */
+        200: {
+          headers: {
+            [name: string]: unknown
+          }
+          content: {
+            'application/json': components['schemas']['TeamResolveResponse']
+          }
+        }
+        401: components['responses']['401']
+        500: components['responses']['500']
+      }
+    }
     delete?: never
     options?: never
     head?: never
@@ -690,6 +755,9 @@ export interface components {
     AddTeamMemberRequest: {
       /** Format: email */
       email: string
+    }
+    CreateTeamRequest: {
+      name: string
     }
     DefaultTemplateAlias: {
       alias: string

--- a/src/core/shared/contracts/dashboard-api.types.ts
+++ b/src/core/shared/contracts/dashboard-api.types.ts
@@ -4,868 +4,871 @@
  */
 
 export interface paths {
-    "/health": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /** Health check */
-        get: {
-            parameters: {
-                query?: never;
-                header?: never;
-                path?: never;
-                cookie?: never;
-            };
-            requestBody?: never;
-            responses: {
-                /** @description Health check successful */
-                200: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": components["schemas"]["HealthResponse"];
-                    };
-                };
-            };
-        };
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/builds": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /** List team builds */
-        get: {
-            parameters: {
-                query?: {
-                    /** @description Optional filter by build identifier, template identifier, or template alias. */
-                    build_id_or_template?: components["parameters"]["build_id_or_template"];
-                    /** @description Comma-separated list of build statuses to include. */
-                    statuses?: components["parameters"]["build_statuses"];
-                    /** @description Maximum number of items to return per page. */
-                    limit?: components["parameters"]["builds_limit"];
-                    /** @description Cursor returned by the previous list response in `created_at|build_id` format. */
-                    cursor?: components["parameters"]["builds_cursor"];
-                };
-                header?: never;
-                path?: never;
-                cookie?: never;
-            };
-            requestBody?: never;
-            responses: {
-                /** @description Successfully returned paginated builds. */
-                200: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": components["schemas"]["BuildsListResponse"];
-                    };
-                };
-                400: components["responses"]["400"];
-                401: components["responses"]["401"];
-                403: components["responses"]["403"];
-                500: components["responses"]["500"];
-            };
-        };
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/builds/statuses": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /** Get build statuses */
-        get: {
-            parameters: {
-                query: {
-                    /** @description Comma-separated list of build IDs to get statuses for. */
-                    build_ids: components["parameters"]["build_ids"];
-                };
-                header?: never;
-                path?: never;
-                cookie?: never;
-            };
-            requestBody?: never;
-            responses: {
-                /** @description Successfully returned build statuses */
-                200: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": components["schemas"]["BuildsStatusesResponse"];
-                    };
-                };
-                400: components["responses"]["400"];
-                401: components["responses"]["401"];
-                403: components["responses"]["403"];
-                500: components["responses"]["500"];
-            };
-        };
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/builds/{build_id}": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /** Get build details */
-        get: {
-            parameters: {
-                query?: never;
-                header?: never;
-                path: {
-                    /** @description Identifier of the build. */
-                    build_id: components["parameters"]["build_id"];
-                };
-                cookie?: never;
-            };
-            requestBody?: never;
-            responses: {
-                /** @description Successfully returned build details. */
-                200: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": components["schemas"]["BuildInfo"];
-                    };
-                };
-                401: components["responses"]["401"];
-                403: components["responses"]["403"];
-                404: components["responses"]["404"];
-                500: components["responses"]["500"];
-            };
-        };
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/sandboxes/{sandboxID}/record": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /** Get sandbox record */
-        get: {
-            parameters: {
-                query?: never;
-                header?: never;
-                path: {
-                    /** @description Identifier of the sandbox. */
-                    sandboxID: components["parameters"]["sandboxID"];
-                };
-                cookie?: never;
-            };
-            requestBody?: never;
-            responses: {
-                /** @description Successfully returned sandbox details. */
-                200: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": components["schemas"]["SandboxRecord"];
-                    };
-                };
-                401: components["responses"]["401"];
-                403: components["responses"]["403"];
-                404: components["responses"]["404"];
-                500: components["responses"]["500"];
-            };
-        };
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/teams": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /**
-         * List user teams
-         * @description Returns all teams the authenticated user belongs to, with limits and default flag.
-         */
-        get: {
-            parameters: {
-                query?: never;
-                header?: never;
-                path?: never;
-                cookie?: never;
-            };
-            requestBody?: never;
-            responses: {
-                /** @description Successfully returned user teams. */
-                200: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": components["schemas"]["UserTeamsResponse"];
-                    };
-                };
-                401: components["responses"]["401"];
-                500: components["responses"]["500"];
-            };
-        };
-        put?: never;
-        /** Create team */
-        post: {
-            parameters: {
-                query?: never;
-                header?: never;
-                path?: never;
-                cookie?: never;
-            };
-            requestBody: {
-                content: {
-                    "application/json": components["schemas"]["CreateTeamRequest"];
-                };
-            };
-            responses: {
-                /** @description Successfully created team. */
-                200: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": components["schemas"]["TeamResolveResponse"];
-                    };
-                };
-                400: components["responses"]["400"];
-                401: components["responses"]["401"];
-                500: components["responses"]["500"];
-            };
-        };
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/admin/users/bootstrap": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get?: never;
-        put?: never;
-        /** Bootstrap user */
-        post: {
-            parameters: {
-                query?: never;
-                header?: never;
-                path?: never;
-                cookie?: never;
-            };
-            requestBody?: never;
-            responses: {
-                /** @description Successfully bootstrapped user. */
-                200: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": components["schemas"]["TeamResolveResponse"];
-                    };
-                };
-                401: components["responses"]["401"];
-                500: components["responses"]["500"];
-            };
-        };
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/teams/resolve": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /**
-         * Resolve team identity
-         * @description Resolves a team slug to the team's identity, validating the user is a member.
-         */
-        get: {
-            parameters: {
-                query: {
-                    /** @description Team slug to resolve. */
-                    slug: components["parameters"]["teamSlug"];
-                };
-                header?: never;
-                path?: never;
-                cookie?: never;
-            };
-            requestBody?: never;
-            responses: {
-                /** @description Successfully resolved team. */
-                200: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": components["schemas"]["TeamResolveResponse"];
-                    };
-                };
-                401: components["responses"]["401"];
-                403: components["responses"]["403"];
-                404: components["responses"]["404"];
-                500: components["responses"]["500"];
-            };
-        };
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/teams/{teamID}": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get?: never;
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        /** Update team */
-        patch: {
-            parameters: {
-                query?: never;
-                header?: never;
-                path: {
-                    /** @description Identifier of the team. */
-                    teamID: components["parameters"]["teamID"];
-                };
-                cookie?: never;
-            };
-            requestBody: {
-                content: {
-                    "application/json": components["schemas"]["UpdateTeamRequest"];
-                };
-            };
-            responses: {
-                /** @description Successfully updated team. */
-                200: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": components["schemas"]["UpdateTeamResponse"];
-                    };
-                };
-                400: components["responses"]["400"];
-                401: components["responses"]["401"];
-                403: components["responses"]["403"];
-                500: components["responses"]["500"];
-            };
-        };
-        trace?: never;
-    };
-    "/teams/{teamID}/members": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /** List team members */
-        get: {
-            parameters: {
-                query?: never;
-                header?: never;
-                path: {
-                    /** @description Identifier of the team. */
-                    teamID: components["parameters"]["teamID"];
-                };
-                cookie?: never;
-            };
-            requestBody?: never;
-            responses: {
-                /** @description Successfully returned team members. */
-                200: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": components["schemas"]["TeamMembersResponse"];
-                    };
-                };
-                401: components["responses"]["401"];
-                403: components["responses"]["403"];
-                500: components["responses"]["500"];
-            };
-        };
-        put?: never;
-        /** Add team member */
-        post: {
-            parameters: {
-                query?: never;
-                header?: never;
-                path: {
-                    /** @description Identifier of the team. */
-                    teamID: components["parameters"]["teamID"];
-                };
-                cookie?: never;
-            };
-            requestBody: {
-                content: {
-                    "application/json": components["schemas"]["AddTeamMemberRequest"];
-                };
-            };
-            responses: {
-                /** @description Successfully added team member. */
-                201: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content?: never;
-                };
-                400: components["responses"]["400"];
-                401: components["responses"]["401"];
-                403: components["responses"]["403"];
-                404: components["responses"]["404"];
-                500: components["responses"]["500"];
-            };
-        };
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/teams/{teamID}/members/{userId}": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get?: never;
-        put?: never;
-        post?: never;
-        /** Remove team member */
-        delete: {
-            parameters: {
-                query?: never;
-                header?: never;
-                path: {
-                    /** @description Identifier of the team. */
-                    teamID: components["parameters"]["teamID"];
-                    /** @description Identifier of the user. */
-                    userId: components["parameters"]["userId"];
-                };
-                cookie?: never;
-            };
-            requestBody?: never;
-            responses: {
-                /** @description Successfully removed team member. */
-                204: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content?: never;
-                };
-                400: components["responses"]["400"];
-                401: components["responses"]["401"];
-                403: components["responses"]["403"];
-                500: components["responses"]["500"];
-            };
-        };
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/templates/defaults": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /**
-         * List default templates
-         * @description Returns the list of default templates with their latest build info and aliases.
-         */
-        get: {
-            parameters: {
-                query?: never;
-                header?: never;
-                path?: never;
-                cookie?: never;
-            };
-            requestBody?: never;
-            responses: {
-                /** @description Successfully returned default templates. */
-                200: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": components["schemas"]["DefaultTemplatesResponse"];
-                    };
-                };
-                401: components["responses"]["401"];
-                500: components["responses"]["500"];
-            };
-        };
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-}
-export type webhooks = Record<string, never>;
-export interface components {
-    schemas: {
-        Error: {
-            /**
-             * Format: int32
-             * @description Error code.
-             */
-            code: number;
-            /** @description Error message. */
-            message: string;
-        };
-        /**
-         * @description Build status mapped for dashboard clients.
-         * @enum {string}
-         */
-        BuildStatus: "building" | "failed" | "success";
-        ListedBuild: {
-            /**
-             * Format: uuid
-             * @description Identifier of the build.
-             */
-            id: string;
-            /** @description Template alias when present, otherwise template ID. */
-            template: string;
-            /** @description Identifier of the template. */
-            templateId: string;
-            status: components["schemas"]["BuildStatus"];
-            /** @description Failure message when status is `failed`, otherwise `null`. */
-            statusMessage: string | null;
-            /**
-             * Format: date-time
-             * @description Build creation timestamp in RFC3339 format.
-             */
-            createdAt: string;
-            /**
-             * Format: date-time
-             * @description Build completion timestamp in RFC3339 format, if finished.
-             */
-            finishedAt: string | null;
-        };
-        BuildsListResponse: {
-            data: components["schemas"]["ListedBuild"][];
-            /** @description Cursor to pass to the next list request, or `null` if there is no next page. */
-            nextCursor: string | null;
-        };
-        BuildStatusItem: {
-            /**
-             * Format: uuid
-             * @description Identifier of the build.
-             */
-            id: string;
-            status: components["schemas"]["BuildStatus"];
-            /**
-             * Format: date-time
-             * @description Build completion timestamp in RFC3339 format, if finished.
-             */
-            finishedAt: string | null;
-            /** @description Failure message when status is `failed`, otherwise `null`. */
-            statusMessage: string | null;
-        };
-        BuildsStatusesResponse: {
-            /** @description List of build statuses */
-            buildStatuses: components["schemas"]["BuildStatusItem"][];
-        };
-        BuildInfo: {
-            /** @description Template names related to this build, if available. */
-            names?: string[] | null;
-            /**
-             * Format: date-time
-             * @description Build creation timestamp in RFC3339 format.
-             */
-            createdAt: string;
-            /**
-             * Format: date-time
-             * @description Build completion timestamp in RFC3339 format, if finished.
-             */
-            finishedAt: string | null;
-            status: components["schemas"]["BuildStatus"];
-            /** @description Failure message when status is `failed`, otherwise `null`. */
-            statusMessage: string | null;
-        };
-        /**
-         * Format: int64
-         * @description CPU cores for the sandbox
-         */
-        CPUCount: number;
-        /**
-         * Format: int64
-         * @description Memory for the sandbox in MiB
-         */
-        MemoryMB: number;
-        /**
-         * Format: int64
-         * @description Disk size for the sandbox in MiB
-         */
-        DiskSizeMB: number;
-        SandboxRecord: {
-            /** @description Identifier of the template from which is the sandbox created */
-            templateID: string;
-            /** @description Alias of the template */
-            alias?: string;
-            /** @description Identifier of the sandbox */
-            sandboxID: string;
-            /**
-             * Format: date-time
-             * @description Time when the sandbox was started
-             */
-            startedAt: string;
-            /**
-             * Format: date-time
-             * @description Time when the sandbox was stopped
-             */
-            stoppedAt?: string | null;
-            /** @description Base domain where the sandbox traffic is accessible */
-            domain?: string | null;
-            cpuCount: components["schemas"]["CPUCount"];
-            memoryMB: components["schemas"]["MemoryMB"];
-            diskSizeMB: components["schemas"]["DiskSizeMB"];
-        };
-        HealthResponse: {
-            /** @description Human-readable health check result. */
-            message: string;
-        };
-        UserTeamLimits: {
-            /** Format: int64 */
-            maxLengthHours: number;
-            /** Format: int32 */
-            concurrentSandboxes: number;
-            /** Format: int32 */
-            concurrentTemplateBuilds: number;
-            /** Format: int32 */
-            maxVcpu: number;
-            /** Format: int32 */
-            maxRamMb: number;
-            /** Format: int32 */
-            diskMb: number;
-        };
-        UserTeam: {
-            /** Format: uuid */
-            id: string;
-            name: string;
-            slug: string;
-            tier: string;
-            email: string;
-            profilePictureUrl: string | null;
-            isBlocked: boolean;
-            isBanned: boolean;
-            blockedReason: string | null;
-            isDefault: boolean;
-            limits: components["schemas"]["UserTeamLimits"];
-            /** Format: date-time */
-            createdAt: string;
-        };
-        UserTeamsResponse: {
-            teams: components["schemas"]["UserTeam"][];
-        };
-        TeamMember: {
-            /** Format: uuid */
-            id: string;
-            email: string;
-            isDefault: boolean;
-            /** Format: uuid */
-            addedBy?: string | null;
-            /** Format: date-time */
-            createdAt: string | null;
-        };
-        TeamMembersResponse: {
-            members: components["schemas"]["TeamMember"][];
-        };
-        UpdateTeamRequest: {
-            name?: string;
-            profilePictureUrl?: string | null;
-        };
-        UpdateTeamResponse: {
-            /** Format: uuid */
-            id: string;
-            name: string;
-            profilePictureUrl?: string | null;
-        };
-        AddTeamMemberRequest: {
-            /** Format: email */
-            email: string;
-        };
-        CreateTeamRequest: {
-            name: string;
-        };
-        DefaultTemplateAlias: {
-            alias: string;
-            namespace?: string | null;
-        };
-        DefaultTemplate: {
-            id: string;
-            aliases: components["schemas"]["DefaultTemplateAlias"][];
-            /** Format: uuid */
-            buildId: string;
-            /** Format: int64 */
-            ramMb: number;
-            /** Format: int64 */
-            vcpu: number;
-            /** Format: int64 */
-            totalDiskSizeMb: number | null;
-            envdVersion?: string | null;
-            /** Format: date-time */
-            createdAt: string;
-            public: boolean;
-            /** Format: int32 */
-            buildCount: number;
-            /** Format: int64 */
-            spawnCount: number;
-        };
-        DefaultTemplatesResponse: {
-            templates: components["schemas"]["DefaultTemplate"][];
-        };
-        TeamResolveResponse: {
-            /** Format: uuid */
-            id: string;
-            slug: string;
-        };
-    };
-    responses: {
-        /** @description Bad request */
-        400: {
-            headers: {
-                [name: string]: unknown;
-            };
-            content: {
-                "application/json": components["schemas"]["Error"];
-            };
-        };
-        /** @description Authentication error */
-        401: {
-            headers: {
-                [name: string]: unknown;
-            };
-            content: {
-                "application/json": components["schemas"]["Error"];
-            };
-        };
-        /** @description Forbidden */
-        403: {
-            headers: {
-                [name: string]: unknown;
-            };
-            content: {
-                "application/json": components["schemas"]["Error"];
-            };
-        };
-        /** @description Not found */
-        404: {
-            headers: {
-                [name: string]: unknown;
-            };
-            content: {
-                "application/json": components["schemas"]["Error"];
-            };
-        };
-        /** @description Server error */
-        500: {
-            headers: {
-                [name: string]: unknown;
-            };
-            content: {
-                "application/json": components["schemas"]["Error"];
-            };
-        };
-    };
+  '/health': {
     parameters: {
-        /** @description Identifier of the build. */
-        build_id: string;
-        /** @description Identifier of the sandbox. */
-        sandboxID: string;
-        /** @description Maximum number of items to return per page. */
-        builds_limit: number;
-        /** @description Cursor returned by the previous list response in `created_at|build_id` format. */
-        builds_cursor: string;
-        /** @description Optional filter by build identifier, template identifier, or template alias. */
-        build_id_or_template: string;
-        /** @description Comma-separated list of build statuses to include. */
-        build_statuses: components["schemas"]["BuildStatus"][];
-        /** @description Comma-separated list of build IDs to get statuses for. */
-        build_ids: string[];
-        /** @description Identifier of the team. */
-        teamID: string;
-        /** @description Identifier of the user. */
-        userId: string;
-        /** @description Team slug to resolve. */
-        teamSlug: string;
-    };
-    requestBodies: never;
-    headers: never;
-    pathItems: never;
+      query?: never
+      header?: never
+      path?: never
+      cookie?: never
+    }
+    /** Health check */
+    get: {
+      parameters: {
+        query?: never
+        header?: never
+        path?: never
+        cookie?: never
+      }
+      requestBody?: never
+      responses: {
+        /** @description Health check successful */
+        200: {
+          headers: {
+            [name: string]: unknown
+          }
+          content: {
+            'application/json': components['schemas']['HealthResponse']
+          }
+        }
+      }
+    }
+    put?: never
+    post?: never
+    delete?: never
+    options?: never
+    head?: never
+    patch?: never
+    trace?: never
+  }
+  '/builds': {
+    parameters: {
+      query?: never
+      header?: never
+      path?: never
+      cookie?: never
+    }
+    /** List team builds */
+    get: {
+      parameters: {
+        query?: {
+          /** @description Optional filter by build identifier, template identifier, or template alias. */
+          build_id_or_template?: components['parameters']['build_id_or_template']
+          /** @description Comma-separated list of build statuses to include. */
+          statuses?: components['parameters']['build_statuses']
+          /** @description Maximum number of items to return per page. */
+          limit?: components['parameters']['builds_limit']
+          /** @description Cursor returned by the previous list response in `created_at|build_id` format. */
+          cursor?: components['parameters']['builds_cursor']
+        }
+        header?: never
+        path?: never
+        cookie?: never
+      }
+      requestBody?: never
+      responses: {
+        /** @description Successfully returned paginated builds. */
+        200: {
+          headers: {
+            [name: string]: unknown
+          }
+          content: {
+            'application/json': components['schemas']['BuildsListResponse']
+          }
+        }
+        400: components['responses']['400']
+        401: components['responses']['401']
+        403: components['responses']['403']
+        500: components['responses']['500']
+      }
+    }
+    put?: never
+    post?: never
+    delete?: never
+    options?: never
+    head?: never
+    patch?: never
+    trace?: never
+  }
+  '/builds/statuses': {
+    parameters: {
+      query?: never
+      header?: never
+      path?: never
+      cookie?: never
+    }
+    /** Get build statuses */
+    get: {
+      parameters: {
+        query: {
+          /** @description Comma-separated list of build IDs to get statuses for. */
+          build_ids: components['parameters']['build_ids']
+        }
+        header?: never
+        path?: never
+        cookie?: never
+      }
+      requestBody?: never
+      responses: {
+        /** @description Successfully returned build statuses */
+        200: {
+          headers: {
+            [name: string]: unknown
+          }
+          content: {
+            'application/json': components['schemas']['BuildsStatusesResponse']
+          }
+        }
+        400: components['responses']['400']
+        401: components['responses']['401']
+        403: components['responses']['403']
+        500: components['responses']['500']
+      }
+    }
+    put?: never
+    post?: never
+    delete?: never
+    options?: never
+    head?: never
+    patch?: never
+    trace?: never
+  }
+  '/builds/{build_id}': {
+    parameters: {
+      query?: never
+      header?: never
+      path?: never
+      cookie?: never
+    }
+    /** Get build details */
+    get: {
+      parameters: {
+        query?: never
+        header?: never
+        path: {
+          /** @description Identifier of the build. */
+          build_id: components['parameters']['build_id']
+        }
+        cookie?: never
+      }
+      requestBody?: never
+      responses: {
+        /** @description Successfully returned build details. */
+        200: {
+          headers: {
+            [name: string]: unknown
+          }
+          content: {
+            'application/json': components['schemas']['BuildInfo']
+          }
+        }
+        401: components['responses']['401']
+        403: components['responses']['403']
+        404: components['responses']['404']
+        500: components['responses']['500']
+      }
+    }
+    put?: never
+    post?: never
+    delete?: never
+    options?: never
+    head?: never
+    patch?: never
+    trace?: never
+  }
+  '/sandboxes/{sandboxID}/record': {
+    parameters: {
+      query?: never
+      header?: never
+      path?: never
+      cookie?: never
+    }
+    /** Get sandbox record */
+    get: {
+      parameters: {
+        query?: never
+        header?: never
+        path: {
+          /** @description Identifier of the sandbox. */
+          sandboxID: components['parameters']['sandboxID']
+        }
+        cookie?: never
+      }
+      requestBody?: never
+      responses: {
+        /** @description Successfully returned sandbox details. */
+        200: {
+          headers: {
+            [name: string]: unknown
+          }
+          content: {
+            'application/json': components['schemas']['SandboxRecord']
+          }
+        }
+        401: components['responses']['401']
+        403: components['responses']['403']
+        404: components['responses']['404']
+        500: components['responses']['500']
+      }
+    }
+    put?: never
+    post?: never
+    delete?: never
+    options?: never
+    head?: never
+    patch?: never
+    trace?: never
+  }
+  '/teams': {
+    parameters: {
+      query?: never
+      header?: never
+      path?: never
+      cookie?: never
+    }
+    /**
+     * List user teams
+     * @description Returns all teams the authenticated user belongs to, with limits and default flag.
+     */
+    get: {
+      parameters: {
+        query?: never
+        header?: never
+        path?: never
+        cookie?: never
+      }
+      requestBody?: never
+      responses: {
+        /** @description Successfully returned user teams. */
+        200: {
+          headers: {
+            [name: string]: unknown
+          }
+          content: {
+            'application/json': components['schemas']['UserTeamsResponse']
+          }
+        }
+        401: components['responses']['401']
+        500: components['responses']['500']
+      }
+    }
+    put?: never
+    /** Create team */
+    post: {
+      parameters: {
+        query?: never
+        header?: never
+        path?: never
+        cookie?: never
+      }
+      requestBody: {
+        content: {
+          'application/json': components['schemas']['CreateTeamRequest']
+        }
+      }
+      responses: {
+        /** @description Successfully created team. */
+        200: {
+          headers: {
+            [name: string]: unknown
+          }
+          content: {
+            'application/json': components['schemas']['TeamResolveResponse']
+          }
+        }
+        400: components['responses']['400']
+        401: components['responses']['401']
+        500: components['responses']['500']
+      }
+    }
+    delete?: never
+    options?: never
+    head?: never
+    patch?: never
+    trace?: never
+  }
+  '/admin/users/{userId}/bootstrap': {
+    parameters: {
+      query?: never
+      header?: never
+      path?: never
+      cookie?: never
+    }
+    get?: never
+    put?: never
+    /** Bootstrap user */
+    post: {
+      parameters: {
+        query?: never
+        header?: never
+        path: {
+          /** @description Identifier of the user. */
+          userId: components['parameters']['userId']
+        }
+        cookie?: never
+      }
+      requestBody?: never
+      responses: {
+        /** @description Successfully bootstrapped user. */
+        200: {
+          headers: {
+            [name: string]: unknown
+          }
+          content: {
+            'application/json': components['schemas']['TeamResolveResponse']
+          }
+        }
+        401: components['responses']['401']
+        500: components['responses']['500']
+      }
+    }
+    delete?: never
+    options?: never
+    head?: never
+    patch?: never
+    trace?: never
+  }
+  '/teams/resolve': {
+    parameters: {
+      query?: never
+      header?: never
+      path?: never
+      cookie?: never
+    }
+    /**
+     * Resolve team identity
+     * @description Resolves a team slug to the team's identity, validating the user is a member.
+     */
+    get: {
+      parameters: {
+        query: {
+          /** @description Team slug to resolve. */
+          slug: components['parameters']['teamSlug']
+        }
+        header?: never
+        path?: never
+        cookie?: never
+      }
+      requestBody?: never
+      responses: {
+        /** @description Successfully resolved team. */
+        200: {
+          headers: {
+            [name: string]: unknown
+          }
+          content: {
+            'application/json': components['schemas']['TeamResolveResponse']
+          }
+        }
+        401: components['responses']['401']
+        403: components['responses']['403']
+        404: components['responses']['404']
+        500: components['responses']['500']
+      }
+    }
+    put?: never
+    post?: never
+    delete?: never
+    options?: never
+    head?: never
+    patch?: never
+    trace?: never
+  }
+  '/teams/{teamID}': {
+    parameters: {
+      query?: never
+      header?: never
+      path?: never
+      cookie?: never
+    }
+    get?: never
+    put?: never
+    post?: never
+    delete?: never
+    options?: never
+    head?: never
+    /** Update team */
+    patch: {
+      parameters: {
+        query?: never
+        header?: never
+        path: {
+          /** @description Identifier of the team. */
+          teamID: components['parameters']['teamID']
+        }
+        cookie?: never
+      }
+      requestBody: {
+        content: {
+          'application/json': components['schemas']['UpdateTeamRequest']
+        }
+      }
+      responses: {
+        /** @description Successfully updated team. */
+        200: {
+          headers: {
+            [name: string]: unknown
+          }
+          content: {
+            'application/json': components['schemas']['UpdateTeamResponse']
+          }
+        }
+        400: components['responses']['400']
+        401: components['responses']['401']
+        403: components['responses']['403']
+        500: components['responses']['500']
+      }
+    }
+    trace?: never
+  }
+  '/teams/{teamID}/members': {
+    parameters: {
+      query?: never
+      header?: never
+      path?: never
+      cookie?: never
+    }
+    /** List team members */
+    get: {
+      parameters: {
+        query?: never
+        header?: never
+        path: {
+          /** @description Identifier of the team. */
+          teamID: components['parameters']['teamID']
+        }
+        cookie?: never
+      }
+      requestBody?: never
+      responses: {
+        /** @description Successfully returned team members. */
+        200: {
+          headers: {
+            [name: string]: unknown
+          }
+          content: {
+            'application/json': components['schemas']['TeamMembersResponse']
+          }
+        }
+        401: components['responses']['401']
+        403: components['responses']['403']
+        500: components['responses']['500']
+      }
+    }
+    put?: never
+    /** Add team member */
+    post: {
+      parameters: {
+        query?: never
+        header?: never
+        path: {
+          /** @description Identifier of the team. */
+          teamID: components['parameters']['teamID']
+        }
+        cookie?: never
+      }
+      requestBody: {
+        content: {
+          'application/json': components['schemas']['AddTeamMemberRequest']
+        }
+      }
+      responses: {
+        /** @description Successfully added team member. */
+        201: {
+          headers: {
+            [name: string]: unknown
+          }
+          content?: never
+        }
+        400: components['responses']['400']
+        401: components['responses']['401']
+        403: components['responses']['403']
+        404: components['responses']['404']
+        500: components['responses']['500']
+      }
+    }
+    delete?: never
+    options?: never
+    head?: never
+    patch?: never
+    trace?: never
+  }
+  '/teams/{teamID}/members/{userId}': {
+    parameters: {
+      query?: never
+      header?: never
+      path?: never
+      cookie?: never
+    }
+    get?: never
+    put?: never
+    post?: never
+    /** Remove team member */
+    delete: {
+      parameters: {
+        query?: never
+        header?: never
+        path: {
+          /** @description Identifier of the team. */
+          teamID: components['parameters']['teamID']
+          /** @description Identifier of the user. */
+          userId: components['parameters']['userId']
+        }
+        cookie?: never
+      }
+      requestBody?: never
+      responses: {
+        /** @description Successfully removed team member. */
+        204: {
+          headers: {
+            [name: string]: unknown
+          }
+          content?: never
+        }
+        400: components['responses']['400']
+        401: components['responses']['401']
+        403: components['responses']['403']
+        500: components['responses']['500']
+      }
+    }
+    options?: never
+    head?: never
+    patch?: never
+    trace?: never
+  }
+  '/templates/defaults': {
+    parameters: {
+      query?: never
+      header?: never
+      path?: never
+      cookie?: never
+    }
+    /**
+     * List default templates
+     * @description Returns the list of default templates with their latest build info and aliases.
+     */
+    get: {
+      parameters: {
+        query?: never
+        header?: never
+        path?: never
+        cookie?: never
+      }
+      requestBody?: never
+      responses: {
+        /** @description Successfully returned default templates. */
+        200: {
+          headers: {
+            [name: string]: unknown
+          }
+          content: {
+            'application/json': components['schemas']['DefaultTemplatesResponse']
+          }
+        }
+        401: components['responses']['401']
+        500: components['responses']['500']
+      }
+    }
+    put?: never
+    post?: never
+    delete?: never
+    options?: never
+    head?: never
+    patch?: never
+    trace?: never
+  }
 }
-export type $defs = Record<string, never>;
-export type operations = Record<string, never>;
+export type webhooks = Record<string, never>
+export interface components {
+  schemas: {
+    Error: {
+      /**
+       * Format: int32
+       * @description Error code.
+       */
+      code: number
+      /** @description Error message. */
+      message: string
+    }
+    /**
+     * @description Build status mapped for dashboard clients.
+     * @enum {string}
+     */
+    BuildStatus: 'building' | 'failed' | 'success'
+    ListedBuild: {
+      /**
+       * Format: uuid
+       * @description Identifier of the build.
+       */
+      id: string
+      /** @description Template alias when present, otherwise template ID. */
+      template: string
+      /** @description Identifier of the template. */
+      templateId: string
+      status: components['schemas']['BuildStatus']
+      /** @description Failure message when status is `failed`, otherwise `null`. */
+      statusMessage: string | null
+      /**
+       * Format: date-time
+       * @description Build creation timestamp in RFC3339 format.
+       */
+      createdAt: string
+      /**
+       * Format: date-time
+       * @description Build completion timestamp in RFC3339 format, if finished.
+       */
+      finishedAt: string | null
+    }
+    BuildsListResponse: {
+      data: components['schemas']['ListedBuild'][]
+      /** @description Cursor to pass to the next list request, or `null` if there is no next page. */
+      nextCursor: string | null
+    }
+    BuildStatusItem: {
+      /**
+       * Format: uuid
+       * @description Identifier of the build.
+       */
+      id: string
+      status: components['schemas']['BuildStatus']
+      /**
+       * Format: date-time
+       * @description Build completion timestamp in RFC3339 format, if finished.
+       */
+      finishedAt: string | null
+      /** @description Failure message when status is `failed`, otherwise `null`. */
+      statusMessage: string | null
+    }
+    BuildsStatusesResponse: {
+      /** @description List of build statuses */
+      buildStatuses: components['schemas']['BuildStatusItem'][]
+    }
+    BuildInfo: {
+      /** @description Template names related to this build, if available. */
+      names?: string[] | null
+      /**
+       * Format: date-time
+       * @description Build creation timestamp in RFC3339 format.
+       */
+      createdAt: string
+      /**
+       * Format: date-time
+       * @description Build completion timestamp in RFC3339 format, if finished.
+       */
+      finishedAt: string | null
+      status: components['schemas']['BuildStatus']
+      /** @description Failure message when status is `failed`, otherwise `null`. */
+      statusMessage: string | null
+    }
+    /**
+     * Format: int64
+     * @description CPU cores for the sandbox
+     */
+    CPUCount: number
+    /**
+     * Format: int64
+     * @description Memory for the sandbox in MiB
+     */
+    MemoryMB: number
+    /**
+     * Format: int64
+     * @description Disk size for the sandbox in MiB
+     */
+    DiskSizeMB: number
+    SandboxRecord: {
+      /** @description Identifier of the template from which is the sandbox created */
+      templateID: string
+      /** @description Alias of the template */
+      alias?: string
+      /** @description Identifier of the sandbox */
+      sandboxID: string
+      /**
+       * Format: date-time
+       * @description Time when the sandbox was started
+       */
+      startedAt: string
+      /**
+       * Format: date-time
+       * @description Time when the sandbox was stopped
+       */
+      stoppedAt?: string | null
+      /** @description Base domain where the sandbox traffic is accessible */
+      domain?: string | null
+      cpuCount: components['schemas']['CPUCount']
+      memoryMB: components['schemas']['MemoryMB']
+      diskSizeMB: components['schemas']['DiskSizeMB']
+    }
+    HealthResponse: {
+      /** @description Human-readable health check result. */
+      message: string
+    }
+    UserTeamLimits: {
+      /** Format: int64 */
+      maxLengthHours: number
+      /** Format: int32 */
+      concurrentSandboxes: number
+      /** Format: int32 */
+      concurrentTemplateBuilds: number
+      /** Format: int32 */
+      maxVcpu: number
+      /** Format: int32 */
+      maxRamMb: number
+      /** Format: int32 */
+      diskMb: number
+    }
+    UserTeam: {
+      /** Format: uuid */
+      id: string
+      name: string
+      slug: string
+      tier: string
+      email: string
+      profilePictureUrl: string | null
+      isBlocked: boolean
+      isBanned: boolean
+      blockedReason: string | null
+      isDefault: boolean
+      limits: components['schemas']['UserTeamLimits']
+      /** Format: date-time */
+      createdAt: string
+    }
+    UserTeamsResponse: {
+      teams: components['schemas']['UserTeam'][]
+    }
+    TeamMember: {
+      /** Format: uuid */
+      id: string
+      email: string
+      isDefault: boolean
+      /** Format: uuid */
+      addedBy?: string | null
+      /** Format: date-time */
+      createdAt: string | null
+    }
+    TeamMembersResponse: {
+      members: components['schemas']['TeamMember'][]
+    }
+    UpdateTeamRequest: {
+      name?: string
+      profilePictureUrl?: string | null
+    }
+    UpdateTeamResponse: {
+      /** Format: uuid */
+      id: string
+      name: string
+      profilePictureUrl?: string | null
+    }
+    AddTeamMemberRequest: {
+      /** Format: email */
+      email: string
+    }
+    CreateTeamRequest: {
+      name: string
+    }
+    DefaultTemplateAlias: {
+      alias: string
+      namespace?: string | null
+    }
+    DefaultTemplate: {
+      id: string
+      aliases: components['schemas']['DefaultTemplateAlias'][]
+      /** Format: uuid */
+      buildId: string
+      /** Format: int64 */
+      ramMb: number
+      /** Format: int64 */
+      vcpu: number
+      /** Format: int64 */
+      totalDiskSizeMb: number | null
+      envdVersion?: string | null
+      /** Format: date-time */
+      createdAt: string
+      public: boolean
+      /** Format: int32 */
+      buildCount: number
+      /** Format: int64 */
+      spawnCount: number
+    }
+    DefaultTemplatesResponse: {
+      templates: components['schemas']['DefaultTemplate'][]
+    }
+    TeamResolveResponse: {
+      /** Format: uuid */
+      id: string
+      slug: string
+    }
+  }
+  responses: {
+    /** @description Bad request */
+    400: {
+      headers: {
+        [name: string]: unknown
+      }
+      content: {
+        'application/json': components['schemas']['Error']
+      }
+    }
+    /** @description Authentication error */
+    401: {
+      headers: {
+        [name: string]: unknown
+      }
+      content: {
+        'application/json': components['schemas']['Error']
+      }
+    }
+    /** @description Forbidden */
+    403: {
+      headers: {
+        [name: string]: unknown
+      }
+      content: {
+        'application/json': components['schemas']['Error']
+      }
+    }
+    /** @description Not found */
+    404: {
+      headers: {
+        [name: string]: unknown
+      }
+      content: {
+        'application/json': components['schemas']['Error']
+      }
+    }
+    /** @description Server error */
+    500: {
+      headers: {
+        [name: string]: unknown
+      }
+      content: {
+        'application/json': components['schemas']['Error']
+      }
+    }
+  }
+  parameters: {
+    /** @description Identifier of the build. */
+    build_id: string
+    /** @description Identifier of the sandbox. */
+    sandboxID: string
+    /** @description Maximum number of items to return per page. */
+    builds_limit: number
+    /** @description Cursor returned by the previous list response in `created_at|build_id` format. */
+    builds_cursor: string
+    /** @description Optional filter by build identifier, template identifier, or template alias. */
+    build_id_or_template: string
+    /** @description Comma-separated list of build statuses to include. */
+    build_statuses: components['schemas']['BuildStatus'][]
+    /** @description Comma-separated list of build IDs to get statuses for. */
+    build_ids: string[]
+    /** @description Identifier of the team. */
+    teamID: string
+    /** @description Identifier of the user. */
+    userId: string
+    /** @description Team slug to resolve. */
+    teamSlug: string
+  }
+  requestBodies: never
+  headers: never
+  pathItems: never
+}
+export type $defs = Record<string, never>
+export type operations = Record<string, never>

--- a/src/lib/env.ts
+++ b/src/lib/env.ts
@@ -5,6 +5,8 @@ export const serverSchema = z.object({
   KV_REST_API_TOKEN: z.string().min(1),
   KV_REST_API_URL: z.url(),
 
+  DASHBOARD_API_ADMIN_TOKEN: z.string().min(1),
+
   BILLING_API_URL: z.url().optional(),
   ZEROBOUNCE_API_KEY: z.string().optional(),
   PLAIN_API_KEY: z.string().min(1).optional(),

--- a/src/lib/env.ts
+++ b/src/lib/env.ts
@@ -5,7 +5,8 @@ export const serverSchema = z.object({
   KV_REST_API_TOKEN: z.string().min(1),
   KV_REST_API_URL: z.url(),
 
-  DASHBOARD_API_ADMIN_TOKEN: z.string().min(1),
+  ENABLE_USER_BOOTSTRAP: z.string().optional(),
+  DASHBOARD_API_ADMIN_TOKEN: z.string().min(1).optional(),
 
   BILLING_API_URL: z.url().optional(),
   ZEROBOUNCE_API_KEY: z.string().optional(),


### PR DESCRIPTION
## Summary
- route dashboard team resolution through the dashboard API and pass the authenticated user id into `resolveUserTeam`
- switch user bootstrapping to the new `/admin/users/{userId}/bootstrap` contract and update generated API types
- split bootstrap logic into a dedicated admin users repository and keep user team reads scoped to the access token-backed teams repository