### PR TITLE
fix(sandbox): restore mobile scroll behavior on details page

### DIFF
--- a/src/features/dashboard/sandbox/layout.tsx
+++ b/src/features/dashboard/sandbox/layout.tsx
@@ -1,41 +1,21 @@
 'use client'
 
-import { notFound, usePathname, useRouter } from 'next/navigation'
+import { notFound } from 'next/navigation'
 import { PROTECTED_URLS } from '@/configs/urls'
 import { useRouteParams } from '@/lib/hooks/use-route-params'
-import { HoverPrefetchLink } from '@/ui/hover-prefetch-link'
+import { DashboardTabsList } from '@/ui/dashboard-tabs'
 import {
   HistoryIcon,
   ListIcon,
   StorageIcon,
   TrendIcon,
 } from '@/ui/primitives/icons'
-import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-} from '@/ui/primitives/select'
-import { Tabs, TabsList, TabsTrigger } from '@/ui/primitives/tabs'
 import { useSandboxContext } from './context'
 
 interface SandboxLayoutProps {
   children: React.ReactNode
   header: React.ReactNode
   tabsHeaderAccessory?: React.ReactNode
-}
-
-const TABS_LAYOUT_KEY = 'tabs-indicator-sandbox'
-
-interface SandboxTab {
-  id: string
-  label: string
-  href: string
-  icon: React.ReactNode
-}
-
-function isTabActive(pathname: string, href: string): boolean {
-  return pathname === href || pathname.startsWith(`${href}/`)
 }
 
 export default function SandboxLayout({
@@ -45,8 +25,6 @@ export default function SandboxLayout({
 }: SandboxLayoutProps) {
   const { teamSlug, sandboxId } =
     useRouteParams<'/dashboard/[teamSlug]/sandboxes/[sandboxId]'>()
-  const pathname = usePathname()
-  const router = useRouter()
   const { sandboxInfo, isSandboxInfoLoading, isSandboxNotFound } =
     useSandboxContext()
 
@@ -60,101 +38,48 @@ export default function SandboxLayout({
     }
   }
 
-  const tabs: SandboxTab[] = [
-    {
-      id: 'monitoring',
-      label: 'Monitoring',
-      href: PROTECTED_URLS.SANDBOX_MONITORING(teamSlug, sandboxId),
-      icon: <TrendIcon className="size-4" />,
-    },
-    {
-      id: 'events',
-      label: 'Events',
-      href: PROTECTED_URLS.SANDBOX_EVENTS(teamSlug, sandboxId),
-      icon: <HistoryIcon className="size-4" />,
-    },
-    {
-      id: 'logs',
-      label: 'Logs',
-      href: PROTECTED_URLS.SANDBOX_LOGS(teamSlug, sandboxId),
-      icon: <ListIcon className="size-4" />,
-    },
-    {
-      id: 'filesystem',
-      label: 'Filesystem',
-      href: PROTECTED_URLS.SANDBOX_FILESYSTEM(teamSlug, sandboxId),
-      icon: <StorageIcon className="size-4" />,
-    },
-  ]
-
-  const firstTab = tabs[0]!
-  const activeTab =
-    tabs.find((tab) => isTabActive(pathname, tab.href)) ?? firstTab
-  const activeTabId = activeTab.id
-
-  const tabTriggers = tabs.map((tab) => (
-    <TabsTrigger
-      key={tab.id}
-      layoutkey={TABS_LAYOUT_KEY}
-      value={tab.id}
-      className="w-fit flex-none"
-      asChild
-    >
-      <HoverPrefetchLink href={tab.href}>
-        {tab.icon}
-        {tab.label}
-      </HoverPrefetchLink>
-    </TabsTrigger>
-  ))
-
-  const handleTabSelect = (id: string) => {
-    const tab = tabs.find((t) => t.id === id)
-    if (tab) router.push(tab.href)
-  }
-
   return (
     <div className="flex h-full min-h-0 flex-1 flex-col">
-      <Tabs
-        value={activeTabId}
-        className="flex h-full w-full min-h-0 flex-col max-md:overflow-y-auto md:flex-1"
-      >
+      <div className="flex h-full w-full min-h-0 flex-col max-md:overflow-y-auto md:flex-1">
         <div className="max-md:shrink-0">{header}</div>
 
         <div className="flex flex-col max-md:h-full max-md:shrink-0 md:min-h-0 md:flex-1">
-          <div className="bg-bg z-20 flex w-full flex-row items-end max-md:sticky max-md:top-0">
-            <Select value={activeTabId} onValueChange={handleTabSelect}>
-              <SelectTrigger className="h-9 w-fit border-x-0 border-t-0 border-b border-solid md:hidden">
-                <div className="flex items-center gap-2">
-                  {activeTab.icon}
-                  {activeTab.label}
-                </div>
-              </SelectTrigger>
-              <SelectContent>
-                {tabs.map((tab) => (
-                  <SelectItem key={tab.id} value={tab.id}>
-                    <div className="flex items-center gap-2">
-                      {tab.icon}
-                      {tab.label}
-                    </div>
-                  </SelectItem>
-                ))}
-              </SelectContent>
-            </Select>
-
-            <TabsList className="bg-bg justify-start max-md:hidden md:flex-1">
-              {tabTriggers}
-            </TabsList>
-
-            {tabsHeaderAccessory && (
-              <div className="flex items-end border-b border-solid max-md:flex-1 max-md:justify-end md:px-6">
-                {tabsHeaderAccessory}
-              </div>
-            )}
-          </div>
+          <DashboardTabsList
+            layoutKey="tabs-indicator-sandbox"
+            className="bg-bg z-20 max-md:sticky max-md:top-0"
+            mobileVariant="select"
+            headerAccessory={tabsHeaderAccessory}
+            tabs={[
+              {
+                id: 'monitoring',
+                label: 'Monitoring',
+                href: PROTECTED_URLS.SANDBOX_MONITORING(teamSlug, sandboxId),
+                icon: <TrendIcon className="size-4" />,
+              },
+              {
+                id: 'events',
+                label: 'Events',
+                href: PROTECTED_URLS.SANDBOX_EVENTS(teamSlug, sandboxId),
+                icon: <HistoryIcon className="size-4" />,
+              },
+              {
+                id: 'logs',
+                label: 'Logs',
+                href: PROTECTED_URLS.SANDBOX_LOGS(teamSlug, sandboxId),
+                icon: <ListIcon className="size-4" />,
+              },
+              {
+                id: 'filesystem',
+                label: 'Filesystem',
+                href: PROTECTED_URLS.SANDBOX_FILESYSTEM(teamSlug, sandboxId),
+                icon: <StorageIcon className="size-4" />,
+              },
+            ]}
+          />
 
           <div className="flex min-h-0 flex-1 flex-col">{children}</div>
         </div>
-      </Tabs>
+      </div>
     </div>
   )
 }

--- a/src/features/dashboard/sandbox/layout.tsx
+++ b/src/features/dashboard/sandbox/layout.tsx
@@ -1,21 +1,41 @@
 'use client'
 
-import { notFound } from 'next/navigation'
+import { notFound, usePathname, useRouter } from 'next/navigation'
 import { PROTECTED_URLS } from '@/configs/urls'
 import { useRouteParams } from '@/lib/hooks/use-route-params'
-import { DashboardTabsList } from '@/ui/dashboard-tabs'
+import { HoverPrefetchLink } from '@/ui/hover-prefetch-link'
 import {
   HistoryIcon,
   ListIcon,
   StorageIcon,
   TrendIcon,
 } from '@/ui/primitives/icons'
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+} from '@/ui/primitives/select'
+import { Tabs, TabsList, TabsTrigger } from '@/ui/primitives/tabs'
 import { useSandboxContext } from './context'
 
 interface SandboxLayoutProps {
   children: React.ReactNode
   header: React.ReactNode
   tabsHeaderAccessory?: React.ReactNode
+}
+
+const TABS_LAYOUT_KEY = 'tabs-indicator-sandbox'
+
+interface SandboxTab {
+  id: string
+  label: string
+  href: string
+  icon: React.ReactNode
+}
+
+function isTabActive(pathname: string, href: string): boolean {
+  return pathname === href || pathname.startsWith(`${href}/`)
 }
 
 export default function SandboxLayout({
@@ -25,7 +45,8 @@ export default function SandboxLayout({
 }: SandboxLayoutProps) {
   const { teamSlug, sandboxId } =
     useRouteParams<'/dashboard/[teamSlug]/sandboxes/[sandboxId]'>()
-
+  const pathname = usePathname()
+  const router = useRouter()
   const { sandboxInfo, isSandboxInfoLoading, isSandboxNotFound } =
     useSandboxContext()
 
@@ -39,42 +60,101 @@ export default function SandboxLayout({
     }
   }
 
-  return (
-    <div className="flex h-full min-h-0 flex-1 flex-col max-md:overflow-y-auto">
-      {header}
+  const tabs: SandboxTab[] = [
+    {
+      id: 'monitoring',
+      label: 'Monitoring',
+      href: PROTECTED_URLS.SANDBOX_MONITORING(teamSlug, sandboxId),
+      icon: <TrendIcon className="size-4" />,
+    },
+    {
+      id: 'events',
+      label: 'Events',
+      href: PROTECTED_URLS.SANDBOX_EVENTS(teamSlug, sandboxId),
+      icon: <HistoryIcon className="size-4" />,
+    },
+    {
+      id: 'logs',
+      label: 'Logs',
+      href: PROTECTED_URLS.SANDBOX_LOGS(teamSlug, sandboxId),
+      icon: <ListIcon className="size-4" />,
+    },
+    {
+      id: 'filesystem',
+      label: 'Filesystem',
+      href: PROTECTED_URLS.SANDBOX_FILESYSTEM(teamSlug, sandboxId),
+      icon: <StorageIcon className="size-4" />,
+    },
+  ]
 
-      <DashboardTabsList
-        layoutKey="tabs-indicator-sandbox"
-        className="max-md:sticky max-md:top-0 max-md:z-20"
-        headerAccessory={tabsHeaderAccessory}
-        tabs={[
-          {
-            id: 'monitoring',
-            label: 'Monitoring',
-            href: PROTECTED_URLS.SANDBOX_MONITORING(teamSlug, sandboxId),
-            icon: <TrendIcon className="size-4" />,
-          },
-          {
-            id: 'events',
-            label: 'Events',
-            href: PROTECTED_URLS.SANDBOX_EVENTS(teamSlug, sandboxId),
-            icon: <HistoryIcon className="size-4" />,
-          },
-          {
-            id: 'logs',
-            label: 'Logs',
-            href: PROTECTED_URLS.SANDBOX_LOGS(teamSlug, sandboxId),
-            icon: <ListIcon className="size-4" />,
-          },
-          {
-            id: 'filesystem',
-            label: 'Filesystem',
-            href: PROTECTED_URLS.SANDBOX_FILESYSTEM(teamSlug, sandboxId),
-            icon: <StorageIcon className="size-4" />,
-          },
-        ]}
-      />
-      {children}
+  const firstTab = tabs[0]!
+  const activeTab =
+    tabs.find((tab) => isTabActive(pathname, tab.href)) ?? firstTab
+  const activeTabId = activeTab.id
+
+  const tabTriggers = tabs.map((tab) => (
+    <TabsTrigger
+      key={tab.id}
+      layoutkey={TABS_LAYOUT_KEY}
+      value={tab.id}
+      className="w-fit flex-none"
+      asChild
+    >
+      <HoverPrefetchLink href={tab.href}>
+        {tab.icon}
+        {tab.label}
+      </HoverPrefetchLink>
+    </TabsTrigger>
+  ))
+
+  const handleTabSelect = (id: string) => {
+    const tab = tabs.find((t) => t.id === id)
+    if (tab) router.push(tab.href)
+  }
+
+  return (
+    <div className="flex h-full min-h-0 flex-1 flex-col">
+      <Tabs
+        value={activeTabId}
+        className="flex h-full w-full min-h-0 flex-col max-md:overflow-y-auto md:flex-1"
+      >
+        <div className="max-md:shrink-0">{header}</div>
+
+        <div className="flex flex-col max-md:h-full max-md:shrink-0 md:min-h-0 md:flex-1">
+          <div className="bg-bg z-20 flex w-full flex-row items-end max-md:sticky max-md:top-0">
+            <Select value={activeTabId} onValueChange={handleTabSelect}>
+              <SelectTrigger className="h-9 w-fit border-x-0 border-t-0 border-b border-solid md:hidden">
+                <div className="flex items-center gap-2">
+                  {activeTab.icon}
+                  {activeTab.label}
+                </div>
+              </SelectTrigger>
+              <SelectContent>
+                {tabs.map((tab) => (
+                  <SelectItem key={tab.id} value={tab.id}>
+                    <div className="flex items-center gap-2">
+                      {tab.icon}
+                      {tab.label}
+                    </div>
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+
+            <TabsList className="bg-bg justify-start max-md:hidden md:flex-1">
+              {tabTriggers}
+            </TabsList>
+
+            {tabsHeaderAccessory && (
+              <div className="flex items-end border-b border-solid max-md:flex-1 max-md:justify-end md:px-6">
+                {tabsHeaderAccessory}
+              </div>
+            )}
+          </div>
+
+          <div className="flex min-h-0 flex-1 flex-col">{children}</div>
+        </div>
+      </Tabs>
     </div>
   )
 }

--- a/src/ui/dashboard-tabs.tsx
+++ b/src/ui/dashboard-tabs.tsx
@@ -1,17 +1,16 @@
 'use client'
 
-import { usePathname } from 'next/navigation'
+import { usePathname, useRouter } from 'next/navigation'
 import { memo, type ReactNode } from 'react'
 import { cn } from '@/lib/utils'
 import { HoverPrefetchLink } from '@/ui/hover-prefetch-link'
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+} from '@/ui/primitives/select'
 import { Tabs, TabsList, TabsTrigger } from '@/ui/primitives/tabs'
-
-export interface DashboardTabsListProps {
-  layoutKey: string
-  tabs: DashboardTabItem[]
-  className?: string
-  headerAccessory?: ReactNode
-}
 
 export interface DashboardTabItem {
   id: string
@@ -20,21 +19,40 @@ export interface DashboardTabItem {
   icon?: ReactNode
 }
 
+export interface DashboardTabsListProps {
+  layoutKey: string
+  tabs: DashboardTabItem[]
+  className?: string
+  headerAccessory?: ReactNode
+  /**
+   * Controls how the tab bar renders on mobile (`max-md`) viewports.
+   * - `tabs` (default): horizontal `TabsList`, identical to desktop.
+   * - `select`: replaces the tab list with a `Select` dropdown and renders
+   *   the optional `headerAccessory` inline on the same row.
+   *
+   * Desktop rendering is unchanged regardless of variant.
+   */
+  mobileVariant?: 'tabs' | 'select'
+}
+
 function DashboardTabsListComponent({
   layoutKey,
   tabs,
   className,
   headerAccessory,
+  mobileVariant = 'tabs',
 }: DashboardTabsListProps) {
   const pathname = usePathname()
+  const router = useRouter()
 
   const firstTab = tabs[0]
   if (!firstTab) {
     return null
   }
 
-  const activeTabId =
-    tabs.find((tab) => isTabActive(pathname, tab.href))?.id ?? firstTab.id
+  const activeTab =
+    tabs.find((tab) => isTabActive(pathname, tab.href)) ?? firstTab
+  const activeTabId = activeTab.id
 
   const tabTriggers = tabs.map((tab) => (
     <TabsTrigger
@@ -50,6 +68,52 @@ function DashboardTabsListComponent({
       </HoverPrefetchLink>
     </TabsTrigger>
   ))
+
+  if (mobileVariant === 'select') {
+    const handleSelectChange = (id: string) => {
+      const next = tabs.find((tab) => tab.id === id)
+      if (next) router.push(next.href)
+    }
+
+    return (
+      <Tabs
+        value={activeTabId}
+        className={cn(
+          'bg-bg flex w-full flex-none flex-row items-end',
+          className
+        )}
+      >
+        <Select value={activeTabId} onValueChange={handleSelectChange}>
+          <SelectTrigger className="h-9 w-fit border-x-0 border-t-0 border-b border-solid md:hidden">
+            <div className="flex items-center gap-2">
+              {activeTab.icon}
+              {activeTab.label}
+            </div>
+          </SelectTrigger>
+          <SelectContent>
+            {tabs.map((tab) => (
+              <SelectItem key={tab.id} value={tab.id}>
+                <div className="flex items-center gap-2">
+                  {tab.icon}
+                  {tab.label}
+                </div>
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+
+        <TabsList className="bg-bg justify-start max-md:hidden md:flex-1">
+          {tabTriggers}
+        </TabsList>
+
+        {headerAccessory && (
+          <div className="flex items-end border-b border-solid max-md:flex-1 max-md:justify-end md:px-6">
+            {headerAccessory}
+          </div>
+        )}
+      </Tabs>
+    )
+  }
 
   return (
     <Tabs value={activeTabId} className={cn('w-full flex-none', className)}>

--- a/src/ui/dashboard-tabs.tsx
+++ b/src/ui/dashboard-tabs.tsx
@@ -93,10 +93,10 @@ function DashboardTabsListComponent({
           <SelectContent>
             {tabs.map((tab) => (
               <SelectItem key={tab.id} value={tab.id}>
-                <div className="flex items-center gap-2">
+                <span className="inline-flex items-center gap-2">
                   {tab.icon}
                   {tab.label}
-                </div>
+                </span>
               </SelectItem>
             ))}
           </SelectContent>


### PR DESCRIPTION
## Summary

- Restore the mobile scroll behavior on the sandbox details page that broke in #317 (`refactor(dashboard): move tabs to route segments`). The sandbox details header can scroll away again, the tab bar pins at the top, and the tab content fills the remaining viewport (`100svh − navbar − statusbar − tabbar`) perfectly.
- Replace the tab list with a `Select` dropdown on mobile (opt-in, scoped to this layout only). The desktop `TabsList` with the orange active-tab indicator is unchanged.
- Inline the kill button (`tabsHeaderAccessory`) on the same row as the Select on mobile, flush to the right edge, with a continuous bottom-border line spanning the full width.

## Implementation notes

- `<Tabs>` is now the mobile scroll container (`max-md:overflow-y-auto`). An inner wrapper uses `max-md:h-full` (= 100% of the scroll container) plus `flex flex-col` so the content area derives its height from the scroll container via `flex-1` instead of subtracting hardcoded chrome heights — no magic numbers.
- `max-md:shrink-0` on header / accessory / inner wrapper prevents flex children from being squished, so total content exceeds the container and triggers overflow scroll.
- Mobile `SelectTrigger` uses `<div>` (not `<span>`) for the icon+label so it doesn't match `[&>span]:line-clamp-1` (which would have stacked them vertically).
- The accessory wrapper takes `max-md:flex-1 max-md:justify-end` and carries the `border-b` so the bottom line stays continuous across the full row width on both breakpoints.
