### PR TITLE
Fix proxied landing sitemap and rewrites

### DIFF
--- a/src/app/(rewrites)/[[...slug]]/route.ts
+++ b/src/app/(rewrites)/[[...slug]]/route.ts
@@ -1,7 +1,5 @@
 import type { NextRequest } from 'next/server'
-import { constructSitemap } from '@/app/sitemap'
 import { ALLOW_SEO_INDEXING } from '@/configs/flags'
-import { ROUTE_REWRITE_CONFIG } from '@/configs/rewrites'
 import { BASE_URL } from '@/configs/urls'
 import { l, serializeErrorForLog } from '@/core/shared/clients/logger/logger'
 import {
@@ -10,6 +8,7 @@ import {
 } from '@/lib/utils/rewrites'
 
 export const dynamic = 'force-static'
+export const dynamicParams = true
 export const revalidate = 900
 
 const REVALIDATE_TIME = 900 // 15 minutes ttl
@@ -113,45 +112,4 @@ export async function GET(request: NextRequest): Promise<Response> {
       }
     )
   }
-}
-
-export async function generateStaticParams() {
-  const sitemapEntries = await constructSitemap()
-
-  const slugs = sitemapEntries
-    .filter((entry) => {
-      const url = new URL(entry.url)
-      const pathname = url.pathname
-
-      // check if this path matches any rule in ROUTE_REWRITE_CONFIG
-      for (const domainConfig of ROUTE_REWRITE_CONFIG) {
-        const isIndex = pathname === '/' || pathname === ''
-        const matchingRule = domainConfig.rules.find((rule) => {
-          if (isIndex && rule.path === '/') {
-            return true
-          }
-          if (pathname === rule.path || pathname.startsWith(`${rule.path}/`)) {
-            return true
-          }
-          return false
-        })
-
-        if (matchingRule) {
-          return true
-        }
-      }
-      return false
-    })
-    .map((entry) => {
-      // map the filtered entries to slug format
-      const url = new URL(entry.url)
-      const pathname = url.pathname
-      const pathSegments = pathname
-        .split('/')
-        .filter((segment) => segment !== '')
-
-      return { slug: pathSegments }
-    })
-
-  return slugs
 }

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -17,6 +17,7 @@ import { DOCUMENTATION_DOMAIN } from '../../next.config.mjs'
 
 // Cache the sitemap for 15 minutes (in seconds)
 const SITEMAP_CACHE_TIME = 15 * 60
+export const revalidate = SITEMAP_CACHE_TIME
 
 /**
  * Valid change frequency values for sitemap entries

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -17,7 +17,7 @@ import { DOCUMENTATION_DOMAIN } from '../../next.config.mjs'
 
 // Cache the sitemap for 15 minutes (in seconds)
 const SITEMAP_CACHE_TIME = 15 * 60
-export const revalidate = SITEMAP_CACHE_TIME
+export const revalidate = 900
 
 /**
  * Valid change frequency values for sitemap entries


### PR DESCRIPTION
## Summary
- revalidate the generated sitemap metadata route so landing-page sitemap updates are reflected after ISR
- remove the sitemap-derived static params allowlist from the proxied rewrite route
- explicitly allow dynamic params so new landing/blog URLs can be generated on first request and cached by ISR

## Verification
- bunx vitest run tests/unit/sitemap.test.ts tests/integration/proxy.test.ts
- bunx biome check src/app/sitemap.ts src/app/'(rewrites)'/'[[...slug]]'/route.ts
- bunx tsc --noEmit --pretty false