### PR TITLE
Harden incident.io status mapping

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -70,7 +70,6 @@ NEXT_PUBLIC_SUPABASE_ANON_KEY=your_supabase_anon_key
 ### Enable dashboard status indicator feature: set to 1 to enable
 ### When enabled, the E2B status is read from the incident.io summary API
 # NEXT_PUBLIC_INCLUDE_STATUS_INDICATOR=0
-# NEXT_PUBLIC_STATUS_PAGE_URL=https://statuspage.incident.io/e2b-service
 
 ### Set to 1 to use mock data
 # NEXT_PUBLIC_MOCK_DATA=0

--- a/.env.example
+++ b/.env.example
@@ -71,7 +71,6 @@ NEXT_PUBLIC_SUPABASE_ANON_KEY=your_supabase_anon_key
 ### When enabled, the E2B status is read from the incident.io summary API
 # NEXT_PUBLIC_INCLUDE_STATUS_INDICATOR=0
 # NEXT_PUBLIC_STATUS_PAGE_URL=https://statuspage.incident.io/e2b-service
-# NEXT_PUBLIC_STATUS_PAGE_SUMMARY_URL=https://statuspage.incident.io/e2b-service/api/v2/summary.json
 
 ### Set to 1 to use mock data
 # NEXT_PUBLIC_MOCK_DATA=0

--- a/.env.example
+++ b/.env.example
@@ -68,10 +68,10 @@ NEXT_PUBLIC_SUPABASE_ANON_KEY=your_supabase_anon_key
 # NEXT_PUBLIC_INCLUDE_REPORT_ISSUE=0
 
 ### Enable dashboard status indicator feature: set to 1 to enable
-### When enabled, the E2B status is read from the incident.io widget API
+### When enabled, the E2B status is read from the incident.io summary API
 # NEXT_PUBLIC_INCLUDE_STATUS_INDICATOR=0
-# NEXT_PUBLIC_STATUS_PAGE_URL=https://status.e2b.dev
-# NEXT_PUBLIC_STATUS_PAGE_WIDGET_URL=https://status.e2b.dev/api/widget
+# NEXT_PUBLIC_STATUS_PAGE_URL=https://statuspage.incident.io/e2b-service
+# NEXT_PUBLIC_STATUS_PAGE_SUMMARY_URL=https://statuspage.incident.io/e2b-service/api/v2/summary.json
 
 ### Set to 1 to use mock data
 # NEXT_PUBLIC_MOCK_DATA=0

--- a/.env.example
+++ b/.env.example
@@ -68,8 +68,10 @@ NEXT_PUBLIC_SUPABASE_ANON_KEY=your_supabase_anon_key
 # NEXT_PUBLIC_INCLUDE_REPORT_ISSUE=0
 
 ### Enable dashboard status indicator feature: set to 1 to enable
-### When enabled, the E2B status is read from https://status.e2b.dev
+### When enabled, the E2B status is read from the incident.io widget API
 # NEXT_PUBLIC_INCLUDE_STATUS_INDICATOR=0
+# NEXT_PUBLIC_STATUS_PAGE_URL=https://status.e2b.dev
+# NEXT_PUBLIC_STATUS_PAGE_WIDGET_URL=https://status.e2b.dev/api/widget
 
 ### Set to 1 to use mock data
 # NEXT_PUBLIC_MOCK_DATA=0

--- a/src/features/dashboard/layouts/status-indicator.server.tsx
+++ b/src/features/dashboard/layouts/status-indicator.server.tsx
@@ -4,39 +4,23 @@ import { cacheLife } from 'next/cache'
 import Link from 'next/link'
 import { l } from '@/core/shared/clients/logger/logger'
 import { LiveDot } from '@/ui/live'
+import {
+  type AggregateState,
+  getStatusPageStateFromWidget,
+  getStatusPageUrl,
+  getStatusPageWidgetUrl,
+  type IncidentIOWidgetResponse,
+} from './status-indicator'
 
-const STATUS_PAGE_URL = 'https://status.e2b.dev'
-const STATUS_PAGE_INDEX_URL = `${STATUS_PAGE_URL}/index.json`
+export const STATUS_PAGE_URL = getStatusPageUrl()
+const STATUS_PAGE_WIDGET_URL = getStatusPageWidgetUrl(STATUS_PAGE_URL)
 const STATUS_PAGE_FETCH_TIMEOUT_MS = 5_000
 const STATUS_PAGE_CACHE_SECONDS = 300
-
-type AggregateState =
-  | 'operational'
-  | 'degraded'
-  | 'downtime'
-  | 'maintenance'
-  | 'unknown'
-
-interface StatusPageIndexResponse {
-  data?: {
-    attributes?: {
-      aggregate_state?: string
-    }
-  }
-}
 
 interface StatusUI {
   label: string
   dotCircleClassName: string
   dotClassName: string
-}
-
-function toAggregateState(value: string | undefined): AggregateState {
-  if (value === 'operational') return 'operational'
-  if (value === 'degraded') return 'degraded'
-  if (value === 'downtime') return 'downtime'
-  if (value === 'maintenance') return 'maintenance'
-  return 'unknown'
 }
 
 function getStatusUI(state: AggregateState): StatusUI {
@@ -83,7 +67,7 @@ async function getStatusPageState(): Promise<AggregateState> {
   })
 
   try {
-    const response = await fetch(STATUS_PAGE_INDEX_URL, {
+    const response = await fetch(STATUS_PAGE_WIDGET_URL, {
       cache: 'force-cache',
       next: { revalidate: STATUS_PAGE_CACHE_SECONDS },
       signal: AbortSignal.timeout(STATUS_PAGE_FETCH_TIMEOUT_MS),
@@ -101,8 +85,8 @@ async function getStatusPageState(): Promise<AggregateState> {
       return 'unknown'
     }
 
-    const data = (await response.json()) as StatusPageIndexResponse
-    return toAggregateState(data.data?.attributes?.aggregate_state)
+    const data = (await response.json()) as IncidentIOWidgetResponse
+    return getStatusPageStateFromWidget(data)
   } catch {
     return 'unknown'
   }

--- a/src/features/dashboard/layouts/status-indicator.server.tsx
+++ b/src/features/dashboard/layouts/status-indicator.server.tsx
@@ -7,13 +7,11 @@ import { LiveDot } from '@/ui/live'
 import {
   type AggregateState,
   getStatusPageStateFromSummary,
-  getStatusPageSummaryUrl,
-  getStatusPageUrl,
   type IncidentIOStatusPageSummaryResponse,
+  STATUS_PAGE_LINK_URL,
+  STATUS_PAGE_SUMMARY_URL,
 } from './status-indicator'
 
-export const STATUS_PAGE_URL = getStatusPageUrl()
-const STATUS_PAGE_SUMMARY_URL = getStatusPageSummaryUrl(STATUS_PAGE_URL)
 const STATUS_PAGE_FETCH_TIMEOUT_MS = 5_000
 const STATUS_PAGE_CACHE_SECONDS = 300
 
@@ -98,7 +96,7 @@ export default async function DashboardStatusBadgeServer() {
 
   return (
     <Link
-      href={STATUS_PAGE_URL}
+      href={STATUS_PAGE_LINK_URL}
       target="_blank"
       rel="noopener noreferrer"
       className="inline-flex h-5 shrink-0 items-center gap-1.5"

--- a/src/features/dashboard/layouts/status-indicator.server.tsx
+++ b/src/features/dashboard/layouts/status-indicator.server.tsx
@@ -13,7 +13,7 @@ import {
 } from './status-indicator'
 
 const STATUS_PAGE_FETCH_TIMEOUT_MS = 5_000
-const STATUS_PAGE_CACHE_SECONDS = 300
+const STATUS_PAGE_CACHE_SECONDS = 30
 
 interface StatusUI {
   label: string

--- a/src/features/dashboard/layouts/status-indicator.server.tsx
+++ b/src/features/dashboard/layouts/status-indicator.server.tsx
@@ -6,14 +6,14 @@ import { l } from '@/core/shared/clients/logger/logger'
 import { LiveDot } from '@/ui/live'
 import {
   type AggregateState,
-  getStatusPageStateFromWidget,
+  getStatusPageStateFromSummary,
+  getStatusPageSummaryUrl,
   getStatusPageUrl,
-  getStatusPageWidgetUrl,
-  type IncidentIOWidgetResponse,
+  type IncidentIOStatusPageSummaryResponse,
 } from './status-indicator'
 
 export const STATUS_PAGE_URL = getStatusPageUrl()
-const STATUS_PAGE_WIDGET_URL = getStatusPageWidgetUrl(STATUS_PAGE_URL)
+const STATUS_PAGE_SUMMARY_URL = getStatusPageSummaryUrl(STATUS_PAGE_URL)
 const STATUS_PAGE_FETCH_TIMEOUT_MS = 5_000
 const STATUS_PAGE_CACHE_SECONDS = 300
 
@@ -67,7 +67,7 @@ async function getStatusPageState(): Promise<AggregateState> {
   })
 
   try {
-    const response = await fetch(STATUS_PAGE_WIDGET_URL, {
+    const response = await fetch(STATUS_PAGE_SUMMARY_URL, {
       cache: 'force-cache',
       next: { revalidate: STATUS_PAGE_CACHE_SECONDS },
       signal: AbortSignal.timeout(STATUS_PAGE_FETCH_TIMEOUT_MS),
@@ -85,8 +85,8 @@ async function getStatusPageState(): Promise<AggregateState> {
       return 'unknown'
     }
 
-    const data = (await response.json()) as IncidentIOWidgetResponse
-    return getStatusPageStateFromWidget(data)
+    const data = (await response.json()) as IncidentIOStatusPageSummaryResponse
+    return getStatusPageStateFromSummary(data)
   } catch {
     return 'unknown'
   }

--- a/src/features/dashboard/layouts/status-indicator.ts
+++ b/src/features/dashboard/layouts/status-indicator.ts
@@ -49,19 +49,32 @@ function hasMaintenanceInProgress(
   maintenances: IncidentIOStatusPageSummaryResponse['scheduled_maintenances']
 ) {
   return maintenances?.some(
-    (maintenance) => maintenance.status === 'maintenance_in_progress'
+    (maintenance) =>
+      maintenance.status === 'in_progress' ||
+      maintenance.status === 'maintenance_in_progress'
   )
 }
 
 export function getStatusPageStateFromSummary(
   data: IncidentIOStatusPageSummaryResponse
 ): AggregateState {
-  if (hasMaintenanceInProgress(data.scheduled_maintenances))
+  const indicatorState = stateFromIndicator(data.status?.indicator)
+  const componentState = getWorstComponentState(data.components)
+
+  if (indicatorState === 'downtime' || componentState === 'downtime')
+    return 'downtime'
+
+  if (indicatorState === 'degraded' || componentState === 'degraded')
+    return 'degraded'
+
+  if (
+    indicatorState === 'maintenance' ||
+    componentState === 'maintenance' ||
+    hasMaintenanceInProgress(data.scheduled_maintenances)
+  )
     return 'maintenance'
 
-  return (
-    stateFromIndicator(data.status?.indicator) ??
-    getWorstComponentState(data.components) ??
-    'unknown'
-  )
+  if (indicatorState === 'operational') return 'operational'
+
+  return 'unknown'
 }

--- a/src/features/dashboard/layouts/status-indicator.ts
+++ b/src/features/dashboard/layouts/status-indicator.ts
@@ -27,11 +27,6 @@ export function getStatusPageUrl() {
 }
 
 export function getStatusPageSummaryUrl(statusPageUrl: string) {
-  const configuredSummaryUrl =
-    process.env.NEXT_PUBLIC_STATUS_PAGE_SUMMARY_URL?.trim()
-
-  if (configuredSummaryUrl) return configuredSummaryUrl
-
   return `${statusPageUrl}/api/v2/summary.json`
 }
 

--- a/src/features/dashboard/layouts/status-indicator.ts
+++ b/src/features/dashboard/layouts/status-indicator.ts
@@ -21,28 +21,62 @@ export const STATUS_PAGE_LINK_URL = 'https://status.e2b.dev'
 const INCIDENT_IO_STATUS_PAGE_URL = 'https://statuspage.incident.io/e2b-service'
 export const STATUS_PAGE_SUMMARY_URL = `${INCIDENT_IO_STATUS_PAGE_URL}/api/v2/summary.json`
 
-function stateFromIndicator(indicator: string | undefined) {
-  if (indicator === 'none') return 'operational'
-  if (indicator === 'minor') return 'degraded'
-  if (indicator === 'major') return 'degraded'
-  if (indicator === 'critical') return 'downtime'
-  if (indicator === 'maintenance') return 'maintenance'
+const STATUS_PRIORITY: Record<AggregateState, number> = {
+  unknown: 0,
+  operational: 1,
+  maintenance: 2,
+  degraded: 3,
+  downtime: 4,
+}
 
-  return undefined
+const INDICATOR_STATE: Record<string, AggregateState> = {
+  none: 'operational',
+  minor: 'degraded',
+  major: 'degraded',
+  critical: 'downtime',
+  maintenance: 'maintenance',
+}
+
+const COMPONENT_STATE: Record<string, AggregateState> = {
+  operational: 'operational',
+  under_maintenance: 'maintenance',
+  degraded_performance: 'degraded',
+  partial_outage: 'degraded',
+  full_outage: 'downtime',
+  major_outage: 'downtime',
+}
+
+const MAINTENANCE_IN_PROGRESS_STATUSES = new Set([
+  'in_progress',
+  'maintenance_in_progress',
+])
+
+function stateFromValue(
+  value: string | undefined,
+  stateMap: Record<string, AggregateState>
+) {
+  return value ? stateMap[value] : undefined
+}
+
+function highestPriorityState(
+  states: Array<AggregateState | undefined>
+): AggregateState | undefined {
+  return states.reduce<AggregateState | undefined>((highest, state) => {
+    if (!state) return highest
+    if (!highest) return state
+
+    return STATUS_PRIORITY[state] > STATUS_PRIORITY[highest] ? state : highest
+  }, undefined)
 }
 
 function getWorstComponentState(
   components: IncidentIOStatusPageSummaryResponse['components']
 ): AggregateState | undefined {
-  const componentStatuses =
-    components?.map((component) => component.status) ?? []
-
-  if (componentStatuses.includes('major_outage')) return 'downtime'
-  if (componentStatuses.includes('partial_outage')) return 'degraded'
-  if (componentStatuses.includes('degraded_performance')) return 'degraded'
-  if (componentStatuses.includes('under_maintenance')) return 'maintenance'
-
-  return undefined
+  return highestPriorityState(
+    components?.map((component) =>
+      stateFromValue(component.status, COMPONENT_STATE)
+    ) ?? []
+  )
 }
 
 function hasMaintenanceInProgress(
@@ -51,8 +85,8 @@ function hasMaintenanceInProgress(
   return (
     maintenances?.some(
       (maintenance) =>
-        maintenance.status === 'in_progress' ||
-        maintenance.status === 'maintenance_in_progress'
+        !!maintenance.status &&
+        MAINTENANCE_IN_PROGRESS_STATUSES.has(maintenance.status)
     ) ?? false
   )
 }
@@ -60,23 +94,14 @@ function hasMaintenanceInProgress(
 export function getStatusPageStateFromSummary(
   data: IncidentIOStatusPageSummaryResponse
 ): AggregateState {
-  const indicatorState = stateFromIndicator(data.status?.indicator)
+  const indicatorState = stateFromValue(data.status?.indicator, INDICATOR_STATE)
   const componentState = getWorstComponentState(data.components)
+  const maintenanceState = hasMaintenanceInProgress(data.scheduled_maintenances)
+    ? 'maintenance'
+    : undefined
 
-  if (indicatorState === 'downtime' || componentState === 'downtime')
-    return 'downtime'
-
-  if (indicatorState === 'degraded' || componentState === 'degraded')
-    return 'degraded'
-
-  if (
-    indicatorState === 'maintenance' ||
-    componentState === 'maintenance' ||
-    hasMaintenanceInProgress(data.scheduled_maintenances)
+  return (
+    highestPriorityState([indicatorState, componentState, maintenanceState]) ??
+    'unknown'
   )
-    return 'maintenance'
-
-  if (indicatorState === 'operational') return 'operational'
-
-  return 'unknown'
 }

--- a/src/features/dashboard/layouts/status-indicator.ts
+++ b/src/features/dashboard/layouts/status-indicator.ts
@@ -47,11 +47,13 @@ function getWorstComponentState(
 
 function hasMaintenanceInProgress(
   maintenances: IncidentIOStatusPageSummaryResponse['scheduled_maintenances']
-) {
-  return maintenances?.some(
-    (maintenance) =>
-      maintenance.status === 'in_progress' ||
-      maintenance.status === 'maintenance_in_progress'
+): boolean {
+  return (
+    maintenances?.some(
+      (maintenance) =>
+        maintenance.status === 'in_progress' ||
+        maintenance.status === 'maintenance_in_progress'
+    ) ?? false
   )
 }
 

--- a/src/features/dashboard/layouts/status-indicator.ts
+++ b/src/features/dashboard/layouts/status-indicator.ts
@@ -1,0 +1,66 @@
+export type AggregateState =
+  | 'operational'
+  | 'degraded'
+  | 'downtime'
+  | 'maintenance'
+  | 'unknown'
+
+export interface IncidentIOWidgetEvent {
+  affected_components?: Array<{
+    status?: string
+  }>
+}
+
+export interface IncidentIOWidgetResponse {
+  ongoing_incidents?: IncidentIOWidgetEvent[]
+  in_progress_maintenances?: IncidentIOWidgetEvent[]
+  scheduled_maintenances?: IncidentIOWidgetEvent[]
+}
+
+export function getStatusPageUrl() {
+  return (process.env.NEXT_PUBLIC_STATUS_PAGE_URL ?? 'https://status.e2b.dev')
+    .trim()
+    .replace(/\/+$/, '')
+}
+
+export function getStatusPageWidgetUrl(statusPageUrl: string) {
+  const configuredWidgetUrl =
+    process.env.NEXT_PUBLIC_STATUS_PAGE_WIDGET_URL?.trim()
+
+  if (configuredWidgetUrl) return configuredWidgetUrl
+
+  return `${statusPageUrl}/api/widget`
+}
+
+function hasEvents(events: IncidentIOWidgetEvent[] | undefined) {
+  return Array.isArray(events) && events.length > 0
+}
+
+function getWorstComponentState(
+  events: IncidentIOWidgetEvent[] | undefined
+): AggregateState | undefined {
+  const componentStatuses =
+    events?.flatMap(
+      (event) =>
+        event.affected_components?.map((component) => component.status) ?? []
+    ) ?? []
+
+  if (componentStatuses.includes('full_outage')) return 'downtime'
+  if (componentStatuses.includes('partial_outage')) return 'degraded'
+  if (componentStatuses.includes('degraded_performance')) return 'degraded'
+  if (componentStatuses.includes('under_maintenance')) return 'maintenance'
+
+  return undefined
+}
+
+export function getStatusPageStateFromWidget(
+  data: IncidentIOWidgetResponse
+): AggregateState {
+  if (hasEvents(data.ongoing_incidents)) {
+    return getWorstComponentState(data.ongoing_incidents) ?? 'degraded'
+  }
+
+  if (hasEvents(data.in_progress_maintenances)) return 'maintenance'
+
+  return 'operational'
+}

--- a/src/features/dashboard/layouts/status-indicator.ts
+++ b/src/features/dashboard/layouts/status-indicator.ts
@@ -17,18 +17,9 @@ export interface IncidentIOStatusPageSummaryResponse {
   }>
 }
 
-export function getStatusPageUrl() {
-  return (
-    process.env.NEXT_PUBLIC_STATUS_PAGE_URL ??
-    'https://statuspage.incident.io/e2b-service'
-  )
-    .trim()
-    .replace(/\/+$/, '')
-}
-
-export function getStatusPageSummaryUrl(statusPageUrl: string) {
-  return `${statusPageUrl}/api/v2/summary.json`
-}
+export const STATUS_PAGE_LINK_URL = 'https://status.e2b.dev'
+const INCIDENT_IO_STATUS_PAGE_URL = 'https://statuspage.incident.io/e2b-service'
+export const STATUS_PAGE_SUMMARY_URL = `${INCIDENT_IO_STATUS_PAGE_URL}/api/v2/summary.json`
 
 function stateFromIndicator(indicator: string | undefined) {
   if (indicator === 'none') return 'operational'

--- a/src/features/dashboard/layouts/status-indicator.ts
+++ b/src/features/dashboard/layouts/status-indicator.ts
@@ -5,47 +5,53 @@ export type AggregateState =
   | 'maintenance'
   | 'unknown'
 
-export interface IncidentIOWidgetEvent {
-  affected_components?: Array<{
+export interface IncidentIOStatusPageSummaryResponse {
+  status?: {
+    indicator?: string
+  }
+  components?: Array<{
+    status?: string
+  }>
+  scheduled_maintenances?: Array<{
     status?: string
   }>
 }
 
-export interface IncidentIOWidgetResponse {
-  ongoing_incidents?: IncidentIOWidgetEvent[]
-  in_progress_maintenances?: IncidentIOWidgetEvent[]
-  scheduled_maintenances?: IncidentIOWidgetEvent[]
-}
-
 export function getStatusPageUrl() {
-  return (process.env.NEXT_PUBLIC_STATUS_PAGE_URL ?? 'https://status.e2b.dev')
+  return (
+    process.env.NEXT_PUBLIC_STATUS_PAGE_URL ??
+    'https://statuspage.incident.io/e2b-service'
+  )
     .trim()
     .replace(/\/+$/, '')
 }
 
-export function getStatusPageWidgetUrl(statusPageUrl: string) {
-  const configuredWidgetUrl =
-    process.env.NEXT_PUBLIC_STATUS_PAGE_WIDGET_URL?.trim()
+export function getStatusPageSummaryUrl(statusPageUrl: string) {
+  const configuredSummaryUrl =
+    process.env.NEXT_PUBLIC_STATUS_PAGE_SUMMARY_URL?.trim()
 
-  if (configuredWidgetUrl) return configuredWidgetUrl
+  if (configuredSummaryUrl) return configuredSummaryUrl
 
-  return `${statusPageUrl}/api/widget`
+  return `${statusPageUrl}/api/v2/summary.json`
 }
 
-function hasEvents(events: IncidentIOWidgetEvent[] | undefined) {
-  return Array.isArray(events) && events.length > 0
+function stateFromIndicator(indicator: string | undefined) {
+  if (indicator === 'none') return 'operational'
+  if (indicator === 'minor') return 'degraded'
+  if (indicator === 'major') return 'degraded'
+  if (indicator === 'critical') return 'downtime'
+  if (indicator === 'maintenance') return 'maintenance'
+
+  return undefined
 }
 
 function getWorstComponentState(
-  events: IncidentIOWidgetEvent[] | undefined
+  components: IncidentIOStatusPageSummaryResponse['components']
 ): AggregateState | undefined {
   const componentStatuses =
-    events?.flatMap(
-      (event) =>
-        event.affected_components?.map((component) => component.status) ?? []
-    ) ?? []
+    components?.map((component) => component.status) ?? []
 
-  if (componentStatuses.includes('full_outage')) return 'downtime'
+  if (componentStatuses.includes('major_outage')) return 'downtime'
   if (componentStatuses.includes('partial_outage')) return 'degraded'
   if (componentStatuses.includes('degraded_performance')) return 'degraded'
   if (componentStatuses.includes('under_maintenance')) return 'maintenance'
@@ -53,14 +59,23 @@ function getWorstComponentState(
   return undefined
 }
 
-export function getStatusPageStateFromWidget(
-  data: IncidentIOWidgetResponse
+function hasMaintenanceInProgress(
+  maintenances: IncidentIOStatusPageSummaryResponse['scheduled_maintenances']
+) {
+  return maintenances?.some(
+    (maintenance) => maintenance.status === 'maintenance_in_progress'
+  )
+}
+
+export function getStatusPageStateFromSummary(
+  data: IncidentIOStatusPageSummaryResponse
 ): AggregateState {
-  if (hasEvents(data.ongoing_incidents)) {
-    return getWorstComponentState(data.ongoing_incidents) ?? 'degraded'
-  }
+  if (hasMaintenanceInProgress(data.scheduled_maintenances))
+    return 'maintenance'
 
-  if (hasEvents(data.in_progress_maintenances)) return 'maintenance'
-
-  return 'operational'
+  return (
+    stateFromIndicator(data.status?.indicator) ??
+    getWorstComponentState(data.components) ??
+    'unknown'
+  )
 }

--- a/src/lib/env.ts
+++ b/src/lib/env.ts
@@ -56,7 +56,6 @@ export const clientSchema = z.object({
   NEXT_PUBLIC_INCLUDE_REPORT_ISSUE: z.string().optional(),
   NEXT_PUBLIC_INCLUDE_STATUS_INDICATOR: z.string().optional(),
   NEXT_PUBLIC_STATUS_PAGE_URL: z.url().optional(),
-  NEXT_PUBLIC_STATUS_PAGE_SUMMARY_URL: z.url().optional(),
   NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY: z.string().optional(),
   NEXT_PUBLIC_SCAN: z.string().optional(),
   NEXT_PUBLIC_MOCK_DATA: z.string().optional(),

--- a/src/lib/env.ts
+++ b/src/lib/env.ts
@@ -56,7 +56,7 @@ export const clientSchema = z.object({
   NEXT_PUBLIC_INCLUDE_REPORT_ISSUE: z.string().optional(),
   NEXT_PUBLIC_INCLUDE_STATUS_INDICATOR: z.string().optional(),
   NEXT_PUBLIC_STATUS_PAGE_URL: z.url().optional(),
-  NEXT_PUBLIC_STATUS_PAGE_WIDGET_URL: z.url().optional(),
+  NEXT_PUBLIC_STATUS_PAGE_SUMMARY_URL: z.url().optional(),
   NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY: z.string().optional(),
   NEXT_PUBLIC_SCAN: z.string().optional(),
   NEXT_PUBLIC_MOCK_DATA: z.string().optional(),

--- a/src/lib/env.ts
+++ b/src/lib/env.ts
@@ -55,7 +55,6 @@ export const clientSchema = z.object({
   NEXT_PUBLIC_INCLUDE_ARGUS: z.string().optional(),
   NEXT_PUBLIC_INCLUDE_REPORT_ISSUE: z.string().optional(),
   NEXT_PUBLIC_INCLUDE_STATUS_INDICATOR: z.string().optional(),
-  NEXT_PUBLIC_STATUS_PAGE_URL: z.url().optional(),
   NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY: z.string().optional(),
   NEXT_PUBLIC_SCAN: z.string().optional(),
   NEXT_PUBLIC_MOCK_DATA: z.string().optional(),

--- a/src/lib/env.ts
+++ b/src/lib/env.ts
@@ -55,6 +55,8 @@ export const clientSchema = z.object({
   NEXT_PUBLIC_INCLUDE_ARGUS: z.string().optional(),
   NEXT_PUBLIC_INCLUDE_REPORT_ISSUE: z.string().optional(),
   NEXT_PUBLIC_INCLUDE_STATUS_INDICATOR: z.string().optional(),
+  NEXT_PUBLIC_STATUS_PAGE_URL: z.url().optional(),
+  NEXT_PUBLIC_STATUS_PAGE_WIDGET_URL: z.url().optional(),
   NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY: z.string().optional(),
   NEXT_PUBLIC_SCAN: z.string().optional(),
   NEXT_PUBLIC_MOCK_DATA: z.string().optional(),

--- a/tests/unit/status-indicator.test.ts
+++ b/tests/unit/status-indicator.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it } from 'vitest'
+import { getStatusPageStateFromWidget } from '@/features/dashboard/layouts/status-indicator'
+
+describe('status-indicator', () => {
+  it('should report operational when widget has no active events', () => {
+    expect(
+      getStatusPageStateFromWidget({
+        ongoing_incidents: [],
+        in_progress_maintenances: [],
+        scheduled_maintenances: [
+          {
+            affected_components: [{ status: 'under_maintenance' }],
+          },
+        ],
+      })
+    ).toBe('operational')
+  })
+
+  it('should report maintenance for in-progress maintenances', () => {
+    expect(
+      getStatusPageStateFromWidget({
+        ongoing_incidents: [],
+        in_progress_maintenances: [{}],
+      })
+    ).toBe('maintenance')
+  })
+
+  it('should report downtime for full outage incidents', () => {
+    expect(
+      getStatusPageStateFromWidget({
+        ongoing_incidents: [
+          {
+            affected_components: [
+              { status: 'degraded_performance' },
+              { status: 'full_outage' },
+            ],
+          },
+        ],
+      })
+    ).toBe('downtime')
+  })
+
+  it('should report degraded for partial outage incidents', () => {
+    expect(
+      getStatusPageStateFromWidget({
+        ongoing_incidents: [
+          {
+            affected_components: [{ status: 'partial_outage' }],
+          },
+        ],
+      })
+    ).toBe('degraded')
+  })
+
+  it('should report degraded when incident has no component status', () => {
+    expect(
+      getStatusPageStateFromWidget({
+        ongoing_incidents: [{}],
+      })
+    ).toBe('degraded')
+  })
+})

--- a/tests/unit/status-indicator.test.ts
+++ b/tests/unit/status-indicator.test.ts
@@ -17,11 +17,38 @@ describe('status-indicator', () => {
       getStatusPageStateFromSummary({
         scheduled_maintenances: [
           {
+            status: 'in_progress',
+          },
+        ],
+      })
+    ).toBe('maintenance')
+  })
+
+  it('should support incident.io maintenance status naming', () => {
+    expect(
+      getStatusPageStateFromSummary({
+        scheduled_maintenances: [
+          {
             status: 'maintenance_in_progress',
           },
         ],
       })
     ).toBe('maintenance')
+  })
+
+  it('should prioritize critical indicator over maintenance', () => {
+    expect(
+      getStatusPageStateFromSummary({
+        status: {
+          indicator: 'critical',
+        },
+        scheduled_maintenances: [
+          {
+            status: 'in_progress',
+          },
+        ],
+      })
+    ).toBe('downtime')
   })
 
   it('should report downtime for critical summary indicator', () => {

--- a/tests/unit/status-indicator.test.ts
+++ b/tests/unit/status-indicator.test.ts
@@ -84,6 +84,21 @@ describe('status-indicator', () => {
     ).toBe('degraded')
   })
 
+  it('should report maintenance for under maintenance components', () => {
+    expect(
+      getStatusPageStateFromSummary({
+        status: {
+          indicator: 'none',
+        },
+        components: [
+          {
+            status: 'under_maintenance',
+          },
+        ],
+      })
+    ).toBe('maintenance')
+  })
+
   it('should prioritize degraded components over maintenance indicator', () => {
     expect(
       getStatusPageStateFromSummary({

--- a/tests/unit/status-indicator.test.ts
+++ b/tests/unit/status-indicator.test.ts
@@ -51,7 +51,7 @@ describe('status-indicator', () => {
     ).toBe('downtime')
   })
 
-  it('should report downtime for major outage components', () => {
+  it('should report downtime for full outage components', () => {
     expect(
       getStatusPageStateFromSummary({
         status: {
@@ -61,6 +61,21 @@ describe('status-indicator', () => {
           {
             status: 'degraded_performance',
           },
+          {
+            status: 'full_outage',
+          },
+        ],
+      })
+    ).toBe('downtime')
+  })
+
+  it('should support major outage as a Statuspage compatibility alias', () => {
+    expect(
+      getStatusPageStateFromSummary({
+        status: {
+          indicator: 'none',
+        },
+        components: [
           {
             status: 'major_outage',
           },

--- a/tests/unit/status-indicator.test.ts
+++ b/tests/unit/status-indicator.test.ts
@@ -1,61 +1,55 @@
 import { describe, expect, it } from 'vitest'
-import { getStatusPageStateFromWidget } from '@/features/dashboard/layouts/status-indicator'
+import { getStatusPageStateFromSummary } from '@/features/dashboard/layouts/status-indicator'
 
 describe('status-indicator', () => {
-  it('should report operational when widget has no active events', () => {
+  it('should report operational for summary indicator none', () => {
     expect(
-      getStatusPageStateFromWidget({
-        ongoing_incidents: [],
-        in_progress_maintenances: [],
-        scheduled_maintenances: [
-          {
-            affected_components: [{ status: 'under_maintenance' }],
-          },
-        ],
+      getStatusPageStateFromSummary({
+        status: {
+          indicator: 'none',
+        },
       })
     ).toBe('operational')
   })
 
-  it('should report maintenance for in-progress maintenances', () => {
+  it('should report maintenance for in-progress maintenance', () => {
     expect(
-      getStatusPageStateFromWidget({
-        ongoing_incidents: [],
-        in_progress_maintenances: [{}],
+      getStatusPageStateFromSummary({
+        scheduled_maintenances: [
+          {
+            status: 'maintenance_in_progress',
+          },
+        ],
       })
     ).toBe('maintenance')
   })
 
-  it('should report downtime for full outage incidents', () => {
+  it('should report downtime for critical summary indicator', () => {
     expect(
-      getStatusPageStateFromWidget({
-        ongoing_incidents: [
-          {
-            affected_components: [
-              { status: 'degraded_performance' },
-              { status: 'full_outage' },
-            ],
-          },
-        ],
+      getStatusPageStateFromSummary({
+        status: {
+          indicator: 'critical',
+        },
       })
     ).toBe('downtime')
   })
 
-  it('should report degraded for partial outage incidents', () => {
+  it('should report degraded for major summary indicator', () => {
     expect(
-      getStatusPageStateFromWidget({
-        ongoing_incidents: [
-          {
-            affected_components: [{ status: 'partial_outage' }],
-          },
-        ],
+      getStatusPageStateFromSummary({
+        status: {
+          indicator: 'major',
+        },
       })
     ).toBe('degraded')
   })
 
-  it('should report degraded when incident has no component status', () => {
+  it('should report degraded for minor summary indicator', () => {
     expect(
-      getStatusPageStateFromWidget({
-        ongoing_incidents: [{}],
+      getStatusPageStateFromSummary({
+        status: {
+          indicator: 'minor',
+        },
       })
     ).toBe('degraded')
   })

--- a/tests/unit/status-indicator.test.ts
+++ b/tests/unit/status-indicator.test.ts
@@ -51,6 +51,54 @@ describe('status-indicator', () => {
     ).toBe('downtime')
   })
 
+  it('should report downtime for major outage components', () => {
+    expect(
+      getStatusPageStateFromSummary({
+        status: {
+          indicator: 'none',
+        },
+        components: [
+          {
+            status: 'degraded_performance',
+          },
+          {
+            status: 'major_outage',
+          },
+        ],
+      })
+    ).toBe('downtime')
+  })
+
+  it('should report degraded for partial outage components', () => {
+    expect(
+      getStatusPageStateFromSummary({
+        status: {
+          indicator: 'none',
+        },
+        components: [
+          {
+            status: 'partial_outage',
+          },
+        ],
+      })
+    ).toBe('degraded')
+  })
+
+  it('should prioritize degraded components over maintenance indicator', () => {
+    expect(
+      getStatusPageStateFromSummary({
+        status: {
+          indicator: 'maintenance',
+        },
+        components: [
+          {
+            status: 'degraded_performance',
+          },
+        ],
+      })
+    ).toBe('degraded')
+  })
+
   it('should report downtime for critical summary indicator', () => {
     expect(
       getStatusPageStateFromSummary({


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What changed
- Hardened status state mapping with explicit status maps and priority ranking.
- Mapped incident.io `full_outage` to downtime and kept `major_outage` as a Statuspage compatibility alias.
- Added unit coverage for full outage mapping.

## Checks
- `bun run format:check`
- `bun run lint`
- `bun vitest run tests/unit/status-indicator.test.ts` *(latest run hit known Vitest/Bun worker startup/teardown error before collecting tests: `Cannot access 'dispose' before initialization`)*
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-42bd97db-cbc9-4394-bad0-4b516273843d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-42bd97db-cbc9-4394-bad0-4b516273843d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

