### PR TITLE
Add Conductor Bun setup script

### DIFF
--- a/.conductor/settings.toml
+++ b/.conductor/settings.toml
@@ -1,0 +1,4 @@
+"$schema" = "https://conductor.build/schemas/settings.repo.schema.json"
+
+[scripts]
+setup = "bun install --frozen-lockfile"


### PR DESCRIPTION
Adds shared Conductor repository settings for workspace setup. The setup script installs dependencies with Bun using the checked-in lockfile via `bun install --frozen-lockfile`.