### PR TITLE
Convert Next config to TypeScript

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,7 +163,7 @@ This application is optimized for deployment on Vercel:
 2. Import your repository in Vercel
 3. Deploy!
 
-> **Note**: The application uses Partial Prerendering (PPR) which is currently only supported on Vercel's infrastructure. This can be turned off inside [`next.config.mjs`](./next.config.mjs).
+> **Note**: The application uses Partial Prerendering (PPR) which is currently only supported on Vercel's infrastructure. This can be turned off inside [`next.config.ts`](./next.config.ts).
 
 ## Contributing
 We welcome contributions! Please see our [Contributing Guide](CONTRIBUTING.md) for details.

--- a/next.config.ts
+++ b/next.config.ts
@@ -1,9 +1,9 @@
 // NOTE: related to src/configs/rewrites.ts
 import path from 'node:path'
+import type { NextConfig } from 'next'
+import { DOCUMENTATION_DOMAIN } from './src/configs/documentation'
 
-export const DOCUMENTATION_DOMAIN = 'e2b.mintlify.app'
-
-const browserStub = (file) => path.resolve(process.cwd(), 'stubs', file)
+const browserStub = (file: string) => path.resolve(process.cwd(), 'stubs', file)
 
 const browserNodeModuleStubs = {
   crypto: browserStub('crypto.ts'),
@@ -16,8 +16,7 @@ const browserNodeModuleStubs = {
   'node:path': browserStub('path.ts'),
 }
 
-/** @type {import('next').NextConfig} */
-const config = {
+const config: NextConfig = {
   reactStrictMode: true,
   reactCompiler: true,
   experimental: {
@@ -48,9 +47,12 @@ const config = {
       }
 
       webpackConfig.plugins.push(
-        new webpack.NormalModuleReplacementPlugin(/^node:/, (resource) => {
-          resource.request = resource.request.replace(/^node:/, '')
-        })
+        new webpack.NormalModuleReplacementPlugin(
+          /^node:/,
+          (resource: { request: string }) => {
+            resource.request = resource.request.replace(/^node:/, '')
+          }
+        )
       )
     }
 

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -9,11 +9,11 @@
 
 import { XMLParser } from 'fast-xml-parser'
 import type { MetadataRoute } from 'next'
+import { DOCUMENTATION_DOMAIN } from '@/configs/documentation'
 import { ALLOW_SEO_INDEXING } from '@/configs/flags'
 import { LANDING_PAGE_DOMAIN, ROUTE_REWRITE_CONFIG } from '@/configs/rewrites'
 import { SITEMAP_EXCLUDE_CONFIG } from '@/configs/sitemap'
 import type { DomainConfig } from '@/types/rewrites.types'
-import { DOCUMENTATION_DOMAIN } from '../../next.config.mjs'
 
 // Cache the sitemap for 15 minutes (in seconds)
 const SITEMAP_CACHE_TIME = 15 * 60

--- a/src/configs/documentation.ts
+++ b/src/configs/documentation.ts
@@ -1,0 +1,1 @@
+export const DOCUMENTATION_DOMAIN = 'e2b.mintlify.app'

--- a/src/configs/rewrites.ts
+++ b/src/configs/rewrites.ts
@@ -1,8 +1,7 @@
 import type { DomainConfig } from '@/types/rewrites.types'
+import { DOCUMENTATION_DOMAIN } from './documentation'
 
 export const LANDING_PAGE_DOMAIN = 'www.e2b-landing-page.com'
-
-import { DOCUMENTATION_DOMAIN } from '../../next.config.mjs'
 
 // Currently we have two locations for rewrites to happen.
 
@@ -41,7 +40,7 @@ export const ROUTE_REWRITE_CONFIG: DomainConfig[] = [
  * Middleware native rewrite config
  *
  * We implement rewrites directly in middleware rather than using Next.js's built-in
- * `rewrites` configuration in next.config.js because we need to set custom request
+ * `rewrites` configuration in next.config.ts because we need to set custom request
  * and response headers for these rewritten requests.
  *
  * Specifically, we need to:

--- a/src/configs/sitemap.ts
+++ b/src/configs/sitemap.ts
@@ -1,4 +1,4 @@
-import { DOCUMENTATION_DOMAIN } from '../../next.config.mjs'
+import { DOCUMENTATION_DOMAIN } from './documentation'
 
 export const SITEMAP_EXCLUDE_CONFIG: Array<{
   domain: string

--- a/tests/integration/e2b-browser-stubs.test.ts
+++ b/tests/integration/e2b-browser-stubs.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import nextConfig from '../../next.config.mjs'
+import nextConfig from '../../next.config'
 
 class MockNormalModuleReplacementPlugin {
   readonly pattern: RegExp

--- a/tests/integration/proxy.test.ts
+++ b/tests/integration/proxy.test.ts
@@ -1,9 +1,9 @@
 import { createServerClient } from '@supabase/ssr'
 import { NextRequest, NextResponse } from 'next/server'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { DOCUMENTATION_DOMAIN } from '@/configs/documentation'
 import { AUTH_URLS, PROTECTED_URLS } from '@/configs/urls'
 import { proxy } from '@/proxy'
-import { DOCUMENTATION_DOMAIN } from '../../next.config.mjs'
 
 // mock supabase auth
 vi.mock('@supabase/ssr', () => ({

--- a/tests/unit/sitemap.test.ts
+++ b/tests/unit/sitemap.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { DOCUMENTATION_DOMAIN } from '@/configs/documentation'
 import { LANDING_PAGE_DOMAIN } from '@/configs/rewrites'
-import { DOCUMENTATION_DOMAIN } from '../../next.config.mjs'
 
 vi.mock('@/configs/flags', () => ({
   ALLOW_SEO_INDEXING: true,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -35,6 +35,7 @@
   },
   "include": [
     "next-env.d.ts",
+    "next.config.ts",
     "src",
     ".next/types/**/*.ts",
     ".next/dev/types/**/*.ts",


### PR DESCRIPTION
## Summary
- Rename the Next config from .mjs to .ts and type it with NextConfig.
- Move DOCUMENTATION_DOMAIN into src/configs/documentation.ts and update app/test imports.
- Update README and tsconfig references for the TypeScript config.

## Validation
- bun biome check next.config.ts src/configs/documentation.ts src/configs/rewrites.ts src/configs/sitemap.ts src/app/sitemap.ts tests/integration/e2b-browser-stubs.test.ts tests/integration/proxy.test.ts tests/unit/sitemap.test.ts tsconfig.json README.md
- bun vitest run tests/integration/e2b-browser-stubs.test.ts tests/unit/sitemap.test.ts tests/integration/proxy.test.ts