### PR TITLE
fix: anchor CMDK dialog to top edge

### DIFF
--- a/src/ui/primitives/command.tsx
+++ b/src/ui/primitives/command.tsx
@@ -26,7 +26,7 @@ const CommandDialog = ({ children, ...props }: DialogProps) => {
   return (
     <Dialog {...props}>
       <DialogContent
-        className="!top-[20svh] !translate-y-0 overflow-hidden p-0"
+        className="top-[20svh] max-h-[calc(80svh-1rem)] translate-y-0 overflow-hidden p-0"
         hideClose
       >
         <DialogTitle className="sr-only">Search through dashboard</DialogTitle>

--- a/src/ui/primitives/command.tsx
+++ b/src/ui/primitives/command.tsx
@@ -25,7 +25,10 @@ Command.displayName = CommandPrimitive.displayName
 const CommandDialog = ({ children, ...props }: DialogProps) => {
   return (
     <Dialog {...props}>
-      <DialogContent className="overflow-hidden p-0" hideClose>
+      <DialogContent
+        className="!top-[20svh] !translate-y-0 overflow-hidden p-0"
+        hideClose
+      >
         <DialogTitle className="sr-only">Search through dashboard</DialogTitle>
         <Command className="[&_[cmdk-group-heading]]:text-fg-tertiary [&_[cmdk-group-heading]]:px-2 [&_[cmdk-group-heading]]:prose-label-highlight [&_[cmdk-group]]:px-2 [&_[cmdk-group]:not([hidden])_~[cmdk-group]]:pt-0 [&_[cmdk-input-wrapper]_svg]:h-5 [&_[cmdk-input-wrapper]_svg]:w-5 [&_[cmdk-input]]:h-12 [&_[cmdk-item]]:px-2 [&_[cmdk-item]]:py-3 [&_[cmdk-item]_svg]:h-5 [&_[cmdk-item]_svg]:w-5">
           {children}


### PR DESCRIPTION
## Summary
- Anchors the dashboard CMDK dialog near the top of the viewport instead of vertically re-centering it.
- Keeps the change scoped to `CommandDialog`; shared `DialogContent` modals remain centered.

## Why
The CMDK menu was inheriting the shared dialog centering styles (`top: 50%` plus vertical translate). As search results changed the menu height, the center point stayed fixed, causing the whole menu to jump vertically. The command menu now overrides that vertical placement with a fixed upper-center top edge so only the bottom edge expands or contracts.

## Before / After
| Before | After |
| ------ | ----- |
| <img width="100%" height="255" alt="CleanShot 2026-06-09 at 18 50 54" src="https://github.com/user-attachments/assets/23c694c3-12b4-41ad-a91e-4f208eab347e" />   | <img width="100%" height="255" alt="CleanShot 2026-06-09 at 18 51 57" src="https://github.com/user-attachments/assets/669dab8b-e658-4196-8a2a-606fce69bb87" />  |
