### PR TITLE
fix(auth): keep Auth.js session handling away from non-auth requests

### DIFF
--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -12,6 +12,8 @@ import {
   handleMiddlewareRedirect,
   handleMiddlewareRewrite,
   handleRouteRewritePassthrough,
+  isAuthRoute,
+  isDashboardRoute,
 } from './core/server/http/proxy'
 import { l, serializeErrorForLog } from './core/shared/clients/logger/logger'
 
@@ -59,9 +61,25 @@ const proxyWithOryAuth = authjsMiddleware((req, _event: NextFetchEvent) => {
   return proxyCore(req, isAuthenticated)
 })
 
+// Dashboard and auth routes are the only matched paths whose handling depends
+// on the session (handleAuthGate / getOryAuthRouteRedirect). Everything else
+// must stay out of the Auth.js wrapper: its per-request session handling
+// re-sets the session cookie and deletes tokens it cannot decrypt, so a stray
+// request (e.g. a 404ing asset) could log the user out.
+function needsAuthResolution(pathname: string): boolean {
+  return isDashboardRoute(pathname) || isAuthRoute(pathname)
+}
+
 export async function proxy(request: NextRequest, event: NextFetchEvent) {
   if (!isOryAuthEnabled()) {
     return proxyCore(request)
+  }
+
+  // knownAuth=false is safe here: getAuthRedirect ignores it for
+  // non-dashboard/auth routes, and it stops handleAuthGate from resolving the
+  // session needlessly.
+  if (!needsAuthResolution(request.nextUrl.pathname)) {
+    return proxyCore(request, false)
   }
 
   return proxyWithOryAuth(request, event)

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -71,13 +71,13 @@ export const config = {
   matcher: [
     /*
      * Match all request paths except:
-     * - _next/static (static files)
-     * - _next/image (image optimization files)
+     * - _next/ (Next.js internals: static files, image optimization, etc.)
      * - static icons and images - .ico, .svg, .png, .jpg, .jpeg, .gif, .webp
      * - api routes
      * - vercel analytics route
      * - posthog routes
+     * - mintlify docs asset routes (rewritten in next.config.ts)
      */
-    '/((?!_next/static|_next/image|api/|.*\\.(?:ico|svg|png|jpg|jpeg|gif|webp)$|_vercel/|ingest/|ph-proxy/|array/|mintlify-assets/|_mintlify/).*)',
+    '/((?!_next/|api/|.*\\.(?:ico|svg|png|jpg|jpeg|gif|webp)$|_vercel/|ingest/|ph-proxy/|array/|mintlify-assets/|_mintlify/).*)',
   ],
 }

--- a/tests/integration/auth-ory-entrypoints.test.ts
+++ b/tests/integration/auth-ory-entrypoints.test.ts
@@ -5,6 +5,9 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 const authSession = vi.hoisted(() => ({
   current: null as Session | null,
 }))
+// Counts requests that actually pass through the Auth.js middleware wrapper,
+// so tests can assert which routes are scoped into session resolution.
+const authWrapperCalls = vi.hoisted(() => ({ count: 0 }))
 const signInMock = vi.hoisted(() => vi.fn())
 const readSignupMetadataMock = vi.hoisted(() => vi.fn())
 const setSignupMetadataCookieMock = vi.hoisted(() => vi.fn())
@@ -18,6 +21,7 @@ vi.mock('@/auth', () => ({
       ) => Response | Promise<Response>
     ) =>
       (request: NextRequest, event: NextFetchEvent) => {
+        authWrapperCalls.count++
         Object.defineProperty(request, 'auth', {
           configurable: true,
           value: authSession.current,
@@ -166,5 +170,28 @@ describe('Ory auth entrypoints', () => {
     )
 
     expect(response?.status).toBe(400)
+  })
+
+  it('runs the Auth.js wrapper only for dashboard and auth routes', async () => {
+    authSession.current = orySession({ accessToken: 'access-token' })
+
+    for (const path of ['/dashboard/team/sandboxes', '/sign-in', '/sign-up']) {
+      const before = authWrapperCalls.count
+      await proxy(request(path), {} as NextFetchEvent)
+      expect(authWrapperCalls.count, path).toBe(before + 1)
+    }
+  })
+
+  it('keeps session-irrelevant routes out of the Auth.js wrapper', async () => {
+    authSession.current = orySession({ accessToken: 'access-token' })
+
+    for (const path of ['/', '/blog/post', '/_next/mintlify-assets/chunk.js']) {
+      const before = authWrapperCalls.count
+      const response = await proxy(request(path), {} as NextFetchEvent)
+
+      expect(authWrapperCalls.count, path).toBe(before)
+      // still served by the plain proxy, no auth redirect
+      expect(response.headers.get('location'), path).toBeNull()
+    }
   })
 })


### PR DESCRIPTION
## Summary

Two related fixes preventing stray requests from touching auth state:

1. **Matcher: skip all `_next/*` paths.** Only `_next/static` and `_next/image` were excluded, so other `/_next/*` paths (e.g. stray `/_next/mintlify-assets/*` requests observed in traffic) ran the full middleware before 404ing. Safe because the app is App Router only (no `_next/data`), and server actions / RSC navigations use page paths. Root-level `mintlify-assets/` and `_mintlify/` exclusions are kept for the `next.config.ts` rewrites.

2. **Scope the Auth.js wrapper to dashboard + auth routes.** In Ory mode the wrapper ran on every matched path, re-setting the session cookie per request and deleting tokens it cannot decrypt — observed in production as `__Secure-authjs.session-token=; Max-Age=0` on a 404ing asset request, i.e. a stray request could log the user out. Only `/dashboard/*` and the auth pages consume the resolved session (`handleAuthGate` / `getOryAuthRouteRedirect`); everything else now goes through plain `proxyCore` with no session side effects.

## Testing

- New tests assert the wrapper runs for `/dashboard/*`, `/sign-in`, `/sign-up` and is skipped for `/`, `/blog/*`, stray `_next` paths
- `tests/unit/proxy-handlers.test.ts`, `tests/integration/proxy.test.ts`, `tests/integration/auth-ory-entrypoints.test.ts` — 20/20 pass
- Verified on the branch preview deployment: `/_next/mintlify-assets/...` returns a bare 404 with no `set-cookie`, while the old build on e2b-juliett.dev sets/deletes authjs cookies on the same path