### PR TITLE
fix(limits): handle missing billing limit fields from staging API

### DIFF
--- a/src/core/modules/billing/repository.server.ts
+++ b/src/core/modules/billing/repository.server.ts
@@ -163,7 +163,11 @@ export function createBillingRepository(
         return err(repoErrorFromHttp(res.status, await parseText(res)))
       }
 
-      return ok((await res.json()) as BillingLimit)
+      const data = (await res.json()) as Partial<BillingLimit>
+      return ok({
+        limit_amount_gte: data.limit_amount_gte ?? null,
+        alert_amount_gte: data.alert_amount_gte ?? null,
+      })
     },
     async setLimit(key, value) {
       const res = await fetch(


### PR DESCRIPTION
## Summary
- Coerces missing `limit_amount_gte` / `alert_amount_gte` fields from the billing API to `null` at the repository boundary so the rest of the limits page can rely on the typed `number | null` contract.
- Fixes a client-side `Cannot read properties of undefined (reading 'toLocaleString')` crash on `/dashboard/[teamSlug]/limits` for any team that has never set a usage limit or alert.

## Why this happened
The billing API's `BillingLimit` struct uses `*int64` with `json:",omitempty"`, so unset limits are **omitted from the JSON response entirely**, not serialized as explicit `null`. The recent limits page refactor (#296) replaced the previous `originalValue?.toLocaleString()` / `?? ''` pattern with strict `value !== null` checks followed by `formatNumber(value)` — which lets `undefined` slip through and throws inside `toLocaleString`.

I verified two weeks of `e2b-dev/belt` history (#654 sqlc migration, #690 SupabaseDB cleanup, #693 oapi-codegen upgrade); none of them changed the `BillingLimit` JSON shape. The API has always omitted unset fields — the dashboard refactor is what removed the tolerance for `undefined`.
