### PR TITLE
Add huv1k as code owner

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,3 +1,3 @@
 # These owners will be the default owners for everything in
 # the repo. Unless a later match takes precedence.
-* @ben-fornefeld @drankou
+* @ben-fornefeld @drankou @huv1k


### PR DESCRIPTION
Adds @huv1k to the default CODEOWNERS rule for the entire repository. This makes @huv1k a default reviewer unless a later CODEOWNERS rule takes precedence.