### PR TITLE
docs: add AGENTS.md with CLAUDE.md symlink

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,7 +41,6 @@ yarn-error.log*
 next-env.d.ts
 
 # AI agents and related files
-CLAUDE.md
 .cursor/
 .agent
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,8 @@
+# E2B Dashboard
+
+A web application for managing and monitoring E2B services — sandboxes, API keys, and usage analytics. Built with Next.js, React, and TypeScript.
+
+## Comments
+
+- Omit verbose or redundant comments. Prefer self-documenting names over narration.
+- Comment only the non-obvious **why**, never the **what** the code already says.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md


### PR DESCRIPTION
First step toward better agentic flows: adds `AGENTS.md` as the canonical agent-guidance doc for the repo, starting with a project description and a note to omit verbose comments. `CLAUDE.md` is a relative symlink to it so Claude Code and other AGENTS.md-aware tools share one source of truth, and its `.gitignore` entry was removed so both files are tracked.