### PR TITLE
fix(auth): allow localhost URLs in email-confirm next param

### DIFF
--- a/src/app/api/auth/confirm/route.ts
+++ b/src/app/api/auth/confirm/route.ts
@@ -4,12 +4,13 @@ import { z } from 'zod'
 import { AUTH_URLS } from '@/configs/urls'
 import { OtpTypeSchema } from '@/core/modules/auth/models'
 import { l } from '@/core/shared/clients/logger/logger'
+import { httpUrlSchema } from '@/core/shared/schemas/url'
 import { encodedRedirect, isExternalOrigin } from '@/lib/utils/auth'
 
 const confirmSchema = z.object({
   token_hash: z.string().min(1),
   type: OtpTypeSchema,
-  next: z.httpUrl(),
+  next: httpUrlSchema,
 })
 
 /**

--- a/src/core/modules/auth/models.ts
+++ b/src/core/modules/auth/models.ts
@@ -1,4 +1,5 @@
 import z from 'zod'
+import { httpUrlSchema } from '@/core/shared/schemas/url'
 
 export const OtpTypeSchema = z.enum([
   'signup',
@@ -14,7 +15,7 @@ export type OtpType = z.infer<typeof OtpTypeSchema>
 export const ConfirmEmailInputSchema = z.object({
   token_hash: z.string().min(1),
   type: OtpTypeSchema,
-  next: z.httpUrl(),
+  next: httpUrlSchema,
 })
 
 export type ConfirmEmailInput = z.infer<typeof ConfirmEmailInputSchema>

--- a/src/core/shared/schemas/url.ts
+++ b/src/core/shared/schemas/url.ts
@@ -1,5 +1,18 @@
 import { z } from 'zod'
 
+/**
+ * Validates that a string is a well-formed HTTP or HTTPS URL.
+ *
+ * Unlike `z.httpUrl()`, this also accepts localhost / 127.0.0.1 URLs so the
+ * email-verification flow works against a local Supabase setup in development.
+ *
+ * The schema only validates URL structure — redirect safety is enforced
+ * downstream by `isExternalOrigin()` and `buildRedirectUrl()` in the auth
+ * route handlers, which reconstruct the redirect using the dashboard's own
+ * origin and preserve only `pathname` + `searchParams` from the input.
+ */
+export const httpUrlSchema = z.url({ protocol: /^https?$/ })
+
 export const relativeUrlSchema = z
   .string()
   .trim()

--- a/tests/unit/url-schema.test.ts
+++ b/tests/unit/url-schema.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, it } from 'vitest'
+import { httpUrlSchema } from '@/core/shared/schemas/url'
+
+describe('httpUrlSchema', () => {
+  describe('accepts valid http/https URLs', () => {
+    it('accepts https production URLs', () => {
+      expect(httpUrlSchema.safeParse('https://e2b.dev/dashboard').success).toBe(
+        true
+      )
+    })
+
+    it('accepts https URLs with paths and query params', () => {
+      expect(
+        httpUrlSchema.safeParse('https://e2b.dev/dashboard?tab=settings')
+          .success
+      ).toBe(true)
+    })
+
+    it('accepts http localhost URLs', () => {
+      expect(
+        httpUrlSchema.safeParse('http://localhost:3000/dashboard').success
+      ).toBe(true)
+    })
+
+    it('accepts http localhost without port', () => {
+      expect(httpUrlSchema.safeParse('http://localhost').success).toBe(true)
+    })
+
+    it('accepts http 127.0.0.1 URLs', () => {
+      expect(httpUrlSchema.safeParse('http://127.0.0.1:3000').success).toBe(
+        true
+      )
+    })
+
+    it('accepts https URLs with subdomains', () => {
+      expect(
+        httpUrlSchema.safeParse('https://app.e2b.dev/dashboard').success
+      ).toBe(true)
+    })
+  })
+
+  describe('rejects non-http(s) schemes', () => {
+    it('rejects mailto URLs', () => {
+      expect(httpUrlSchema.safeParse('mailto:user@example.com').success).toBe(
+        false
+      )
+    })
+
+    it('rejects ftp URLs', () => {
+      expect(httpUrlSchema.safeParse('ftp://files.example.com').success).toBe(
+        false
+      )
+    })
+
+    it('rejects file URLs', () => {
+      expect(httpUrlSchema.safeParse('file:///etc/passwd').success).toBe(false)
+    })
+
+    it('rejects javascript URLs', () => {
+      expect(httpUrlSchema.safeParse('javascript:alert(1)').success).toBe(false)
+    })
+  })
+
+  describe('rejects invalid inputs', () => {
+    it('rejects plain strings', () => {
+      expect(httpUrlSchema.safeParse('not-a-url').success).toBe(false)
+    })
+
+    it('rejects empty strings', () => {
+      expect(httpUrlSchema.safeParse('').success).toBe(false)
+    })
+  })
+})


### PR DESCRIPTION
## Summary

Fixes [#241](https://github.com/e2b-dev/dashboard/issues/241): Zod validation error blocks email verification on local-dev Supabase setups.

- Replaces `z.httpUrl()` with a shared `httpUrlSchema` that uses `z.url({ protocol: /^https?$/ })` — still requires http/https, but accepts `http://localhost:3000/...`.
 - Schema lives in `src/core/shared/schemas/url.ts` alongside the existing `relativeUrlSchema`, and both the auth confirm route handler and `ConfirmEmailInputSchema` consume it.
- Webhook URL validation (`src/core/server/functions/webhooks/schema.ts`) intentionally kept on `z.httpUrl()` — webhooks should not accept localhost.

## Files changed

 - `src/core/shared/schemas/url.ts` — adds `httpUrlSchema` alongside existing `relativeUrlSchema`
- `src/core/modules/auth/models.ts` — `ConfirmEmailInputSchema.next` uses the shared schema
- `src/app/api/auth/confirm/route.ts` — same for the route's inline `confirmSchema`
- `tests/unit/url-schema.test.ts` *(new)* — 12 unit tests covering accept/reject cases

## Tests

```
bun run test:unit
bun run lint
```

## Credits
Adapted from #249 by @taheerahmed 