### PR TITLE
fix(auth): scope Auth.js session cookie via AUTH_COOKIE_PREFIX

### DIFF
--- a/src/lib/env.ts
+++ b/src/lib/env.ts
@@ -17,6 +17,10 @@ export const serverSchema = z.object({
   AUTH_PROVIDER: z.enum(['supabase', 'ory']).optional(),
   AUTH_SECRET: z.string().min(1).optional(),
   AUTH_TRUST_HOST: z.string().optional(),
+  // Prefix for Auth.js cookie names to disambiguate multiple local
+  // instances sharing localhost (cookies aren't scoped by port).
+  // Leave unset in prod/preview.
+  AUTH_COOKIE_PREFIX: z.string().min(1).optional(),
   ORY_SDK_URL: z.url().optional(),
   ORY_OAUTH2_CLIENT_ID: z.string().min(1).optional(),
   ORY_OAUTH2_CLIENT_SECRET: z.string().min(1).optional(),


### PR DESCRIPTION
Cookies are scoped by host+path+name, not port, so multiple local dashboards on different localhost ports shared the default authjs.session-token cookie and clobbered each other's sessions. AUTH_COOKIE_PREFIX lets each instance use a distinct cookie name; unset in prod/preview keeps the standard name.