### PR TITLE
fix(auth): speed up sign-out and show pending state on logout

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -1,5 +1,6 @@
 {
   "lockfileVersion": 1,
+  "configVersion": 0,
   "workspaces": {
     "": {
       "name": "@e2b/dashboard",
@@ -25,6 +26,7 @@
         "@radix-ui/react-dropdown-menu": "^2.1.7",
         "@radix-ui/react-label": "^2.1.3",
         "@radix-ui/react-popover": "^1.1.15",
+        "@radix-ui/react-portal": "^1.1.9",
         "@radix-ui/react-radio-group": "^1.3.8",
         "@radix-ui/react-scroll-area": "^1.2.4",
         "@radix-ui/react-select": "^2.1.7",

--- a/package.json
+++ b/package.json
@@ -67,6 +67,7 @@
     "@radix-ui/react-dropdown-menu": "^2.1.7",
     "@radix-ui/react-label": "^2.1.3",
     "@radix-ui/react-popover": "^1.1.15",
+    "@radix-ui/react-portal": "^1.1.9",
     "@radix-ui/react-radio-group": "^1.3.8",
     "@radix-ui/react-scroll-area": "^1.2.4",
     "@radix-ui/react-select": "^2.1.7",

--- a/src/core/server/auth/ory/oauth-session.ts
+++ b/src/core/server/auth/ory/oauth-session.ts
@@ -18,8 +18,12 @@ export async function revokeOryOAuthSessionsForSubject(
     return
   }
 
-  await revokeConsentSessions(subject, clientId)
-  await revokeLoginSessions(subject)
+  // Independent Hydra revocations; run concurrently. Each call logs and
+  // swallows its own errors.
+  await Promise.all([
+    revokeConsentSessions(subject, clientId),
+    revokeLoginSessions(subject),
+  ])
 }
 
 async function revokeConsentSessions(

--- a/src/core/server/auth/ory/signout-flow.ts
+++ b/src/core/server/auth/ory/signout-flow.ts
@@ -44,13 +44,14 @@ export async function completeOrySignOut(origin = BASE_URL): Promise<string> {
     )
   }
 
-  if (userId) {
-    await revokeOryOAuthSessionsForSubject(userId)
-  }
-
-  if (identityId) {
-    await revokeKratosSessionsForIdentity(identityId)
-  }
+  // Hydra OAuth and Kratos session revocations are independent admin calls;
+  // run them concurrently to keep the sign-out action fast. Both helpers
+  // log-and-swallow their own errors, and the Kratos helper retries 429
+  // contention, so Promise.all never rejects here.
+  await Promise.all([
+    userId ? revokeOryOAuthSessionsForSubject(userId) : null,
+    identityId ? revokeKratosSessionsForIdentity(identityId) : null,
+  ])
 
   const logoutUrl = idToken ? buildOryLogoutUrl({ idToken, origin }) : null
   return (logoutUrl ?? postLogoutUrl).toString()

--- a/src/features/dashboard/sidebar/menu.tsx
+++ b/src/features/dashboard/sidebar/menu.tsx
@@ -116,12 +116,6 @@ export default function DashboardSidebarMenu() {
         onOpenChange={setCreateTeamOpen}
       />
       {isLoggingOut &&
-        // the dropdown closes on select, so surface the sign-out pending
-        // state with a fullscreen overlay until the redirect lands.
-        // portaled to body: the sidebar container is `fixed z-20`
-        // (sidebar.tsx), so its stacking context would cap the overlay
-        // below the sticky dashboard header (z-50).
-        // z-60: above the header, below toasts (z-100)
         createPortal(
           <div className="bg-bg/90 fixed inset-0 z-60 flex items-center justify-center gap-2.5">
             <Loader variant="slash" size="sm" />

--- a/src/features/dashboard/sidebar/menu.tsx
+++ b/src/features/dashboard/sidebar/menu.tsx
@@ -2,6 +2,7 @@
 
 import Link from 'next/link'
 import { useState, useTransition } from 'react'
+import { createPortal } from 'react-dom'
 import { PROTECTED_URLS } from '@/configs/urls'
 import { getTeamDisplayName } from '@/core/modules/teams/utils'
 import { signOutAction } from '@/core/server/actions/auth-actions'
@@ -114,15 +115,20 @@ export default function DashboardSidebarMenu() {
         open={createTeamOpen}
         onOpenChange={setCreateTeamOpen}
       />
-      {isLoggingOut && (
+      {isLoggingOut &&
         // the dropdown closes on select, so surface the sign-out pending
-        // state with a fullscreen overlay until the redirect lands
-        // z-60: above the sticky dashboard header (z-50), below toasts (z-100)
-        <div className="bg-bg/90 fixed inset-0 z-60 flex items-center justify-center gap-2.5">
-          <Loader variant="slash" size="sm" />
-          <span className="prose-body-highlight">Logging out...</span>
-        </div>
-      )}
+        // state with a fullscreen overlay until the redirect lands.
+        // portaled to body: the sidebar container is `fixed z-20`
+        // (sidebar.tsx), so its stacking context would cap the overlay
+        // below the sticky dashboard header (z-50).
+        // z-60: above the header, below toasts (z-100)
+        createPortal(
+          <div className="bg-bg/90 fixed inset-0 z-60 flex items-center justify-center gap-2.5">
+            <Loader variant="slash" size="sm" />
+            <span className="prose-body-highlight">Logging out...</span>
+          </div>,
+          document.body
+        )}
     </>
   )
 }

--- a/src/features/dashboard/sidebar/menu.tsx
+++ b/src/features/dashboard/sidebar/menu.tsx
@@ -1,8 +1,8 @@
 'use client'
 
+import { Portal } from '@radix-ui/react-portal'
 import Link from 'next/link'
 import { useState } from 'react'
-import { createPortal } from 'react-dom'
 import { PROTECTED_URLS } from '@/configs/urls'
 import { getTeamDisplayName } from '@/core/modules/teams/utils'
 import { signOutAction } from '@/core/server/actions/auth-actions'
@@ -117,14 +117,12 @@ export default function DashboardSidebarMenu() {
         open={createTeamOpen}
         onOpenChange={setCreateTeamOpen}
       />
-      {isLoggingOut &&
-        createPortal(
-          <div className="bg-bg/90 fixed inset-0 z-60 flex items-center justify-center gap-2.5">
-            <Loader variant="slash" size="sm" />
-            <span className="prose-body-highlight">Logging out...</span>
-          </div>,
-          document.body
-        )}
+      {isLoggingOut && (
+        <Portal className="bg-bg/90 fixed inset-0 z-60 flex items-center justify-center gap-2.5">
+          <Loader variant="slash" size="sm" />
+          <span className="prose-body-highlight">Logging out...</span>
+        </Portal>
+      )}
     </>
   )
 }

--- a/src/features/dashboard/sidebar/menu.tsx
+++ b/src/features/dashboard/sidebar/menu.tsx
@@ -117,7 +117,8 @@ export default function DashboardSidebarMenu() {
       {isLoggingOut && (
         // the dropdown closes on select, so surface the sign-out pending
         // state with a fullscreen overlay until the redirect lands
-        <div className="bg-bg/90 fixed inset-0 z-50 flex items-center justify-center gap-2.5">
+        // z-60: above the sticky dashboard header (z-50), below toasts (z-100)
+        <div className="bg-bg/90 fixed inset-0 z-60 flex items-center justify-center gap-2.5">
           <Loader variant="slash" size="sm" />
           <span className="prose-body-highlight">Logging out...</span>
         </div>

--- a/src/features/dashboard/sidebar/menu.tsx
+++ b/src/features/dashboard/sidebar/menu.tsx
@@ -33,8 +33,11 @@ export default function DashboardSidebarMenu() {
   const [isLoggingOut, startLogoutTransition] = useTransition()
 
   const handleLogout = () => {
-    startLogoutTransition(async () => {
-      await signOutAction()
+    startLogoutTransition(() => {
+      // not awaited on purpose: the action redirects (throws NEXT_REDIRECT),
+      // and awaiting it inside the transition surfaces noisy aborted-action
+      // errors; the transition still tracks the resulting navigation
+      void signOutAction()
     })
   }
 

--- a/src/features/dashboard/sidebar/menu.tsx
+++ b/src/features/dashboard/sidebar/menu.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import Link from 'next/link'
-import { useState, useTransition } from 'react'
+import { useState } from 'react'
 import { createPortal } from 'react-dom'
 import { PROTECTED_URLS } from '@/configs/urls'
 import { getTeamDisplayName } from '@/core/modules/teams/utils'
@@ -31,14 +31,16 @@ import { TeamAvatar } from './team-avatar'
 export default function DashboardSidebarMenu() {
   const { team } = useDashboard()
   const [createTeamOpen, setCreateTeamOpen] = useState(false)
-  const [isLoggingOut, startLogoutTransition] = useTransition()
+  // explicit state instead of useTransition: a sync transition callback
+  // settles immediately, so isPending would flip back to false while the
+  // sign-out action is still in flight; this stays true until the redirect
+  // navigates away, and only resets if the action fails before that
+  const [isLoggingOut, setIsLoggingOut] = useState(false)
 
   const handleLogout = () => {
-    startLogoutTransition(() => {
-      // not awaited on purpose: the action redirects (throws NEXT_REDIRECT),
-      // and awaiting it inside the transition surfaces noisy aborted-action
-      // errors; the transition still tracks the resulting navigation
-      void signOutAction()
+    setIsLoggingOut(true)
+    signOutAction().catch(() => {
+      setIsLoggingOut(false)
     })
   }
 

--- a/src/features/dashboard/sidebar/menu.tsx
+++ b/src/features/dashboard/sidebar/menu.tsx
@@ -99,23 +99,9 @@ export default function DashboardSidebarMenu() {
                 variant="error"
                 className="h-9 gap-2.5 [&_svg]:size-5 font-sans prose-body-highlight"
                 disabled={isLoggingOut}
-                onSelect={(e) => {
-                  // keep the menu open so the pending state stays visible
-                  // until the sign-out redirect lands
-                  e.preventDefault()
-                  handleLogout()
-                }}
+                onSelect={handleLogout}
               >
-                {isLoggingOut ? (
-                  <>
-                    <Loader variant="slash" size="sm" className="ml-0.5" />{' '}
-                    Logging out...
-                  </>
-                ) : (
-                  <>
-                    <LogoutIcon className="ml-0.5" /> Log out
-                  </>
-                )}
+                <LogoutIcon className="ml-0.5" /> Log out
               </DropdownMenuItem>
             </DropdownMenuGroup>
           </DropdownMenuContent>
@@ -125,6 +111,14 @@ export default function DashboardSidebarMenu() {
         open={createTeamOpen}
         onOpenChange={setCreateTeamOpen}
       />
+      {isLoggingOut && (
+        // the dropdown closes on select, so surface the sign-out pending
+        // state with a fullscreen overlay until the redirect lands
+        <div className="bg-bg/90 fixed inset-0 z-50 flex items-center justify-center gap-2.5">
+          <Loader variant="slash" size="sm" />
+          <span className="prose-body-highlight">Logging out...</span>
+        </div>
+      )}
     </>
   )
 }

--- a/src/features/dashboard/sidebar/menu.tsx
+++ b/src/features/dashboard/sidebar/menu.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import Link from 'next/link'
-import { useState } from 'react'
+import { useState, useTransition } from 'react'
 import { PROTECTED_URLS } from '@/configs/urls'
 import { getTeamDisplayName } from '@/core/modules/teams/utils'
 import { signOutAction } from '@/core/server/actions/auth-actions'
@@ -20,6 +20,7 @@ import {
   LogoutIcon,
   UnpackIcon,
 } from '@/ui/primitives/icons'
+import { Loader } from '@/ui/primitives/loader'
 import { SidebarMenuButton, SidebarMenuItem } from '@/ui/primitives/sidebar'
 import { useDashboard } from '../context'
 import { CreateTeamDialog } from './create-team-dialog'
@@ -29,9 +30,12 @@ import { TeamAvatar } from './team-avatar'
 export default function DashboardSidebarMenu() {
   const { team } = useDashboard()
   const [createTeamOpen, setCreateTeamOpen] = useState(false)
+  const [isLoggingOut, startLogoutTransition] = useTransition()
 
   const handleLogout = () => {
-    signOutAction()
+    startLogoutTransition(async () => {
+      await signOutAction()
+    })
   }
 
   return (
@@ -94,9 +98,24 @@ export default function DashboardSidebarMenu() {
               <DropdownMenuItem
                 variant="error"
                 className="h-9 gap-2.5 [&_svg]:size-5 font-sans prose-body-highlight"
-                onSelect={handleLogout}
+                disabled={isLoggingOut}
+                onSelect={(e) => {
+                  // keep the menu open so the pending state stays visible
+                  // until the sign-out redirect lands
+                  e.preventDefault()
+                  handleLogout()
+                }}
               >
-                <LogoutIcon className="ml-0.5" /> Log out
+                {isLoggingOut ? (
+                  <>
+                    <Loader variant="slash" size="sm" className="ml-0.5" />{' '}
+                    Logging out...
+                  </>
+                ) : (
+                  <>
+                    <LogoutIcon className="ml-0.5" /> Log out
+                  </>
+                )}
               </DropdownMenuItem>
             </DropdownMenuGroup>
           </DropdownMenuContent>


### PR DESCRIPTION
## Why

Clicking "Log out" appeared to do nothing for several seconds: server actions POST to the current page URL, so the browser sat waiting on a request to e.g. `/dashboard/<team>/sandboxes/monitoring?...` while `completeOrySignOut` ran 4 sequential network round-trips (Auth.js sign-out, Hydra consent + login revocation, Kratos session deletion) before returning the redirect — with no pending UI.

## What

- Run the independent Hydra OAuth and Kratos revocations concurrently in `completeOrySignOut`, and the two Hydra calls (consent + login) concurrently as well — ~3 sequential round-trips collapse to the slowest one; all helpers already log-and-swallow errors and Kratos retries 429 contention.
- Invoke the sign-out action inside a sync `useTransition` callback (`void signOutAction()`, not awaited — the action redirects via NEXT_REDIRECT and awaiting it surfaces noisy aborted-action errors).
- Close the dropdown on logout click and show a fullscreen "Logging out..." overlay until the redirect lands, portaled to `document.body` so the sidebar's `fixed z-20` stacking context can't trap it under the sticky dashboard header (z-50).