### PR TITLE
fix: avoid duplicate bootstrap during auth callback

### DIFF
--- a/src/__test__/integration/auth-callback-route.test.ts
+++ b/src/__test__/integration/auth-callback-route.test.ts
@@ -2,17 +2,7 @@ import { redirect } from 'next/navigation'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { AUTH_URLS } from '@/configs/urls'
 
-const {
-  mockFlags,
-  mockCreateAdminUsersRepository,
-  mockBootstrapUser,
-  mockSupabaseClient,
-} = vi.hoisted(() => ({
-  mockFlags: {
-    enableUserBootstrap: true,
-  },
-  mockCreateAdminUsersRepository: vi.fn(),
-  mockBootstrapUser: vi.fn(),
+const { mockSupabaseClient } = vi.hoisted(() => ({
   mockSupabaseClient: {
     auth: {
       exchangeCodeForSession: vi.fn(),
@@ -24,18 +14,8 @@ vi.mock('next/navigation', () => ({
   redirect: vi.fn((url) => ({ destination: url })),
 }))
 
-vi.mock('@/configs/flags', () => ({
-  get ENABLE_USER_BOOTSTRAP() {
-    return mockFlags.enableUserBootstrap
-  },
-}))
-
 vi.mock('@/core/shared/clients/supabase/server', () => ({
   createClient: vi.fn(() => mockSupabaseClient),
-}))
-
-vi.mock('@/core/modules/users/admin-repository.server', () => ({
-  createAdminUsersRepository: mockCreateAdminUsersRepository,
 }))
 
 vi.mock('@/lib/utils/auth', () => ({
@@ -51,13 +31,9 @@ import { GET } from '@/app/api/auth/callback/route'
 describe('Auth Callback Route', () => {
   beforeEach(() => {
     vi.clearAllMocks()
-    mockFlags.enableUserBootstrap = true
-    mockCreateAdminUsersRepository.mockReturnValue({
-      bootstrapUser: mockBootstrapUser,
-    })
   })
 
-  it('continues login when bootstrap fails', async () => {
+  it('redirects to dashboard after a successful session exchange', async () => {
     mockSupabaseClient.auth.exchangeCodeForSession.mockResolvedValue({
       data: {
         user: { id: 'user-123' },
@@ -65,16 +41,11 @@ describe('Auth Callback Route', () => {
       },
       error: null,
     })
-    mockBootstrapUser.mockResolvedValue({
-      ok: false,
-      error: new Error('DASHBOARD_API_ADMIN_TOKEN is not configured'),
-    })
 
     const result = await GET(
       new Request('https://dashboard.e2b.dev/api/auth/callback?code=test')
     )
 
-    expect(mockBootstrapUser).toHaveBeenCalledWith('user-123')
     expect(redirect).toHaveBeenCalledWith('/dashboard')
     expect(result).toEqual({ destination: '/dashboard' })
   })

--- a/src/app/api/auth/callback/route.ts
+++ b/src/app/api/auth/callback/route.ts
@@ -1,7 +1,5 @@
 import { redirect } from 'next/navigation'
-import { ENABLE_USER_BOOTSTRAP } from '@/configs/flags'
 import { AUTH_URLS, PROTECTED_URLS } from '@/configs/urls'
-import { createAdminUsersRepository } from '@/core/modules/users/admin-repository.server'
 import { l, serializeErrorForLog } from '@/core/shared/clients/logger/logger'
 import { createClient } from '@/core/shared/clients/supabase/server'
 import { encodedRedirect } from '@/lib/utils/auth'
@@ -59,23 +57,6 @@ export async function GET(request: Request) {
           AUTH_URLS.SIGN_IN,
           'Missing session after auth callback'
         )
-      }
-
-      if (ENABLE_USER_BOOTSTRAP) {
-        const adminUsersRepository = createAdminUsersRepository()
-
-        const bootstrapResult = await adminUsersRepository.bootstrapUser(userId)
-
-        if (!bootstrapResult.ok) {
-          l.warn(
-            {
-              key: 'auth_callback:bootstrap_error',
-              user_id: userId,
-              error: serializeErrorForLog(bootstrapResult.error),
-            },
-            `Auth callback bootstrap failed; continuing with sign-in flow`
-          )
-        }
       }
 
       l.info(


### PR DESCRIPTION
## Summary
- remove user bootstrap from the auth callback flow so sign-in no longer triggers a second bootstrap request before dashboard resolution
- keep bootstrap ownership on the existing `/dashboard` empty-team fallback path to preserve account setup behavior
- update the auth callback integration test to cover the new single-entry bootstrap flow

## Test plan
- [x] `bun vitest run src/__test__/integration/auth-callback-route.test.ts src/__test__/integration/resolve-user-team.test.ts`

Made with [Cursor](https://cursor.com)