### PR TITLE
fix: prevent sensitive data leaking into logs

### DIFF
--- a/src/app/api/auth/callback/route.ts
+++ b/src/app/api/auth/callback/route.ts
@@ -38,7 +38,7 @@ export async function GET(request: Request) {
           key: 'auth_callback:supabase_error',
           error: serializeErrorForLog(error),
           context: {
-            code,
+            hasCode: !!code,
             origin,
             returnTo,
             redirectTo,

--- a/src/core/server/actions/client.ts
+++ b/src/core/server/actions/client.ts
@@ -28,7 +28,7 @@ import type {
 import {
   ActionError,
   flattenClientInputValue,
-  summarizeClientInput,
+  sanitizeClientInput,
 } from './utils'
 
 type SupabaseServerClient = Awaited<ReturnType<typeof createClient>>
@@ -139,11 +139,7 @@ export const actionClient = createSafeActionClient({
   const baseLogPayload = {
     server_function_type: type,
     server_function_name: name,
-    // Do NOT log raw clientInput — it's an arbitrary user-supplied payload
-    // and relying on pino redaction as a blocklist is fragile (any new action
-    // with a non-standard sensitive field name would leak by default).
-    // summarizeClientInput keeps an allowlisted, debug-safe shape view.
-    server_function_input_summary: summarizeClientInput(clientInput),
+    server_function_input_summary: sanitizeClientInput(clientInput),
     server_function_duration_ms: duration.toFixed(3),
     request_url: requestObservabilityContext.request_url,
     request_path: requestObservabilityContext.request_path,

--- a/src/core/server/actions/client.ts
+++ b/src/core/server/actions/client.ts
@@ -25,7 +25,11 @@ import type {
   RequestScope,
   TeamRequestScope,
 } from '@/core/shared/repository-scope'
-import { ActionError, flattenClientInputValue } from './utils'
+import {
+  ActionError,
+  flattenClientInputValue,
+  summarizeClientInput,
+} from './utils'
 
 type SupabaseServerClient = Awaited<ReturnType<typeof createClient>>
 
@@ -135,7 +139,11 @@ export const actionClient = createSafeActionClient({
   const baseLogPayload = {
     server_function_type: type,
     server_function_name: name,
-    server_function_input: clientInput,
+    // Do NOT log raw clientInput — it's an arbitrary user-supplied payload
+    // and relying on pino redaction as a blocklist is fragile (any new action
+    // with a non-standard sensitive field name would leak by default).
+    // summarizeClientInput keeps an allowlisted, debug-safe shape view.
+    server_function_input_summary: summarizeClientInput(clientInput),
     server_function_duration_ms: duration.toFixed(3),
     request_url: requestObservabilityContext.request_url,
     request_path: requestObservabilityContext.request_path,

--- a/src/core/server/actions/utils.ts
+++ b/src/core/server/actions/utils.ts
@@ -45,14 +45,6 @@ export const flattenClientInputValue = (
   return undefined
 }
 
-/**
- * Keys that are safe to log in cleartext from action inputs — IDs, slugs,
- * enums, and small flags. Any key not on this list is replaced with a type
- * hint (e.g. `string(64)`, `array(3)`, `object`) so we never leak raw values.
- *
- * Keep this list tight: prefer adding scoped per-action logging in the action
- * body over expanding this allowlist.
- */
 const SAFE_INPUT_KEYS = new Set<string>([
   'teamSlug',
   'teamId',

--- a/src/core/server/actions/utils.ts
+++ b/src/core/server/actions/utils.ts
@@ -44,3 +44,73 @@ export const flattenClientInputValue = (
 
   return undefined
 }
+
+/**
+ * Keys that are safe to log in cleartext from action inputs — IDs, slugs,
+ * enums, and small flags. Any key not on this list is replaced with a type
+ * hint (e.g. `string(64)`, `array(3)`, `object`) so we never leak raw values.
+ *
+ * Keep this list tight: prefer adding scoped per-action logging in the action
+ * body over expanding this allowlist.
+ */
+const SAFE_INPUT_KEYS = new Set<string>([
+  'teamSlug',
+  'teamId',
+  'templateId',
+  'sandboxId',
+  'userId',
+  'webhookId',
+  'organizationId',
+  'page',
+  'pageSize',
+  'limit',
+  'offset',
+  'sortBy',
+  'sortOrder',
+  'mode',
+  'kind',
+  'type',
+])
+
+function describeValue(value: unknown): string {
+  if (value === null) return 'null'
+  if (value === undefined) return 'undefined'
+  if (Array.isArray(value)) return `array(${value.length})`
+  const t = typeof value
+  if (t === 'string') return `string(${(value as string).length})`
+  if (t === 'object') return 'object'
+  return t
+}
+
+/**
+ * Build a debug-safe summary of an action's clientInput.
+ *
+ * - Allowlisted scalar keys are inlined as-is.
+ * - Everything else is replaced with `_<key>: <type-hint>` so shape and
+ *   length are visible without leaking values.
+ *
+ * This is the inverse of the previous blocklist-via-pino-redaction approach:
+ * new sensitive fields are safe by default and only become loggable when
+ * explicitly added to {@link SAFE_INPUT_KEYS}.
+ */
+export function summarizeClientInput(input: unknown): Record<string, unknown> {
+  if (!input || typeof input !== 'object' || Array.isArray(input)) {
+    return { _shape: describeValue(input) }
+  }
+
+  const out: Record<string, unknown> = {}
+  for (const [key, value] of Object.entries(input as Record<string, unknown>)) {
+    const valueType = typeof value
+    if (
+      SAFE_INPUT_KEYS.has(key) &&
+      (valueType === 'string' ||
+        valueType === 'number' ||
+        valueType === 'boolean')
+    ) {
+      out[key] = value
+    } else {
+      out[`_${key}`] = describeValue(value)
+    }
+  }
+  return out
+}

--- a/src/core/server/actions/utils.ts
+++ b/src/core/server/actions/utils.ts
@@ -83,17 +83,17 @@ function describeValue(value: unknown): string {
 }
 
 /**
- * Build a debug-safe summary of an action's clientInput.
+ * Sanitize action `clientInput` for safe logging (e.g. telemetry summaries).
  *
  * - Allowlisted scalar keys are inlined as-is.
  * - Everything else is replaced with `_<key>: <type-hint>` so shape and
  *   length are visible without leaking values.
  *
- * This is the inverse of the previous blocklist-via-pino-redaction approach:
- * new sensitive fields are safe by default and only become loggable when
- * explicitly added to {@link SAFE_INPUT_KEYS}.
+ * Allowlist-based sanitization is the inverse of the old blocklist-via-pino-
+ * redaction approach: new sensitive fields are safe by default and only become
+ * loggable when explicitly added to {@link SAFE_INPUT_KEYS}.
  */
-export function summarizeClientInput(input: unknown): Record<string, unknown> {
+export function sanitizeClientInput(input: unknown): Record<string, unknown> {
   if (!input || typeof input !== 'object' || Array.isArray(input)) {
     return { _shape: describeValue(input) }
   }

--- a/src/core/shared/clients/logger/redaction.ts
+++ b/src/core/shared/clients/logger/redaction.ts
@@ -6,6 +6,7 @@ const TOP_LEVEL_REDACTION_KEYS = [
   'refreshToken',
   'refresh_token',
   'secret',
+  'signatureSecret',
   'token',
   'apiKey',
   'api_key',

--- a/tests/unit/action-input-summary.test.ts
+++ b/tests/unit/action-input-summary.test.ts
@@ -1,0 +1,144 @@
+import { describe, expect, it } from 'vitest'
+import { summarizeClientInput } from '@/core/server/actions/utils'
+
+describe('summarizeClientInput', () => {
+  it('inlines allowlisted scalar keys verbatim', () => {
+    const out = summarizeClientInput({
+      teamSlug: 'acme',
+      teamId: 't_123',
+      templateId: 'tmpl_456',
+      sandboxId: 'sbx_789',
+      userId: 'user_abc',
+      webhookId: 'wh_xyz',
+      organizationId: 'org_1',
+      page: 2,
+      pageSize: 50,
+      limit: 100,
+      offset: 0,
+      sortBy: 'createdAt',
+      sortOrder: 'desc',
+      mode: 'add',
+      kind: 'standard',
+      type: 'webhook',
+    })
+
+    expect(out).toEqual({
+      teamSlug: 'acme',
+      teamId: 't_123',
+      templateId: 'tmpl_456',
+      sandboxId: 'sbx_789',
+      userId: 'user_abc',
+      webhookId: 'wh_xyz',
+      organizationId: 'org_1',
+      page: 2,
+      pageSize: 50,
+      limit: 100,
+      offset: 0,
+      sortBy: 'createdAt',
+      sortOrder: 'desc',
+      mode: 'add',
+      kind: 'standard',
+      type: 'webhook',
+    })
+  })
+
+  it('summarizes non-allowlisted keys as a type hint, never the raw value', () => {
+    const out = summarizeClientInput({
+      signatureSecret: 'a'.repeat(64),
+      password: 'hunter2',
+      apiToken: 'tok_secret',
+      privateKey: '-----BEGIN PRIVATE KEY-----\n…',
+    })
+
+    expect(out).toEqual({
+      _signatureSecret: 'string(64)',
+      _password: 'string(7)',
+      _apiToken: 'string(10)',
+      _privateKey: `string(${'-----BEGIN PRIVATE KEY-----\n…'.length})`,
+    })
+
+    // Belt and braces: no value should appear in the JSON-serialized output.
+    const serialized = JSON.stringify(out)
+    expect(serialized).not.toContain('hunter2')
+    expect(serialized).not.toContain('tok_secret')
+    expect(serialized).not.toContain('BEGIN PRIVATE KEY')
+    expect(serialized).not.toContain('a'.repeat(64))
+  })
+
+  it('mixes allowlisted and sensitive fields safely', () => {
+    const out = summarizeClientInput({
+      teamSlug: 'acme',
+      webhookId: 'wh_123',
+      signatureSecret: 'super-secret-value',
+    })
+
+    expect(out).toEqual({
+      teamSlug: 'acme',
+      webhookId: 'wh_123',
+      _signatureSecret: 'string(18)',
+    })
+  })
+
+  it('summarizes nested objects as "object" without recursing into values', () => {
+    const out = summarizeClientInput({
+      teamSlug: 'acme',
+      payload: {
+        nested: {
+          secret: 'should-never-appear',
+        },
+      },
+    })
+
+    expect(out).toEqual({
+      teamSlug: 'acme',
+      _payload: 'object',
+    })
+    expect(JSON.stringify(out)).not.toContain('should-never-appear')
+  })
+
+  it('describes arrays with length', () => {
+    const out = summarizeClientInput({
+      sandboxIds: ['a', 'b', 'c', 'd'],
+    })
+
+    expect(out).toEqual({ _sandboxIds: 'array(4)' })
+  })
+
+  it('handles null, undefined, and primitive inputs', () => {
+    expect(summarizeClientInput(null)).toEqual({ _shape: 'null' })
+    expect(summarizeClientInput(undefined)).toEqual({ _shape: 'undefined' })
+    expect(summarizeClientInput('raw-string')).toEqual({
+      _shape: 'string(10)',
+    })
+    expect(summarizeClientInput(42)).toEqual({ _shape: 'number' })
+    expect(summarizeClientInput(true)).toEqual({ _shape: 'boolean' })
+  })
+
+  it('treats top-level array input as a non-object shape', () => {
+    expect(summarizeClientInput(['a', 'b'])).toEqual({ _shape: 'array(2)' })
+  })
+
+  it('describes null and undefined values inside an object', () => {
+    const out = summarizeClientInput({
+      teamSlug: 'acme',
+      maybeNull: null,
+      maybeUndefined: undefined,
+    })
+
+    expect(out).toEqual({
+      teamSlug: 'acme',
+      _maybeNull: 'null',
+      _maybeUndefined: 'undefined',
+    })
+  })
+
+  it('does not inline allowlisted keys when their value is a non-scalar', () => {
+    // teamSlug is allowlisted, but only when scalar — guard against payload
+    // shapes that smuggle objects through allowlisted keys.
+    const out = summarizeClientInput({
+      teamSlug: { evil: 'object' },
+    })
+
+    expect(out).toEqual({ _teamSlug: 'object' })
+  })
+})

--- a/tests/unit/action-input-summary.test.ts
+++ b/tests/unit/action-input-summary.test.ts
@@ -1,9 +1,9 @@
 import { describe, expect, it } from 'vitest'
-import { summarizeClientInput } from '@/core/server/actions/utils'
+import { sanitizeClientInput } from '@/core/server/actions/utils'
 
-describe('summarizeClientInput', () => {
+describe('sanitizeClientInput', () => {
   it('inlines allowlisted scalar keys verbatim', () => {
-    const out = summarizeClientInput({
+    const out = sanitizeClientInput({
       teamSlug: 'acme',
       teamId: 't_123',
       templateId: 'tmpl_456',
@@ -43,7 +43,7 @@ describe('summarizeClientInput', () => {
   })
 
   it('summarizes non-allowlisted keys as a type hint, never the raw value', () => {
-    const out = summarizeClientInput({
+    const out = sanitizeClientInput({
       signatureSecret: 'a'.repeat(64),
       password: 'hunter2',
       apiToken: 'tok_secret',
@@ -66,7 +66,7 @@ describe('summarizeClientInput', () => {
   })
 
   it('mixes allowlisted and sensitive fields safely', () => {
-    const out = summarizeClientInput({
+    const out = sanitizeClientInput({
       teamSlug: 'acme',
       webhookId: 'wh_123',
       signatureSecret: 'super-secret-value',
@@ -80,7 +80,7 @@ describe('summarizeClientInput', () => {
   })
 
   it('summarizes nested objects as "object" without recursing into values', () => {
-    const out = summarizeClientInput({
+    const out = sanitizeClientInput({
       teamSlug: 'acme',
       payload: {
         nested: {
@@ -97,7 +97,7 @@ describe('summarizeClientInput', () => {
   })
 
   it('describes arrays with length', () => {
-    const out = summarizeClientInput({
+    const out = sanitizeClientInput({
       sandboxIds: ['a', 'b', 'c', 'd'],
     })
 
@@ -105,21 +105,21 @@ describe('summarizeClientInput', () => {
   })
 
   it('handles null, undefined, and primitive inputs', () => {
-    expect(summarizeClientInput(null)).toEqual({ _shape: 'null' })
-    expect(summarizeClientInput(undefined)).toEqual({ _shape: 'undefined' })
-    expect(summarizeClientInput('raw-string')).toEqual({
+    expect(sanitizeClientInput(null)).toEqual({ _shape: 'null' })
+    expect(sanitizeClientInput(undefined)).toEqual({ _shape: 'undefined' })
+    expect(sanitizeClientInput('raw-string')).toEqual({
       _shape: 'string(10)',
     })
-    expect(summarizeClientInput(42)).toEqual({ _shape: 'number' })
-    expect(summarizeClientInput(true)).toEqual({ _shape: 'boolean' })
+    expect(sanitizeClientInput(42)).toEqual({ _shape: 'number' })
+    expect(sanitizeClientInput(true)).toEqual({ _shape: 'boolean' })
   })
 
   it('treats top-level array input as a non-object shape', () => {
-    expect(summarizeClientInput(['a', 'b'])).toEqual({ _shape: 'array(2)' })
+    expect(sanitizeClientInput(['a', 'b'])).toEqual({ _shape: 'array(2)' })
   })
 
   it('describes null and undefined values inside an object', () => {
-    const out = summarizeClientInput({
+    const out = sanitizeClientInput({
       teamSlug: 'acme',
       maybeNull: null,
       maybeUndefined: undefined,
@@ -135,7 +135,7 @@ describe('summarizeClientInput', () => {
   it('does not inline allowlisted keys when their value is a non-scalar', () => {
     // teamSlug is allowlisted, but only when scalar — guard against payload
     // shapes that smuggle objects through allowlisted keys.
-    const out = summarizeClientInput({
+    const out = sanitizeClientInput({
       teamSlug: { evil: 'object' },
     })
 

--- a/tests/unit/logger-redaction.test.ts
+++ b/tests/unit/logger-redaction.test.ts
@@ -39,8 +39,10 @@ describe('logger redaction', () => {
         captchaToken: 'captcha-secret',
         nested: {
           token_hash: 'otp-token-hash',
+          signatureSecret: 'nested-signature-secret',
         },
         password: 'super-secret-password',
+        signatureSecret: 'webhook-signing-secret',
       },
     })
 
@@ -58,8 +60,10 @@ describe('logger redaction', () => {
         captchaToken?: string
         nested?: {
           token_hash?: string
+          signatureSecret?: string
         }
         password?: string
+        signatureSecret?: string
       }
     }
 
@@ -67,9 +71,43 @@ describe('logger redaction', () => {
     expect(payload.server_function_input?.captchaToken).toBe(REDACTION_CENSOR)
     expect(payload.server_function_input?.access_token).toBe(REDACTION_CENSOR)
     expect(payload.server_function_input?.api_key).toBe(REDACTION_CENSOR)
+    expect(payload.server_function_input?.signatureSecret).toBe(
+      REDACTION_CENSOR
+    )
     expect(payload.server_function_input?.nested?.token_hash).toBe(
       REDACTION_CENSOR
     )
+    expect(payload.server_function_input?.nested?.signatureSecret).toBe(
+      REDACTION_CENSOR
+    )
     expect(payload.error?.config?.headers?.Authorization).toBe(REDACTION_CENSOR)
+  })
+
+  it('redacts signatureSecret at top level', () => {
+    const writes: string[] = []
+
+    const logger = pino(
+      {
+        base: undefined,
+        redact: {
+          paths: REDACTION_PATHS,
+          censor: REDACTION_CENSOR,
+        },
+        timestamp: false,
+      },
+      {
+        write(chunk: string) {
+          writes.push(chunk)
+        },
+      }
+    )
+
+    logger.info({ signatureSecret: 'top-level-webhook-secret' })
+
+    const payload = JSON.parse(writes[0] ?? '{}') as {
+      signatureSecret?: string
+    }
+
+    expect(payload.signatureSecret).toBe(REDACTION_CENSOR)
   })
 })


### PR DESCRIPTION
Closes #259 . Supersedes #260 with a broader fix + tests.

## Changes
- `src/app/api/auth/callback/route.ts` — error branch logs `hasCode: !!code `instead of the raw auth code (matches the info log above).
- `src/core/shared/clients/logger/redaction.ts` — add `signatureSecret` to redaction paths. (access_token is already covered.)
- `src/core/server/actions/{client,utils}.ts` —  avoid logging raw `clientInput`. A new `summarizeClientInput` helper inlines a small set of allowlisted scalar keys and replaces all other fields with shape hints like `string(64)`, `array(3)`, `object`.