### PR TITLE
fix(auth): pass Ory signup metadata to dashboard bootstrap

### DIFF
--- a/spec/openapi.dashboard-api.yaml
+++ b/spec/openapi.dashboard-api.yaml
@@ -313,6 +313,10 @@ components:
         oidc_user_name:
           type: string
           nullable: true
+        signup_ip:
+          type: string
+        signup_user_agent:
+          type: string
 
     AdminTeamBootstrapRequest:
       type: object

--- a/src/core/server/auth/ory/dashboard-bootstrap.ts
+++ b/src/core/server/auth/ory/dashboard-bootstrap.ts
@@ -5,6 +5,7 @@ import { api } from '@/core/shared/clients/api'
 import { l, serializeErrorForLog } from '@/core/shared/clients/logger/logger'
 import { repoErrorFromHttp } from '@/core/shared/errors'
 import { decodeJwtClaims, readStringClaim, tokenFormat } from './jwt-claims'
+import { readOrySignupMetadataCookie } from './signup-metadata'
 
 type BootstrapOryUserInput = {
   accessToken: string
@@ -26,6 +27,15 @@ type OryTokenClaims = {
   name?: unknown
   given_name?: unknown
   preferred_username?: unknown
+}
+
+type DashboardBootstrapBody = {
+  oidc_issuer: string
+  oidc_user_id: string
+  oidc_user_email: string
+  oidc_user_name: string | null
+  signup_ip?: string
+  signup_user_agent?: string
 }
 
 export async function ensureOryUserBootstrapped(
@@ -109,11 +119,16 @@ async function bootstrapOryUserWithClaims(
       return false
     }
 
-    const body = {
+    const signupMetadata = await readOrySignupMetadataCookie()
+    const body: DashboardBootstrapBody = {
       oidc_issuer: claims.oidcIssuer,
       oidc_user_id: claims.oidcUserId,
       oidc_user_email: claims.oidcUserEmail,
       oidc_user_name: claims.oidcUserName,
+    }
+    if (signupMetadata?.signup_ip) body.signup_ip = signupMetadata.signup_ip
+    if (signupMetadata?.signup_user_agent) {
+      body.signup_user_agent = signupMetadata.signup_user_agent
     }
 
     const { error, response } = await api.POST('/admin/users/bootstrap', {

--- a/src/core/server/auth/ory/dashboard-bootstrap.ts
+++ b/src/core/server/auth/ory/dashboard-bootstrap.ts
@@ -3,6 +3,7 @@ import 'server-only'
 import { ADMIN_AUTH_HEADERS } from '@/configs/api'
 import { api } from '@/core/shared/clients/api'
 import { l, serializeErrorForLog } from '@/core/shared/clients/logger/logger'
+import type { components as DashboardApiComponents } from '@/core/shared/contracts/dashboard-api.types'
 import { repoErrorFromHttp } from '@/core/shared/errors'
 import { decodeJwtClaims, readStringClaim, tokenFormat } from './jwt-claims'
 import { readOrySignupMetadataCookie } from './signup-metadata'
@@ -27,15 +28,6 @@ type OryTokenClaims = {
   name?: unknown
   given_name?: unknown
   preferred_username?: unknown
-}
-
-type DashboardBootstrapBody = {
-  oidc_issuer: string
-  oidc_user_id: string
-  oidc_user_email: string
-  oidc_user_name: string | null
-  signup_ip?: string
-  signup_user_agent?: string
 }
 
 export async function ensureOryUserBootstrapped(
@@ -120,16 +112,18 @@ async function bootstrapOryUserWithClaims(
     }
 
     const signupMetadata = await readOrySignupMetadataCookie()
-    const body: DashboardBootstrapBody = {
+    const body = {
       oidc_issuer: claims.oidcIssuer,
       oidc_user_id: claims.oidcUserId,
       oidc_user_email: claims.oidcUserEmail,
       oidc_user_name: claims.oidcUserName,
-    }
-    if (signupMetadata?.signup_ip) body.signup_ip = signupMetadata.signup_ip
-    if (signupMetadata?.signup_user_agent) {
-      body.signup_user_agent = signupMetadata.signup_user_agent
-    }
+      ...(signupMetadata?.signup_ip
+        ? { signup_ip: signupMetadata.signup_ip }
+        : {}),
+      ...(signupMetadata?.signup_user_agent
+        ? { signup_user_agent: signupMetadata.signup_user_agent }
+        : {}),
+    } satisfies DashboardApiComponents['schemas']['AdminAuthProviderUserBootstrapRequest']
 
     const { error, response } = await api.POST('/admin/users/bootstrap', {
       body,

--- a/src/core/server/auth/ory/signup-metadata.ts
+++ b/src/core/server/auth/ory/signup-metadata.ts
@@ -83,6 +83,23 @@ export async function persistOrySignupMetadataFromCookie(
   }
 }
 
+export async function readOrySignupMetadataCookie(): Promise<OrySignupMetadata | null> {
+  const cookieStore = await cookies()
+  const encoded = cookieStore.get(ORY_SIGNUP_METADATA_COOKIE)?.value
+
+  if (!encoded) return null
+
+  const metadata = decodeSignupMetadata(encoded)
+  if (!metadata) {
+    l.warn(
+      { key: 'auth_provider:ory_signup_metadata:invalid_cookie' },
+      'Ignoring invalid Ory signup metadata cookie'
+    )
+  }
+
+  return metadata
+}
+
 export async function persistOrySignupMetadata(
   identityId: string,
   metadata: OrySignupMetadata
@@ -125,19 +142,9 @@ export async function persistOrySignupMetadata(
 
 async function consumeOrySignupMetadataCookie(): Promise<OrySignupMetadata | null> {
   const cookieStore = await cookies()
-  const encoded = cookieStore.get(ORY_SIGNUP_METADATA_COOKIE)?.value
+  const metadata = await readOrySignupMetadataCookie()
 
   cookieStore.delete(ORY_SIGNUP_METADATA_COOKIE)
-
-  if (!encoded) return null
-
-  const metadata = decodeSignupMetadata(encoded)
-  if (!metadata) {
-    l.warn(
-      { key: 'auth_provider:ory_signup_metadata:invalid_cookie' },
-      'Ignoring invalid Ory signup metadata cookie'
-    )
-  }
 
   return metadata
 }

--- a/src/core/shared/contracts/dashboard-api.types.ts
+++ b/src/core/shared/contracts/dashboard-api.types.ts
@@ -890,6 +890,8 @@ export interface components {
       /** Format: email */
       oidc_user_email: string
       oidc_user_name?: string | null
+      signup_ip?: string
+      signup_user_agent?: string
     }
     AdminTeamBootstrapRequest: {
       /** @description Team name. */

--- a/tests/integration/auth-ory-dashboard-bootstrap.test.ts
+++ b/tests/integration/auth-ory-dashboard-bootstrap.test.ts
@@ -8,6 +8,7 @@ const loggerMocks = vi.hoisted(() => ({
 }))
 
 const apiPostMock = vi.hoisted(() => vi.fn())
+const readSignupMetadataCookieMock = vi.hoisted(() => vi.fn())
 const originalDashboardApiAdminToken = process.env.DASHBOARD_API_ADMIN_TOKEN
 
 function jwt(claims: Record<string, unknown>) {
@@ -35,6 +36,10 @@ vi.mock('@/core/shared/clients/api', () => ({
   },
 }))
 
+vi.mock('@/core/server/auth/ory/signup-metadata', () => ({
+  readOrySignupMetadataCookie: readSignupMetadataCookieMock,
+}))
+
 const { ensureOryUserBootstrapped } = await import(
   '@/core/server/auth/ory/dashboard-bootstrap'
 )
@@ -43,6 +48,7 @@ describe('dashboard bootstrap for Ory users', () => {
   beforeEach(() => {
     process.env.DASHBOARD_API_ADMIN_TOKEN = 'admin-token'
     apiPostMock.mockReset()
+    readSignupMetadataCookieMock.mockReset().mockResolvedValue(null)
     loggerMocks.error.mockClear()
   })
 
@@ -77,6 +83,40 @@ describe('dashboard bootstrap for Ory users', () => {
         oidc_user_id: 'e2b-user-id',
         oidc_user_email: 'ada@example.test',
         oidc_user_name: 'Ada',
+      },
+      headers: { 'X-Admin-Token': 'admin-token' },
+    })
+  })
+
+  it('passes signup metadata to dashboard-api when available', async () => {
+    readSignupMetadataCookieMock.mockResolvedValue({
+      signup_ip: '203.0.113.10',
+      signup_user_agent: 'Mozilla/5.0',
+    })
+    apiPostMock.mockResolvedValue({
+      data: { id: 'team-1', slug: 'team-1' },
+      error: null,
+      response: { ok: true, status: 200, statusText: 'OK' },
+    })
+
+    const result = await ensureOryUserBootstrapped({
+      accessToken: jwt({
+        iss: 'https://ory.example.test',
+        sub: 'e2b-user-id',
+        email: 'ada@example.test',
+      }),
+      provider: 'ory',
+    })
+
+    expect(result).toBe(true)
+    expect(apiPostMock).toHaveBeenCalledWith('/admin/users/bootstrap', {
+      body: {
+        oidc_issuer: 'https://ory.example.test',
+        oidc_user_id: 'e2b-user-id',
+        oidc_user_email: 'ada@example.test',
+        oidc_user_name: null,
+        signup_ip: '203.0.113.10',
+        signup_user_agent: 'Mozilla/5.0',
       },
       headers: { 'X-Admin-Token': 'admin-token' },
     })


### PR DESCRIPTION
## Summary
- read the signed Ory signup metadata cookie during dashboard bootstrap
- forward signup_ip and signup_user_agent to dashboard-api before billing provisioning runs
- keep the existing Ory metadata_admin persistence path for audit/history

Pairs with infra PR: https://github.com/e2b-dev/infra/pull/2978