### PR TITLE
fix(rewrites): decouple catch-all from sitemap

### DIFF
--- a/src/app/(rewrites)/[[...slug]]/route.ts
+++ b/src/app/(rewrites)/[[...slug]]/route.ts
@@ -1,7 +1,5 @@
 import type { NextRequest } from 'next/server'
-import { constructSitemap } from '@/app/sitemap'
 import { ALLOW_SEO_INDEXING } from '@/configs/flags'
-import { ROUTE_REWRITE_CONFIG } from '@/configs/rewrites'
 import { BASE_URL } from '@/configs/urls'
 import { l, serializeErrorForLog } from '@/core/shared/clients/logger/logger'
 import {
@@ -31,8 +29,6 @@ export async function GET(request: NextRequest): Promise<Response> {
     url.pathname = '/'
   }
 
-  const requestHostname = url.hostname
-
   const updateUrlHostname = (newHostname: string) => {
     url.hostname = newHostname
     url.port = ''
@@ -49,15 +45,12 @@ export async function GET(request: NextRequest): Promise<Response> {
   }
 
   try {
-    const notFound = url.hostname === requestHostname
-
-    // if hostname did not change, we want to make sure it does not cache the route based on the build times hostname (127.0.0.1:3000)
+    const notFound = !config
     const fetchUrl = notFound ? `${BASE_URL}/not-found` : url.toString()
 
     const res = await fetch(fetchUrl, {
       headers: new Headers(request.headers),
       redirect: 'follow',
-      // if the hostname is the same, we don't want to cache the response, since it will not be available in build time
       ...(notFound
         ? { cache: 'no-store' }
         : {
@@ -113,45 +106,4 @@ export async function GET(request: NextRequest): Promise<Response> {
       }
     )
   }
-}
-
-export async function generateStaticParams() {
-  const sitemapEntries = await constructSitemap()
-
-  const slugs = sitemapEntries
-    .filter((entry) => {
-      const url = new URL(entry.url)
-      const pathname = url.pathname
-
-      // check if this path matches any rule in ROUTE_REWRITE_CONFIG
-      for (const domainConfig of ROUTE_REWRITE_CONFIG) {
-        const isIndex = pathname === '/' || pathname === ''
-        const matchingRule = domainConfig.rules.find((rule) => {
-          if (isIndex && rule.path === '/') {
-            return true
-          }
-          if (pathname === rule.path || pathname.startsWith(`${rule.path}/`)) {
-            return true
-          }
-          return false
-        })
-
-        if (matchingRule) {
-          return true
-        }
-      }
-      return false
-    })
-    .map((entry) => {
-      // map the filtered entries to slug format
-      const url = new URL(entry.url)
-      const pathname = url.pathname
-      const pathSegments = pathname
-        .split('/')
-        .filter((segment) => segment !== '')
-
-      return { slug: pathSegments }
-    })
-
-  return slugs
 }

--- a/src/app/(rewrites)/[[...slug]]/route.ts
+++ b/src/app/(rewrites)/[[...slug]]/route.ts
@@ -12,7 +12,15 @@ export const dynamic = 'force-dynamic'
 const REVALIDATE_TIME = 900 // 15 minutes ttl
 const CDN_CACHE_CONTROL = `public, s-maxage=${REVALIDATE_TIME}, stale-while-revalidate=${REVALIDATE_TIME}`
 
+function getRewriteRequestHeaders(): Headers {
+  return new Headers({
+    Accept: 'text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8',
+  })
+}
+
 function setRewriteCacheHeaders(headers: Headers): void {
+  headers.delete('set-cookie')
+  headers.delete('set-cookie2')
   headers.set('Cache-Control', 'public, max-age=0, must-revalidate')
   headers.set('CDN-Cache-Control', CDN_CACHE_CONTROL)
   headers.set('Vercel-CDN-Cache-Control', CDN_CACHE_CONTROL)
@@ -55,7 +63,9 @@ export async function GET(request: NextRequest): Promise<Response> {
     const fetchUrl = notFound ? `${BASE_URL}/not-found` : url.toString()
 
     const res = await fetch(fetchUrl, {
-      headers: new Headers(request.headers),
+      headers: notFound
+        ? new Headers(request.headers)
+        : getRewriteRequestHeaders(),
       redirect: 'follow',
       ...(notFound
         ? { cache: 'no-store' }
@@ -78,6 +88,7 @@ export async function GET(request: NextRequest): Promise<Response> {
 
       // remove content-encoding header to ensure proper rendering
       newHeaders.delete('content-encoding')
+      newHeaders.delete('content-length')
 
       // rewrite absolute URLs pointing to the rewritten domain to relative paths and with correct SEO tags
       if (config) {

--- a/src/app/(rewrites)/[[...slug]]/route.ts
+++ b/src/app/(rewrites)/[[...slug]]/route.ts
@@ -7,10 +7,16 @@ import {
   rewriteContentPagesHtml,
 } from '@/lib/utils/rewrites'
 
-export const dynamic = 'force-static'
-export const revalidate = 900
+export const dynamic = 'force-dynamic'
 
 const REVALIDATE_TIME = 900 // 15 minutes ttl
+const CDN_CACHE_CONTROL = `public, s-maxage=${REVALIDATE_TIME}, stale-while-revalidate=${REVALIDATE_TIME}`
+
+function setRewriteCacheHeaders(headers: Headers): void {
+  headers.set('Cache-Control', 'public, max-age=0, must-revalidate')
+  headers.set('CDN-Cache-Control', CDN_CACHE_CONTROL)
+  headers.set('Vercel-CDN-Cache-Control', CDN_CACHE_CONTROL)
+}
 
 export async function GET(request: NextRequest): Promise<Response> {
   const url = new URL(request.url)
@@ -63,6 +69,10 @@ export async function GET(request: NextRequest): Promise<Response> {
     const contentType = res.headers.get('Content-Type')
     const newHeaders = new Headers(res.headers)
 
+    if (!notFound) {
+      setRewriteCacheHeaders(newHeaders)
+    }
+
     if (contentType?.startsWith('text/html')) {
       let html = await res.text()
 
@@ -91,7 +101,11 @@ export async function GET(request: NextRequest): Promise<Response> {
       return modifiedResponse
     }
 
-    return res
+    return new Response(res.body, {
+      status: res.status,
+      statusText: res.statusText,
+      headers: newHeaders,
+    })
   } catch (error) {
     l.error({
       key: 'url_rewrite:unexpected_error',


### PR DESCRIPTION
## Summary
- keep the catch-all route-handler rewrite path and HTML SEO tag rewriting
- remove sitemap-derived generateStaticParams so published upstream pages are not gated by sitemap.xml
- make the catch-all handler dynamic so Vercel invokes it for runtime /blog/* paths
- make rewritten responses Vercel-CDN cacheable by stripping upstream Set-Cookie headers and setting CDN cache headers
- avoid forwarding request cookies/authorization/preview headers to the landing origin; use a stable upstream Accept header for cacheable rewrites
- keep ROUTE_REWRITE_CONFIG as the routing allowlist
- keep proxy behavior unchanged: route rewrites pass through to the catch-all handler, middleware-native rewrites remain for docs/MCP

## 404 behavior
- unmatched ROUTE_REWRITE_CONFIG path: serves the local not-found page with a 404 status
- matched rewrite path whose upstream URL returns 404: returns the upstream 404 status
- matched rewrite path whose upstream URL returns 200: returns 200, even if absent from sitemap.xml

## Checks
- bunx biome check "src/app/(rewrites)/[[...slug]]/route.ts"
- bunx vitest run tests/unit/proxy-handlers.test.ts tests/integration/proxy.test.ts tests/unit/sitemap.test.ts
- bun run build
- local production smoke test verifying /[[...slug]] is dynamic, cache headers are set, Set-Cookie is stripped, / and /blog/stackai return 200, upstream 404 returns 404, unmatched path returns 404
- ALLOW_SEO_INDEXING=1 local production smoke test verifying rewritten robots/canonical tags