### PR TITLE
fix(auth): block localhost host-confusion bypass in CLI auth redirect

### DIFF
--- a/src/app/(auth)/auth/cli/page.tsx
+++ b/src/app/(auth)/auth/cli/page.tsx
@@ -4,6 +4,7 @@ import { AUTH_URLS, PROTECTED_URLS } from '@/configs/urls'
 import { createUserTeamsRepository } from '@/core/modules/teams/user-teams-repository.server'
 import { auth } from '@/core/server/auth'
 import { l, serializeErrorForLog } from '@/core/shared/clients/logger/logger'
+import { isLoopbackUrl } from '@/core/shared/schemas/url'
 import { encodedRedirect } from '@/lib/utils/auth'
 import { generateE2BUserAccessToken } from '@/lib/utils/server'
 import { Alert, AlertDescription, AlertTitle } from '@/ui/primitives/alert'
@@ -23,7 +24,7 @@ async function handleCLIAuth(
   userEmail: string,
   supabaseAccessToken: string
 ) {
-  if (!next?.startsWith('http://localhost')) {
+  if (!isLoopbackUrl(next)) {
     throw new Error('Invalid redirect URL')
   }
 
@@ -103,7 +104,7 @@ export default async function CLIAuthPage({
   }
 
   // Validate redirect URL
-  if (!next?.startsWith('http://localhost')) {
+  if (!next || !isLoopbackUrl(next)) {
     l.error(
       {
         key: 'cli_auth:invalid_redirect_url',

--- a/src/core/shared/schemas/url.ts
+++ b/src/core/shared/schemas/url.ts
@@ -32,3 +32,29 @@ export const relativeUrlSchema = z
       message: 'Must be a relative URL starting with /',
     }
   )
+
+const LOOPBACK_HOSTNAMES = new Set(['localhost', '127.0.0.1', '[::1]'])
+
+/**
+ * True only when `value` is an http(s) URL whose host is an actual loopback
+ * address. Parses with the URL constructor instead of prefix-matching, so
+ * hosts like `localhost.evil.com` or `localhost@evil.com` are rejected.
+ */
+export function isLoopbackUrl(value: string): boolean {
+  let url: URL
+  try {
+    url = new URL(value)
+  } catch {
+    return false
+  }
+
+  if (url.protocol !== 'http:' && url.protocol !== 'https:') {
+    return false
+  }
+
+  return LOOPBACK_HOSTNAMES.has(url.hostname)
+}
+
+export const loopbackUrlSchema = z.string().refine(isLoopbackUrl, {
+  message: 'Must be an http(s) URL pointing at localhost',
+})

--- a/tests/unit/url-schema.test.ts
+++ b/tests/unit/url-schema.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it } from 'vitest'
-import { httpUrlSchema } from '@/core/shared/schemas/url'
+import {
+  httpUrlSchema,
+  isLoopbackUrl,
+  loopbackUrlSchema,
+} from '@/core/shared/schemas/url'
 
 describe('httpUrlSchema', () => {
   describe('accepts valid http/https URLs', () => {
@@ -69,5 +73,93 @@ describe('httpUrlSchema', () => {
     it('rejects empty strings', () => {
       expect(httpUrlSchema.safeParse('').success).toBe(false)
     })
+  })
+})
+
+describe('isLoopbackUrl', () => {
+  describe('accepts genuine loopback URLs', () => {
+    it('accepts http localhost with port and path', () => {
+      expect(isLoopbackUrl('http://localhost:3000/callback')).toBe(true)
+    })
+
+    it('accepts http localhost without port', () => {
+      expect(isLoopbackUrl('http://localhost')).toBe(true)
+    })
+
+    it('accepts http 127.0.0.1 with port', () => {
+      expect(isLoopbackUrl('http://127.0.0.1:55021')).toBe(true)
+    })
+
+    it('accepts http IPv6 loopback', () => {
+      expect(isLoopbackUrl('http://[::1]:9000')).toBe(true)
+    })
+
+    it('accepts https loopback', () => {
+      expect(isLoopbackUrl('https://localhost:3000/callback')).toBe(true)
+    })
+  })
+
+  describe('rejects host-confusion bypass attempts', () => {
+    it('rejects a subdomain of an attacker host', () => {
+      expect(isLoopbackUrl('http://localhost.evil.com')).toBe(false)
+    })
+
+    it('rejects a subdomain with a port', () => {
+      expect(isLoopbackUrl('http://localhost.evil.com:3000/callback')).toBe(
+        false
+      )
+    })
+
+    it('rejects a hyphenated attacker host', () => {
+      expect(isLoopbackUrl('http://localhost-evil.com')).toBe(false)
+    })
+
+    it('rejects userinfo pointing at an attacker host', () => {
+      expect(isLoopbackUrl('http://localhost@evil.com')).toBe(false)
+    })
+
+    it('rejects an attacker host with localhost in the path', () => {
+      expect(isLoopbackUrl('http://evil.com/localhost')).toBe(false)
+    })
+  })
+
+  describe('rejects non-http(s) and malformed inputs', () => {
+    it('rejects a non-loopback https host', () => {
+      expect(isLoopbackUrl('https://evil.com')).toBe(false)
+    })
+
+    it('rejects javascript URLs', () => {
+      expect(isLoopbackUrl('javascript:alert(1)')).toBe(false)
+    })
+
+    it('rejects file URLs to loopback-looking paths', () => {
+      expect(isLoopbackUrl('file://localhost/etc/passwd')).toBe(false)
+    })
+
+    it('rejects protocol-relative URLs', () => {
+      expect(isLoopbackUrl('//localhost')).toBe(false)
+    })
+
+    it('rejects plain strings', () => {
+      expect(isLoopbackUrl('not-a-url')).toBe(false)
+    })
+
+    it('rejects empty strings', () => {
+      expect(isLoopbackUrl('')).toBe(false)
+    })
+  })
+})
+
+describe('loopbackUrlSchema', () => {
+  it('parses a genuine loopback URL', () => {
+    expect(loopbackUrlSchema.safeParse('http://localhost:3000').success).toBe(
+      true
+    )
+  })
+
+  it('fails on a host-confusion bypass attempt', () => {
+    expect(
+      loopbackUrlSchema.safeParse('http://localhost.evil.com').success
+    ).toBe(false)
   })
 })


### PR DESCRIPTION
## Problem

The CLI auth page validated the callback URL (`next`) with `next.startsWith('http://localhost')`, a substring check that passes for attacker-controlled hosts like `http://localhost.evil.com`, `http://localhost-evil.com`, and `http://localhost@evil.com`

## Fix

Added a reusable `isLoopbackUrl()` helper (and `loopbackUrlSchema`) in `src/core/shared/schemas/url.ts` that parses with the WHATWG `URL` constructor and checks the real `hostname` against a strict loopback allowlist (`localhost`, `127.0.0.1`, `[::1]`) over http/https only, then used it for both `next` checks in the CLI auth page. Added unit tests in `tests/unit/url-schema.test.ts` covering genuine loopback URLs, the bypass class, and malformed/non-http inputs (30 tests pass).