### PR TITLE
feat: templates list pagination

### DIFF
--- a/spec/openapi.dashboard-api.yaml
+++ b/spec/openapi.dashboard-api.yaml
@@ -162,8 +162,6 @@ components:
         type: string
         enum:
           [
-            name_asc,
-            name_desc,
             created_at_asc,
             created_at_desc,
             updated_at_asc,

--- a/spec/openapi.dashboard-api.yaml
+++ b/spec/openapi.dashboard-api.yaml
@@ -182,10 +182,6 @@ components:
           [
             name_asc,
             name_desc,
-            cpu_count_asc,
-            cpu_count_desc,
-            memory_mb_asc,
-            memory_mb_desc,
             created_at_asc,
             created_at_desc,
             updated_at_asc,

--- a/spec/openapi.dashboard-api.yaml
+++ b/spec/openapi.dashboard-api.yaml
@@ -139,24 +139,6 @@ components:
       description: Cursor returned by the previous list response in `{sort}|{value}|{templateID}` format. Rejected if its sort does not match the request.
       schema:
         type: string
-    templates_cpu_count:
-      name: cpuCount
-      in: query
-      required: false
-      description: Filter templates by exact vCPU count.
-      schema:
-        type: integer
-        format: int32
-        minimum: 1
-    templates_memory_mb:
-      name: memoryMB
-      in: query
-      required: false
-      description: Filter templates by exact memory size in MB.
-      schema:
-        type: integer
-        format: int32
-        minimum: 1
     templates_public:
       name: public
       in: query
@@ -1346,8 +1328,6 @@ paths:
         - AuthProviderBearerAuth: []
           AuthProviderTeamAuth: []
       parameters:
-        - $ref: "#/components/parameters/templates_cpu_count"
-        - $ref: "#/components/parameters/templates_memory_mb"
         - $ref: "#/components/parameters/templates_public"
         - $ref: "#/components/parameters/templates_search"
         - $ref: "#/components/parameters/templates_sort"

--- a/spec/openapi.dashboard-api.yaml
+++ b/spec/openapi.dashboard-api.yaml
@@ -169,7 +169,7 @@ components:
             updated_at_asc,
             updated_at_desc,
           ]
-        default: created_at_desc
+        default: updated_at_desc
 
   responses:
     "400":

--- a/src/app/dashboard/[teamSlug]/templates/(tabs)/list/page.tsx
+++ b/src/app/dashboard/[teamSlug]/templates/(tabs)/list/page.tsx
@@ -1,11 +1,30 @@
 import { Suspense } from 'react'
 import LoadingLayout from '@/features/dashboard/loading-layout'
+import {
+  TEMPLATES_DEFAULT_SORT,
+  TEMPLATES_PAGE_SIZE,
+} from '@/features/dashboard/templates/list/constants'
 import TemplatesTable from '@/features/dashboard/templates/list/table'
+import { HydrateClient, prefetch, trpc } from '@/trpc/server'
 
-export default function TemplatesListPage() {
+export default async function TemplatesListPage({
+  params,
+}: PageProps<'/dashboard/[teamSlug]/templates/list'>) {
+  const { teamSlug } = await params
+
+  prefetch(
+    trpc.templates.getTemplates.infiniteQueryOptions({
+      teamSlug,
+      limit: TEMPLATES_PAGE_SIZE,
+      sort: TEMPLATES_DEFAULT_SORT,
+    })
+  )
+
   return (
-    <Suspense fallback={<LoadingLayout />}>
-      <TemplatesTable />
-    </Suspense>
+    <HydrateClient>
+      <Suspense fallback={<LoadingLayout />}>
+        <TemplatesTable />
+      </Suspense>
+    </HydrateClient>
   )
 }

--- a/src/core/modules/templates/models.ts
+++ b/src/core/modules/templates/models.ts
@@ -1,3 +1,7 @@
+import type {
+  components as DashboardComponents,
+  paths as DashboardPaths,
+} from '@/contracts/dashboard-api'
 import type { components as InfraComponents } from '@/contracts/infra-api'
 
 export type Template = Pick<
@@ -22,4 +26,15 @@ export type Template = Pick<
 export type DefaultTemplate = Template & {
   isDefault: true
   defaultDescription?: string
+}
+
+export type TemplatesSort = DashboardComponents['parameters']['templates_sort']
+
+export type ListTeamTemplatesOptions = NonNullable<
+  DashboardPaths['/templates']['get']['parameters']['query']
+>
+
+export interface ListTeamTemplatesResult {
+  data: Array<Template | DefaultTemplate>
+  nextCursor: string | null
 }

--- a/src/core/modules/templates/repository.server.ts
+++ b/src/core/modules/templates/repository.server.ts
@@ -7,7 +7,12 @@ import {
   MOCK_DEFAULT_TEMPLATES_DATA,
   MOCK_TEMPLATES_DATA,
 } from '@/configs/mock-data'
-import type { DefaultTemplate, Template } from '@/core/modules/templates/models'
+import type {
+  DefaultTemplate,
+  ListTeamTemplatesOptions,
+  ListTeamTemplatesResult,
+  Template,
+} from '@/core/modules/templates/models'
 import {
   type AuthUserEmailResolver,
   getAuthUserEmailsById,
@@ -30,6 +35,9 @@ type TemplatesRepositoryDeps = {
 
 export interface TeamTemplatesRepository {
   getTeamTemplates(): Promise<RepoResult<{ templates: Template[] }>>
+  listTeamTemplates(
+    options: ListTeamTemplatesOptions
+  ): Promise<RepoResult<ListTeamTemplatesResult>>
   deleteTemplate(templateId: string): Promise<RepoResult<{ success: true }>>
   updateTemplateVisibility(
     templateId: string,
@@ -86,6 +94,62 @@ export function createTemplatesRepository(
           deps.resolveAuthUserEmailsById
         ),
       })
+    },
+    async listTeamTemplates(options) {
+      if (USE_MOCK_DATA) {
+        return ok({ data: MOCK_TEMPLATES_DATA, nextCursor: null })
+      }
+
+      const res = await deps.apiClient.GET('/templates', {
+        params: {
+          query: options,
+        },
+        headers: {
+          ...deps.authHeaders(scope.accessToken, scope.teamId),
+        },
+      })
+
+      if (!res.response.ok || res.error) {
+        return err(
+          repoErrorFromHttp(
+            res.response.status,
+            res.error?.message ?? 'Failed to fetch templates',
+            res.error
+          )
+        )
+      }
+
+      if (!res.data?.data?.length) {
+        return ok({ data: [], nextCursor: res.data?.nextCursor ?? null })
+      }
+
+      const data = res.data.data.map((t): Template | DefaultTemplate => ({
+        templateID: t.templateID,
+        buildID: t.buildID,
+        cpuCount: t.cpuCount,
+        memoryMB: t.memoryMB,
+        diskSizeMB: t.diskSizeMB ?? 0,
+        public: t.public,
+        aliases: t.aliases,
+        names: t.names,
+        createdAt: t.createdAt,
+        updatedAt: t.updatedAt,
+        // Email resolution is deferred while the Supabase auth migration is
+        // in progress; the endpoint returns only the creator id for now.
+        createdBy: t.createdBy
+          ? { id: t.createdBy.id, email: t.createdBy.email ?? '' }
+          : null,
+        lastSpawnedAt: t.lastSpawnedAt ?? null,
+        spawnCount: t.spawnCount,
+        buildCount: t.buildCount,
+        envdVersion: t.envdVersion ?? '',
+        ...(t.isDefault && {
+          isDefault: true as const,
+          defaultDescription: t.defaultDescription ?? undefined,
+        }),
+      }))
+
+      return ok({ data, nextCursor: res.data.nextCursor ?? null })
     },
     async deleteTemplate(templateId) {
       const res = await deps.infraClient.DELETE('/templates/{templateID}', {

--- a/src/core/server/api/routers/templates.ts
+++ b/src/core/server/api/routers/templates.ts
@@ -45,8 +45,6 @@ export const templatesRouter = createTRPCRouter({
         search: z.string().optional(),
         sort: z
           .enum([
-            'name_asc',
-            'name_desc',
             'created_at_asc',
             'created_at_desc',
             'updated_at_asc',

--- a/src/core/server/api/routers/templates.ts
+++ b/src/core/server/api/routers/templates.ts
@@ -49,10 +49,6 @@ export const templatesRouter = createTRPCRouter({
           .enum([
             'name_asc',
             'name_desc',
-            'cpu_count_asc',
-            'cpu_count_desc',
-            'memory_mb_asc',
-            'memory_mb_desc',
             'created_at_asc',
             'created_at_desc',
             'updated_at_asc',

--- a/src/core/server/api/routers/templates.ts
+++ b/src/core/server/api/routers/templates.ts
@@ -36,11 +36,44 @@ const teamTemplatesRepositoryProcedure = protectedTeamProcedure.use(
 export const templatesRouter = createTRPCRouter({
   // QUERIES
 
-  getTemplates: teamTemplatesRepositoryProcedure.query(async ({ ctx }) => {
-    const result = await ctx.templatesRepository.getTeamTemplates()
-    if (!result.ok) throwTRPCErrorFromRepoError(result.error)
-    return result.data
-  }),
+  getTemplates: teamTemplatesRepositoryProcedure
+    .input(
+      z.object({
+        cursor: z.string().optional(),
+        limit: z.number().int().min(1).max(100).default(50),
+        cpuCount: z.number().int().positive().optional(),
+        memoryMB: z.number().int().positive().optional(),
+        public: z.boolean().optional(),
+        search: z.string().optional(),
+        sort: z
+          .enum([
+            'name_asc',
+            'name_desc',
+            'cpu_count_asc',
+            'cpu_count_desc',
+            'memory_mb_asc',
+            'memory_mb_desc',
+            'created_at_asc',
+            'created_at_desc',
+            'updated_at_asc',
+            'updated_at_desc',
+          ])
+          .default('updated_at_desc'),
+      })
+    )
+    .query(async ({ ctx, input }) => {
+      const result = await ctx.templatesRepository.listTeamTemplates({
+        cursor: input.cursor,
+        limit: input.limit,
+        cpuCount: input.cpuCount,
+        memoryMB: input.memoryMB,
+        public: input.public,
+        search: input.search,
+        sort: input.sort,
+      })
+      if (!result.ok) throwTRPCErrorFromRepoError(result.error)
+      return result.data
+    }),
 
   getDefaultTemplatesCached: templatesRepositoryProcedure.query(
     async ({ ctx }) => {

--- a/src/core/server/api/routers/templates.ts
+++ b/src/core/server/api/routers/templates.ts
@@ -41,8 +41,6 @@ export const templatesRouter = createTRPCRouter({
       z.object({
         cursor: z.string().optional(),
         limit: z.number().int().min(1).max(100).default(50),
-        cpuCount: z.number().int().positive().optional(),
-        memoryMB: z.number().int().positive().optional(),
         public: z.boolean().optional(),
         search: z.string().optional(),
         sort: z
@@ -61,8 +59,6 @@ export const templatesRouter = createTRPCRouter({
       const result = await ctx.templatesRepository.listTeamTemplates({
         cursor: input.cursor,
         limit: input.limit,
-        cpuCount: input.cpuCount,
-        memoryMB: input.memoryMB,
         public: input.public,
         search: input.search,
         sort: input.sort,

--- a/src/core/shared/contracts/dashboard-api.types.ts
+++ b/src/core/shared/contracts/dashboard-api.types.ts
@@ -767,10 +767,6 @@ export interface paths {
     get: {
       parameters: {
         query?: {
-          /** @description Filter templates by exact vCPU count. */
-          cpuCount?: components['parameters']['templates_cpu_count']
-          /** @description Filter templates by exact memory size in MB. */
-          memoryMB?: components['parameters']['templates_memory_mb']
           /** @description Filter templates by visibility (true = public, false = internal). */
           public?: components['parameters']['templates_public']
           /** @description Case-insensitive substring match on template names, aliases, and template id. */
@@ -1232,10 +1228,6 @@ export interface components {
     templates_limit: number
     /** @description Cursor returned by the previous list response in `{sort}|{value}|{templateID}` format. Rejected if its sort does not match the request. */
     templates_cursor: string
-    /** @description Filter templates by exact vCPU count. */
-    templates_cpu_count: number
-    /** @description Filter templates by exact memory size in MB. */
-    templates_memory_mb: number
     /** @description Filter templates by visibility (true = public, false = internal). */
     templates_public: boolean
     /** @description Case-insensitive substring match on template names, aliases, and template id. */

--- a/src/core/shared/contracts/dashboard-api.types.ts
+++ b/src/core/shared/contracts/dashboard-api.types.ts
@@ -1234,8 +1234,6 @@ export interface components {
     templates_search: string
     /** @description Sort column and direction. */
     templates_sort:
-      | 'name_asc'
-      | 'name_desc'
       | 'created_at_asc'
       | 'created_at_desc'
       | 'updated_at_asc'

--- a/src/core/shared/contracts/dashboard-api.types.ts
+++ b/src/core/shared/contracts/dashboard-api.types.ts
@@ -1244,10 +1244,6 @@ export interface components {
     templates_sort:
       | 'name_asc'
       | 'name_desc'
-      | 'cpu_count_asc'
-      | 'cpu_count_desc'
-      | 'memory_mb_asc'
-      | 'memory_mb_desc'
       | 'created_at_asc'
       | 'created_at_desc'
       | 'updated_at_asc'

--- a/src/features/dashboard/templates/builds/table-cells.tsx
+++ b/src/features/dashboard/templates/builds/table-cells.tsx
@@ -61,42 +61,6 @@ export function Template({
   )
 }
 
-export function LoadMoreButton({
-  isLoading,
-  onLoadMore,
-}: {
-  isLoading: boolean
-  onLoadMore: () => void
-}) {
-  if (isLoading) {
-    return (
-      <span className="inline-flex items-center gap-1">
-        Loading
-        <Loader variant="dots" />
-      </span>
-    )
-  }
-  return (
-    <button
-      onClick={onLoadMore}
-      className="underline text-fg-secondary hover:text-accent-main-highlight transition-colors"
-    >
-      Load more
-    </button>
-  )
-}
-
-export function BackToTopButton({ onBackToTop }: { onBackToTop: () => void }) {
-  return (
-    <button
-      onClick={onBackToTop}
-      className="underline text-fg-secondary hover:text-accent-main-highlight transition-colors"
-    >
-      Back to top
-    </button>
-  )
-}
-
 export function Duration({
   createdAt,
   finishedAt,

--- a/src/features/dashboard/templates/builds/table.tsx
+++ b/src/features/dashboard/templates/builds/table.tsx
@@ -16,6 +16,7 @@ import type {
 import { useRouteParams } from '@/lib/hooks/use-route-params'
 import { cn } from '@/lib/utils/ui'
 import { useTRPC } from '@/trpc/client'
+import { BackToTopButton, LoadMoreButton } from '@/ui/pagination-buttons'
 import { ArrowDownIcon } from '@/ui/primitives/icons'
 import { Loader } from '@/ui/primitives/loader'
 import {
@@ -28,10 +29,8 @@ import {
 } from '@/ui/primitives/table'
 import BuildsEmpty from './empty'
 import {
-  BackToTopButton,
   BuildId,
   Duration,
-  LoadMoreButton,
   Reason,
   StartedAt,
   Status,

--- a/src/features/dashboard/templates/list/constants.ts
+++ b/src/features/dashboard/templates/list/constants.ts
@@ -1,0 +1,16 @@
+import type { SortingState } from '@tanstack/react-table'
+import type { TemplatesSort } from '@/core/modules/templates/models'
+
+export const TEMPLATES_PAGE_SIZE = 50
+
+export const TEMPLATES_DEFAULT_SORT_COLUMN_ID = 'createdAt'
+export const TEMPLATES_DEFAULT_SORT_BASE = 'created_at'
+export const TEMPLATES_DEFAULT_SORT_DESC = true
+
+export const TEMPLATES_DEFAULT_SORT: TemplatesSort = `${TEMPLATES_DEFAULT_SORT_BASE}_${
+  TEMPLATES_DEFAULT_SORT_DESC ? 'desc' : 'asc'
+}`
+
+export const TEMPLATES_DEFAULT_SORTING: SortingState = [
+  { id: TEMPLATES_DEFAULT_SORT_COLUMN_ID, desc: TEMPLATES_DEFAULT_SORT_DESC },
+]

--- a/src/features/dashboard/templates/list/constants.ts
+++ b/src/features/dashboard/templates/list/constants.ts
@@ -3,8 +3,8 @@ import type { TemplatesSort } from '@/core/modules/templates/models'
 
 export const TEMPLATES_PAGE_SIZE = 50
 
-export const TEMPLATES_DEFAULT_SORT_COLUMN_ID = 'createdAt'
-export const TEMPLATES_DEFAULT_SORT_BASE = 'created_at'
+export const TEMPLATES_DEFAULT_SORT_COLUMN_ID = 'updatedAt'
+export const TEMPLATES_DEFAULT_SORT_BASE = 'updated_at'
 export const TEMPLATES_DEFAULT_SORT_DESC = true
 
 export const TEMPLATES_DEFAULT_SORT: TemplatesSort = `${TEMPLATES_DEFAULT_SORT_BASE}_${

--- a/src/features/dashboard/templates/list/header.tsx
+++ b/src/features/dashboard/templates/list/header.tsx
@@ -12,12 +12,8 @@ interface TemplatesHeaderProps {
 export default function TemplatesHeader({ table }: TemplatesHeaderProps) {
   'use no memo'
 
-  const { globalFilter, cpuCount, memoryMB, isPublic } = useTemplateTableStore()
-  const isFiltered =
-    Boolean(globalFilter) ||
-    cpuCount !== undefined ||
-    memoryMB !== undefined ||
-    isPublic !== undefined
+  const { globalFilter, isPublic } = useTemplateTableStore()
+  const isFiltered = Boolean(globalFilter) || isPublic !== undefined
 
   // With server-side pagination we only know how many rows are currently
   // loaded, not the grand total.

--- a/src/features/dashboard/templates/list/header.tsx
+++ b/src/features/dashboard/templates/list/header.tsx
@@ -1,6 +1,7 @@
 import type { Table } from '@tanstack/react-table'
 import { Suspense } from 'react'
 import type { Template } from '@/core/modules/templates/models'
+import { useTemplateTableStore } from './stores/table-store'
 import TemplatesTableFilters from './table-filters'
 import { SearchInput } from './table-search'
 
@@ -11,13 +12,16 @@ interface TemplatesHeaderProps {
 export default function TemplatesHeader({ table }: TemplatesHeaderProps) {
   'use no memo'
 
-  const { columnFilters, globalFilter } = table.getState()
-  const showFilteredRowCount = columnFilters.length > 0 || Boolean(globalFilter)
+  const { globalFilter, cpuCount, memoryMB, isPublic } = useTemplateTableStore()
+  const isFiltered =
+    Boolean(globalFilter) ||
+    cpuCount !== undefined ||
+    memoryMB !== undefined ||
+    isPublic !== undefined
 
-  const totalCount = table.options.data.length
-  const filteredCount = showFilteredRowCount
-    ? table.getFilteredRowModel().rows.length
-    : totalCount
+  // With server-side pagination we only know how many rows are currently
+  // loaded, not the grand total.
+  const loadedCount = table.options.data.length
 
   return (
     <div className="flex min-w-0 flex-wrap items-start gap-1 sm:items-center">
@@ -33,17 +37,12 @@ export default function TemplatesHeader({ table }: TemplatesHeaderProps) {
       <div className="hidden w-2 shrink-0 sm:block" aria-hidden="true" />
 
       <span className="prose-label-highlight h-9 flex w-full min-w-0 items-center gap-1 uppercase sm:w-auto">
-        {showFilteredRowCount ? (
-          <>
-            <span className="text-fg">
-              {filteredCount} {filteredCount === 1 ? 'result' : 'results'}
-            </span>
-            <span className="text-fg-tertiary"> · </span>
-            <span className="text-fg-tertiary">{totalCount} total</span>
-          </>
-        ) : (
-          <span className="text-fg-tertiary">{totalCount} total</span>
-        )}
+        <span className="text-fg">
+          {loadedCount} {loadedCount === 1 ? 'template' : 'templates'}
+        </span>
+        {isFiltered ? (
+          <span className="text-fg-tertiary"> · filtered</span>
+        ) : null}
       </span>
     </div>
   )

--- a/src/features/dashboard/templates/list/stores/table-store.ts
+++ b/src/features/dashboard/templates/list/stores/table-store.ts
@@ -2,6 +2,7 @@ import type { OnChangeFn, SortingState } from '@tanstack/react-table'
 import { create } from 'zustand'
 import { createJSONStorage, persist } from 'zustand/middleware'
 import { createHashStorage } from '@/lib/utils/store'
+import { TEMPLATES_DEFAULT_SORTING } from '../constants'
 import { trackTemplateTableInteraction } from '../table-config'
 
 interface TemplateTableState {
@@ -33,7 +34,7 @@ type Store = TemplateTableState & TemplateTableActions
 
 const initialState: TemplateTableState = {
   // Table state
-  sorting: [{ id: 'updatedAt', desc: true }],
+  sorting: TEMPLATES_DEFAULT_SORTING,
   globalFilter: '',
   // Filter state
   cpuCount: undefined,

--- a/src/features/dashboard/templates/list/table-body.tsx
+++ b/src/features/dashboard/templates/list/table-body.tsx
@@ -2,8 +2,10 @@ import { flexRender, type Table } from '@tanstack/react-table'
 import type { RefObject } from 'react'
 import type { Template } from '@/core/modules/templates/models'
 import { useVirtualRows } from '@/lib/hooks/use-virtual-rows'
+import { cn } from '@/lib/utils'
 import { DataTableBody, DataTableCell, DataTableRow } from '@/ui/data-table'
 import Empty from '@/ui/empty'
+import { LoadMoreButton } from '@/ui/pagination-buttons'
 import { Button } from '@/ui/primitives/button'
 import { CloseIcon, ExternalLinkIcon } from '@/ui/primitives/icons'
 import { useTemplateTableStore } from './stores/table-store'
@@ -16,16 +18,25 @@ interface TemplatesTableBodyProps {
   templates: Template[] | undefined
   table: Table<Template>
   scrollRef: RefObject<HTMLDivElement | null>
+  hasNextPage: boolean
+  isFetchingNextPage: boolean
+  fetchNextPage: () => void
+  isRefetching: boolean
 }
 
 export function TemplatesTableBody({
   templates,
   table,
   scrollRef,
+  hasNextPage,
+  isFetchingNextPage,
+  fetchNextPage,
+  isRefetching,
 }: TemplatesTableBodyProps) {
   'use no memo'
 
-  const resetFilters = useTemplateTableStore((state) => state.resetFilters)
+  const { resetFilters, globalFilter, cpuCount, memoryMB, isPublic } =
+    useTemplateTableStore()
 
   const centerRows = table.getCenterRows()
   const {
@@ -47,9 +58,10 @@ export function TemplatesTableBody({
   const isEmpty = templates && centerRows.length === 0
 
   const hasFilter =
-    Object.values(table.getState().columnFilters).some(
-      (filter) => filter.value !== undefined
-    ) || table.getState().globalFilter !== ''
+    Boolean(globalFilter) ||
+    cpuCount !== undefined ||
+    memoryMB !== undefined ||
+    isPublic !== undefined
 
   if (isEmpty) {
     if (hasFilter) {
@@ -85,21 +97,35 @@ export function TemplatesTableBody({
   }
 
   return (
-    <DataTableBody virtualizedTotalHeight={virtualizedTotalHeight}>
-      {virtualPaddingTop > 0 && <div style={{ height: virtualPaddingTop }} />}
-      {rows.map((row) => (
-        <DataTableRow
-          key={row.id}
-          isSelected={row.getIsSelected()}
-          className="h-8 border-b"
-        >
-          {row.getVisibleCells().map((cell) => (
-            <DataTableCell key={cell.id} cell={cell}>
-              {flexRender(cell.column.columnDef.cell, cell.getContext())}
-            </DataTableCell>
-          ))}
-        </DataTableRow>
-      ))}
-    </DataTableBody>
+    <>
+      <DataTableBody
+        virtualizedTotalHeight={virtualizedTotalHeight}
+        className={cn(isRefetching && 'opacity-70 transition-opacity')}
+      >
+        {virtualPaddingTop > 0 && <div style={{ height: virtualPaddingTop }} />}
+        {rows.map((row) => (
+          <DataTableRow
+            key={row.id}
+            isSelected={row.getIsSelected()}
+            className="h-8 border-b"
+          >
+            {row.getVisibleCells().map((cell) => (
+              <DataTableCell key={cell.id} cell={cell}>
+                {flexRender(cell.column.columnDef.cell, cell.getContext())}
+              </DataTableCell>
+            ))}
+          </DataTableRow>
+        ))}
+      </DataTableBody>
+
+      {hasNextPage && (
+        <div className="flex items-center justify-center py-3 text-fg-tertiary max-md:sticky max-md:left-0 max-md:w-[calc(100svw-1.5rem)]">
+          <LoadMoreButton
+            isLoading={isFetchingNextPage}
+            onLoadMore={fetchNextPage}
+          />
+        </div>
+      )}
+    </>
   )
 }

--- a/src/features/dashboard/templates/list/table-body.tsx
+++ b/src/features/dashboard/templates/list/table-body.tsx
@@ -35,8 +35,7 @@ export function TemplatesTableBody({
 }: TemplatesTableBodyProps) {
   'use no memo'
 
-  const { resetFilters, globalFilter, cpuCount, memoryMB, isPublic } =
-    useTemplateTableStore()
+  const { resetFilters, globalFilter, isPublic } = useTemplateTableStore()
 
   const centerRows = table.getCenterRows()
   const {
@@ -57,11 +56,7 @@ export function TemplatesTableBody({
 
   const isEmpty = templates && centerRows.length === 0
 
-  const hasFilter =
-    Boolean(globalFilter) ||
-    cpuCount !== undefined ||
-    memoryMB !== undefined ||
-    isPublic !== undefined
+  const hasFilter = Boolean(globalFilter) || isPublic !== undefined
 
   if (isEmpty) {
     if (hasFilter) {

--- a/src/features/dashboard/templates/list/table-cells.tsx
+++ b/src/features/dashboard/templates/list/table-cells.tsx
@@ -5,7 +5,6 @@ import type { CellContext } from '@tanstack/react-table'
 import { useMemo, useState } from 'react'
 import type { DefaultTemplate, Template } from '@/core/modules/templates/models'
 import { useClipboard } from '@/lib/hooks/use-clipboard'
-import { useRouteParams } from '@/lib/hooks/use-route-params'
 import {
   defaultErrorToast,
   defaultSuccessToast,
@@ -56,16 +55,18 @@ export function ActionsCell({
 }: CellContext<Template | DefaultTemplate, unknown>) {
   const template = row.original
   const { team } = useDashboard()
-  const { teamSlug } = useRouteParams<'/dashboard/[teamSlug]/templates'>()
 
   const { toast } = useToast()
   const trpc = useTRPC()
   const queryClient = useQueryClient()
+  // Path-level key matches the paginated infinite query across every
+  // sort/filter/search variant currently in the cache.
+  const templatesListKey = trpc.templates.getTemplates.pathKey()
   const [isDeleteDialogOpen, setIsDeleteDialogOpen] = useState(false)
 
   const updateTemplateMutation = useMutation(
     trpc.templates.updateTemplate.mutationOptions({
-      onSuccess: async (data, variables) => {
+      onSuccess: (data) => {
         const templateName = template.aliases[0] || template.templateID
 
         toast(
@@ -77,30 +78,6 @@ export function ActionsCell({
             </>
           )
         )
-
-        await queryClient.cancelQueries({
-          queryKey: trpc.templates.getTemplates.queryKey({
-            teamSlug,
-          }),
-        })
-
-        queryClient.setQueryData(
-          trpc.templates.getTemplates.queryKey({
-            teamSlug,
-          }),
-          (old) => {
-            if (!old?.templates) return old
-
-            return {
-              ...old,
-              templates: old.templates.map((t: Template) =>
-                t.templateID === variables.templateId
-                  ? { ...t, public: variables.public }
-                  : t
-              ),
-            }
-          }
-        )
       },
       onError: (error) => {
         const templateName = template.aliases[0] || template.templateID
@@ -111,18 +88,14 @@ export function ActionsCell({
         )
       },
       onSettled: () => {
-        queryClient.invalidateQueries({
-          queryKey: trpc.templates.getTemplates.queryKey({
-            teamSlug,
-          }),
-        })
+        queryClient.invalidateQueries({ queryKey: templatesListKey })
       },
     })
   )
 
   const deleteTemplateMutation = useMutation(
     trpc.templates.deleteTemplate.mutationOptions({
-      onSuccess: async (_, variables) => {
+      onSuccess: () => {
         const templateName = template.aliases[0] || template.templateID
         toast(
           defaultSuccessToast(
@@ -133,32 +106,8 @@ export function ActionsCell({
             </>
           )
         )
-
-        // stop ongoing invlaidations and remove template from state while refetch is going in the background
-
-        await queryClient.cancelQueries({
-          queryKey: trpc.templates.getTemplates.queryKey({
-            teamSlug,
-          }),
-        })
-
-        queryClient.setQueryData(
-          trpc.templates.getTemplates.queryKey({
-            teamSlug,
-          }),
-
-          (old) => {
-            if (!old?.templates) return old
-            return {
-              ...old,
-              templates: old.templates.filter(
-                (t: Template) => t.templateID !== variables.templateId
-              ),
-            }
-          }
-        )
       },
-      onError: (error, _variables) => {
+      onError: (error) => {
         const templateName = template.aliases[0] || template.templateID
         toast(
           defaultErrorToast(
@@ -168,12 +117,7 @@ export function ActionsCell({
       },
       onSettled: () => {
         setIsDeleteDialogOpen(false)
-
-        queryClient.invalidateQueries({
-          queryKey: trpc.templates.getTemplates.queryKey({
-            teamSlug,
-          }),
-        })
+        queryClient.invalidateQueries({ queryKey: templatesListKey })
       },
     })
   )

--- a/src/features/dashboard/templates/list/table-cells.tsx
+++ b/src/features/dashboard/templates/list/table-cells.tsx
@@ -330,6 +330,17 @@ export function MemoryCell({
   )
 }
 
+export function StorageCell({
+  row,
+}: CellContext<Template | DefaultTemplate, unknown>) {
+  const diskSizeMB = row.getValue('diskSizeMB') as number
+  return (
+    <div className="w-full flex justify-end">
+      <ResourceUsage type="disk" total={diskSizeMB / 1024} mode="simple" />
+    </div>
+  )
+}
+
 export function CreatedAtCell({
   getValue,
 }: CellContext<Template | DefaultTemplate, unknown>) {

--- a/src/features/dashboard/templates/list/table-cells.tsx
+++ b/src/features/dashboard/templates/list/table-cells.tsx
@@ -330,17 +330,6 @@ export function MemoryCell({
   )
 }
 
-export function StorageCell({
-  row,
-}: CellContext<Template | DefaultTemplate, unknown>) {
-  const diskSizeMB = row.getValue('diskSizeMB') as number
-  return (
-    <div className="w-full flex justify-end">
-      <ResourceUsage type="disk" total={diskSizeMB / 1024} mode="simple" />
-    </div>
-  )
-}
-
 export function CreatedAtCell({
   getValue,
 }: CellContext<Template | DefaultTemplate, unknown>) {

--- a/src/features/dashboard/templates/list/table-config.tsx
+++ b/src/features/dashboard/templates/list/table-config.tsx
@@ -14,7 +14,6 @@ import {
   CreatedAtCell,
   EnvdVersionCell,
   MemoryCell,
-  StorageCell,
   TemplateIdCell,
   TemplateNameCell,
   UpdatedAtCell,
@@ -70,14 +69,6 @@ export const useColumns = (deps: unknown[]) => {
         size: 80,
         enableResizing: false,
         cell: MemoryCell,
-        enableSorting: false,
-      },
-      {
-        accessorKey: 'diskSizeMB',
-        header: 'Storage',
-        size: 80,
-        enableResizing: false,
-        cell: StorageCell,
         enableSorting: false,
       },
       {

--- a/src/features/dashboard/templates/list/table-config.tsx
+++ b/src/features/dashboard/templates/list/table-config.tsx
@@ -45,6 +45,7 @@ export const useColumns = (deps: unknown[]) => {
         minSize: 140,
         maxSize: 400,
         enableResizing: true,
+        enableSorting: false,
         cell: TemplateNameCell,
       },
       {

--- a/src/features/dashboard/templates/list/table-config.tsx
+++ b/src/features/dashboard/templates/list/table-config.tsx
@@ -1,12 +1,8 @@
 'use client'
 
-import { rankItem } from '@tanstack/match-sorter-utils'
 import {
   type ColumnDef,
-  type FilterFn,
   getCoreRowModel,
-  getFilteredRowModel,
-  getSortedRowModel,
   type TableOptions,
 } from '@tanstack/react-table'
 import posthog from 'posthog-js'
@@ -23,33 +19,6 @@ import {
   UpdatedAtCell,
   VisibilityCell,
 } from './table-cells'
-
-// FILTERS
-export const fuzzyFilter: FilterFn<unknown> = (
-  row,
-  columnId,
-  value,
-  addMeta
-) => {
-  // Skip undefined values
-  if (!value || !value.length) return true
-
-  const searchValue = value.toLowerCase()
-  const rowValue = row.getValue(columnId)
-
-  // Handle null/undefined row values
-  if (rowValue == null) return false
-
-  // Convert row value to string and lowercase for comparison
-  const itemStr = String(rowValue).toLowerCase()
-  const itemRank = rankItem(itemStr, searchValue)
-
-  addMeta({
-    itemRank,
-  })
-
-  return itemRank.passed
-}
 
 // TABLE CONFIG
 export const fallbackData: (Template | DefaultTemplate)[] = []
@@ -82,6 +51,7 @@ export const useColumns = (deps: unknown[]) => {
         header: 'ID',
         size: 156,
         enableResizing: false,
+        enableSorting: false,
         cell: TemplateIdCell,
       },
       {
@@ -161,18 +131,14 @@ export const useColumns = (deps: unknown[]) => {
 export const templatesTableConfig: Partial<
   TableOptions<Template | DefaultTemplate>
 > = {
-  filterFns: {
-    fuzzy: fuzzyFilter,
-  },
   getCoreRowModel: getCoreRowModel(),
-  getFilteredRowModel: getFilteredRowModel(),
-  getSortedRowModel: getSortedRowModel(),
+  // Sorting, filtering, and search are performed server-side; the table is a
+  // pure renderer over the rows returned by the paginated query.
+  manualSorting: true,
+  manualFiltering: true,
   enableSorting: true,
   enableMultiSort: false,
   enableSortingRemoval: false,
   columnResizeMode: 'onChange',
   enableColumnResizing: true,
-  enableGlobalFilter: true,
-  // @ts-expect-error globalFilterFn is not a valid option
-  globalFilterFn: 'fuzzy',
 }

--- a/src/features/dashboard/templates/list/table-config.tsx
+++ b/src/features/dashboard/templates/list/table-config.tsx
@@ -62,7 +62,7 @@ export const useColumns = (deps: unknown[]) => {
         enableResizing: false,
         cell: CpuCell,
         filterFn: 'equals',
-        sortDescFirst: true,
+        enableSorting: false,
       },
       {
         accessorKey: 'memoryMB',
@@ -71,7 +71,7 @@ export const useColumns = (deps: unknown[]) => {
         enableResizing: false,
         cell: MemoryCell,
         filterFn: 'equals',
-        sortDescFirst: true,
+        enableSorting: false,
       },
       {
         accessorKey: 'diskSizeMB',

--- a/src/features/dashboard/templates/list/table-config.tsx
+++ b/src/features/dashboard/templates/list/table-config.tsx
@@ -61,7 +61,6 @@ export const useColumns = (deps: unknown[]) => {
         size: 64,
         enableResizing: false,
         cell: CpuCell,
-        filterFn: 'equals',
         enableSorting: false,
       },
       {
@@ -70,7 +69,6 @@ export const useColumns = (deps: unknown[]) => {
         size: 80,
         enableResizing: false,
         cell: MemoryCell,
-        filterFn: 'equals',
         enableSorting: false,
       },
       {

--- a/src/features/dashboard/templates/list/table-config.tsx
+++ b/src/features/dashboard/templates/list/table-config.tsx
@@ -14,6 +14,7 @@ import {
   CreatedAtCell,
   EnvdVersionCell,
   MemoryCell,
+  StorageCell,
   TemplateIdCell,
   TemplateNameCell,
   UpdatedAtCell,
@@ -71,6 +72,14 @@ export const useColumns = (deps: unknown[]) => {
         cell: MemoryCell,
         filterFn: 'equals',
         sortDescFirst: true,
+      },
+      {
+        accessorKey: 'diskSizeMB',
+        header: 'Storage',
+        size: 80,
+        enableResizing: false,
+        cell: StorageCell,
+        enableSorting: false,
       },
       {
         accessorKey: 'createdAt',

--- a/src/features/dashboard/templates/list/table-filters.tsx
+++ b/src/features/dashboard/templates/list/table-filters.tsx
@@ -23,8 +23,9 @@ import { Separator } from '@/ui/primitives/separator'
 import { TableFilterButton } from '@/ui/table-filter-button'
 import { useTemplateTableStore } from './stores/table-store'
 
-// Components
-const ResourcesFilter = () => {
+// Currently unused on the templates page (server-side resource filtering was
+// dropped from the dropdown); kept exported for reuse on the builds page.
+export const ResourcesFilter = () => {
   const { cpuCount, setCpuCount, memoryMB, setMemoryMB } =
     useTemplateTableStore()
 
@@ -132,15 +133,9 @@ const TemplatesTableFilters = React.forwardRef<
   TemplatesTableFiltersProps
 >(({ className, ...props }, ref) => {
   const {
-    globalFilter,
-    cpuCount,
-    memoryMB,
     isPublic,
     createdAfter,
     createdBefore,
-    setGlobalFilter,
-    setCpuCount,
-    setMemoryMB,
     setIsPublic,
     setCreatedAfter,
     setCreatedBefore,
@@ -161,14 +156,6 @@ const TemplatesTableFilters = React.forwardRef<
         <DropdownMenuContent>
           <DropdownMenuGroup>
             <DropdownMenuLabel>Filters</DropdownMenuLabel>
-            <DropdownMenuSub>
-              <DropdownMenuSubTrigger>Resources</DropdownMenuSubTrigger>
-              <DropdownMenuPortal>
-                <DropdownMenuSubContent>
-                  <ResourcesFilter />
-                </DropdownMenuSubContent>
-              </DropdownMenuPortal>
-            </DropdownMenuSub>
             <DropdownMenuSub>
               <DropdownMenuSubTrigger>Visibility</DropdownMenuSubTrigger>
               <DropdownMenuPortal>
@@ -207,20 +194,6 @@ const TemplatesTableFilters = React.forwardRef<
       </DropdownMenu>
 
       {/* Filter Pills */}
-      {cpuCount && (
-        <TableFilterButton
-          label="CPU"
-          value={`${cpuCount} cores`}
-          onClick={() => setCpuCount(undefined)}
-        />
-      )}
-      {memoryMB && (
-        <TableFilterButton
-          label="Memory"
-          value={`${memoryMB} MB`}
-          onClick={() => setMemoryMB(undefined)}
-        />
-      )}
       {isPublic !== undefined && (
         <TableFilterButton
           label="Visibility"

--- a/src/features/dashboard/templates/list/table.tsx
+++ b/src/features/dashboard/templates/list/table.tsx
@@ -42,7 +42,6 @@ import { TemplatesTableBody as TableBody } from './table-body'
 import { fallbackData, templatesTableConfig, useColumns } from './table-config'
 
 const COLUMN_TO_SORT_BASE: Record<string, string> = {
-  name: 'name',
   createdAt: 'created_at',
   updatedAt: 'updated_at',
 }

--- a/src/features/dashboard/templates/list/table.tsx
+++ b/src/features/dashboard/templates/list/table.tsx
@@ -55,7 +55,7 @@ export default function TemplatesTable() {
 
   const { sorting, setSorting, globalFilter, setGlobalFilter } =
     useTemplateTableStore()
-  const { cpuCount, memoryMB, isPublic } = useTemplateTableStore()
+  const { isPublic } = useTemplateTableStore()
 
   // Persisted state (URL hash) may still reference columns that are no longer sortable.
   const activeSorting = useMemo(
@@ -85,8 +85,6 @@ export default function TemplatesTable() {
       {
         teamSlug,
         limit: TEMPLATES_PAGE_SIZE,
-        cpuCount,
-        memoryMB,
         public: isPublic,
         search: globalFilter || undefined,
         sort,
@@ -107,8 +105,6 @@ export default function TemplatesTable() {
   const { isRefetching, clearRefetching } = useTemplatesRefetchTracking(
     sort,
     globalFilter,
-    cpuCount,
-    memoryMB,
     isPublic
   )
 
@@ -155,7 +151,7 @@ export default function TemplatesTable() {
       scrollRef.current.scrollTop = 0
       scrollRef.current.scrollLeft = 0
     }
-  }, [sort, globalFilter, cpuCount, memoryMB, isPublic])
+  }, [sort, globalFilter, isPublic])
 
   if (templatesError) {
     return (
@@ -243,8 +239,6 @@ export default function TemplatesTable() {
 function useTemplatesRefetchTracking(
   sort: string,
   globalFilter: string,
-  cpuCount: number | undefined,
-  memoryMB: number | undefined,
   isPublic: boolean | undefined
 ) {
   const [isRefetching, setIsRefetching] = useState(false)
@@ -257,7 +251,7 @@ function useTemplatesRefetchTracking(
       return
     }
     setIsRefetching(true)
-  }, [sort, globalFilter, cpuCount, memoryMB, isPublic])
+  }, [sort, globalFilter, isPublic])
 
   const clearRefetching = useCallback(() => setIsRefetching(false), [])
 

--- a/src/features/dashboard/templates/list/table.tsx
+++ b/src/features/dashboard/templates/list/table.tsx
@@ -193,9 +193,7 @@ export default function TemplatesTable() {
                       activeSorting.find((s) => s.id === header.id)?.desc
                     }
                     align={
-                      header.id === 'cpuCount' ||
-                      header.id === 'memoryMB' ||
-                      header.id === 'diskSizeMB'
+                      header.id === 'cpuCount' || header.id === 'memoryMB'
                         ? 'right'
                         : 'left'
                     }

--- a/src/features/dashboard/templates/list/table.tsx
+++ b/src/features/dashboard/templates/list/table.tsx
@@ -43,8 +43,6 @@ import { fallbackData, templatesTableConfig, useColumns } from './table-config'
 
 const COLUMN_TO_SORT_BASE: Record<string, string> = {
   name: 'name',
-  cpuCount: 'cpu_count',
-  memoryMB: 'memory_mb',
   createdAt: 'created_at',
   updatedAt: 'updated_at',
 }
@@ -59,8 +57,14 @@ export default function TemplatesTable() {
     useTemplateTableStore()
   const { cpuCount, memoryMB, isPublic } = useTemplateTableStore()
 
+  // Persisted state (URL hash) may still reference columns that are no longer sortable.
+  const activeSorting = useMemo(
+    () => sorting.filter((s) => s.id in COLUMN_TO_SORT_BASE),
+    [sorting]
+  )
+
   // Derive the single server sort token from the active sort column + direction.
-  const sortColumn = sorting[0]
+  const sortColumn = activeSorting[0]
   const sortBase =
     (sortColumn && COLUMN_TO_SORT_BASE[sortColumn.id]) ??
     TEMPLATES_DEFAULT_SORT_BASE
@@ -135,7 +139,7 @@ export default function TemplatesTable() {
     columns: columns ?? fallbackData,
     state: {
       globalFilter,
-      sorting,
+      sorting: activeSorting,
       columnSizing,
     },
     onGlobalFilterChange: setGlobalFilter,
@@ -190,7 +194,9 @@ export default function TemplatesTable() {
                   <DataTableHead
                     key={header.id}
                     header={header}
-                    sorting={sorting.find((s) => s.id === header.id)?.desc}
+                    sorting={
+                      activeSorting.find((s) => s.id === header.id)?.desc
+                    }
                     align={
                       header.id === 'cpuCount' ||
                       header.id === 'memoryMB' ||

--- a/src/features/dashboard/templates/list/table.tsx
+++ b/src/features/dashboard/templates/list/table.tsx
@@ -1,16 +1,22 @@
 'use client'
 
-import { useSuspenseQuery } from '@tanstack/react-query'
 import {
-  type ColumnFiltersState,
+  keepPreviousData,
+  useSuspenseInfiniteQuery,
+} from '@tanstack/react-query'
+import {
   type ColumnSizingState,
   flexRender,
   type TableOptions,
   useReactTable,
 } from '@tanstack/react-table'
-import { useEffect, useMemo, useRef, useState } from 'react'
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { useLocalStorage } from 'usehooks-ts'
-import type { Template } from '@/core/modules/templates/models'
+import type {
+  DefaultTemplate,
+  Template,
+  TemplatesSort,
+} from '@/core/modules/templates/models'
 import { useColumnSizeVars } from '@/lib/hooks/use-column-size-vars'
 import { useRouteParams } from '@/lib/hooks/use-route-params'
 import { cn } from '@/lib/utils'
@@ -25,10 +31,23 @@ import {
 import ErrorBoundary from '@/ui/error'
 import HelpTooltip from '@/ui/help-tooltip'
 import { SIDEBAR_TRANSITION_CLASSNAMES } from '@/ui/primitives/sidebar'
+import {
+  TEMPLATES_DEFAULT_SORT_BASE,
+  TEMPLATES_DEFAULT_SORT_DESC,
+  TEMPLATES_PAGE_SIZE,
+} from './constants'
 import TemplatesHeader from './header'
 import { useTemplateTableStore } from './stores/table-store'
 import { TemplatesTableBody as TableBody } from './table-body'
 import { fallbackData, templatesTableConfig, useColumns } from './table-config'
+
+const COLUMN_TO_SORT_BASE: Record<string, string> = {
+  name: 'name',
+  cpuCount: 'cpu_count',
+  memoryMB: 'memory_mb',
+  createdAt: 'created_at',
+  updatedAt: 'updated_at',
+}
 
 export default function TemplatesTable() {
   'use no memo'
@@ -36,41 +55,68 @@ export default function TemplatesTable() {
   const trpc = useTRPC()
   const { teamSlug } = useRouteParams<'/dashboard/[teamSlug]/templates'>()
 
-  const { data: templatesData, error: templatesError } = useSuspenseQuery(
-    trpc.templates.getTemplates.queryOptions(
-      { teamSlug },
+  const { sorting, setSorting, globalFilter, setGlobalFilter } =
+    useTemplateTableStore()
+  const { cpuCount, memoryMB, isPublic } = useTemplateTableStore()
+
+  // Derive the single server sort token from the active sort column + direction.
+  const sortColumn = sorting[0]
+  const sortBase =
+    (sortColumn && COLUMN_TO_SORT_BASE[sortColumn.id]) ??
+    TEMPLATES_DEFAULT_SORT_BASE
+  const isDesc = sortColumn
+    ? sortColumn.desc !== false
+    : TEMPLATES_DEFAULT_SORT_DESC
+  const sort = `${sortBase}_${isDesc ? 'desc' : 'asc'}` as TemplatesSort
+
+  const {
+    data,
+    error: templatesError,
+    fetchNextPage,
+    hasNextPage,
+    isFetchingNextPage,
+    isFetching,
+  } = useSuspenseInfiniteQuery(
+    trpc.templates.getTemplates.infiniteQueryOptions(
       {
-        refetchOnMount: false,
-        refetchOnWindowFocus: false,
-        refetchOnReconnect: false,
+        teamSlug,
+        limit: TEMPLATES_PAGE_SIZE,
+        cpuCount,
+        memoryMB,
+        public: isPublic,
+        search: globalFilter || undefined,
+        sort,
+      },
+      {
+        getNextPageParam: (lastPage) => lastPage.nextCursor ?? undefined,
+        initialCursor: undefined,
+        placeholderData: keepPreviousData,
       }
     )
   )
 
-  const { data: defaultTemplatesData } = useSuspenseQuery(
-    trpc.templates.getDefaultTemplatesCached.queryOptions(undefined, {
-      refetchOnMount: false,
-      refetchOnWindowFocus: false,
-      refetchOnReconnect: false,
-    })
+  const templates = useMemo<Array<Template | DefaultTemplate>>(
+    () => data?.pages.flatMap((page) => page.data) ?? [],
+    [data]
   )
 
-  const templates = useMemo(
-    () => [
-      ...(defaultTemplatesData?.templates ?? []),
-      ...(templatesData?.templates ?? []),
-    ],
-    [templatesData, defaultTemplatesData]
+  const { isRefetching, clearRefetching } = useTemplatesRefetchTracking(
+    sort,
+    globalFilter,
+    cpuCount,
+    memoryMB,
+    isPublic
   )
+
+  useEffect(() => {
+    if (!isFetching && isRefetching) {
+      clearRefetching()
+    }
+  }, [isFetching, isRefetching, clearRefetching])
+
+  const isListDimmed = isRefetching && templates.length > 0
 
   const scrollRef = useRef<HTMLDivElement>(null)
-
-  const { sorting, setSorting, globalFilter, setGlobalFilter } =
-    useTemplateTableStore()
-
-  const { cpuCount, memoryMB, isPublic } = useTemplateTableStore()
-
-  const [columnFilters, setColumnFilters] = useState<ColumnFiltersState>([])
 
   const [columnSizing, setColumnSizing] = useLocalStorage<ColumnSizingState>(
     'templates:columnSizing:v3',
@@ -80,37 +126,6 @@ export default function TemplatesTable() {
       serializer: (value) => JSON.stringify(value),
     }
   )
-
-  // Effect hooks for filters
-  useEffect(() => {
-    let newFilters = [...columnFilters]
-
-    // Handle CPU filter
-    if (!cpuCount) {
-      newFilters = newFilters.filter((f) => f.id !== 'cpuCount')
-    } else {
-      newFilters = newFilters.filter((f) => f.id !== 'cpuCount')
-      newFilters.push({ id: 'cpuCount', value: cpuCount })
-    }
-
-    // Handle memory filter
-    if (!memoryMB) {
-      newFilters = newFilters.filter((f) => f.id !== 'memoryMB')
-    } else {
-      newFilters = newFilters.filter((f) => f.id !== 'memoryMB')
-      newFilters.push({ id: 'memoryMB', value: memoryMB })
-    }
-
-    // Handle public filter
-    if (isPublic === undefined) {
-      newFilters = newFilters.filter((f) => f.id !== 'public')
-    } else {
-      newFilters = newFilters.filter((f) => f.id !== 'public')
-      newFilters.push({ id: 'public', value: isPublic })
-    }
-
-    setColumnFilters(newFilters)
-  }, [cpuCount, memoryMB, isPublic])
 
   const columns = useColumns([])
 
@@ -122,27 +137,21 @@ export default function TemplatesTable() {
       globalFilter,
       sorting,
       columnSizing,
-      columnFilters,
     },
     onGlobalFilterChange: setGlobalFilter,
     onSortingChange: setSorting,
     onColumnSizingChange: setColumnSizing,
-    onColumnFiltersChange: setColumnFilters,
   } as TableOptions<Template>)
 
   const columnSizeVars = useColumnSizeVars(table)
 
-  const resetScroll = () => {
+  // biome-ignore lint/correctness/useExhaustiveDependencies: scroll reset is triggered by query-input changes
+  useEffect(() => {
     if (scrollRef.current) {
       scrollRef.current.scrollTop = 0
       scrollRef.current.scrollLeft = 0
     }
-  }
-
-  // Add effect hook for scrolling to top when sorting or global filter changes
-  useEffect(() => {
-    resetScroll()
-  }, [sorting, globalFilter])
+  }, [sort, globalFilter, cpuCount, memoryMB, isPublic])
 
   if (templatesError) {
     return (
@@ -212,9 +221,37 @@ export default function TemplatesTable() {
             templates={templates}
             table={table}
             scrollRef={scrollRef}
+            hasNextPage={hasNextPage}
+            isFetchingNextPage={isFetchingNextPage}
+            fetchNextPage={fetchNextPage}
+            isRefetching={isListDimmed}
           />
         </DataTable>
       </div>
     </ClientOnly>
   )
+}
+
+function useTemplatesRefetchTracking(
+  sort: string,
+  globalFilter: string,
+  cpuCount: number | undefined,
+  memoryMB: number | undefined,
+  isPublic: boolean | undefined
+) {
+  const [isRefetching, setIsRefetching] = useState(false)
+  const isFirstRender = useRef(true)
+
+  // biome-ignore lint/correctness/useExhaustiveDependencies: these are change triggers, not values read in the effect
+  useEffect(() => {
+    if (isFirstRender.current) {
+      isFirstRender.current = false
+      return
+    }
+    setIsRefetching(true)
+  }, [sort, globalFilter, cpuCount, memoryMB, isPublic])
+
+  const clearRefetching = useCallback(() => setIsRefetching(false), [])
+
+  return { isRefetching, clearRefetching }
 }

--- a/src/features/dashboard/templates/list/table.tsx
+++ b/src/features/dashboard/templates/list/table.tsx
@@ -192,7 +192,9 @@ export default function TemplatesTable() {
                     header={header}
                     sorting={sorting.find((s) => s.id === header.id)?.desc}
                     align={
-                      header.id === 'cpuCount' || header.id === 'memoryMB'
+                      header.id === 'cpuCount' ||
+                      header.id === 'memoryMB' ||
+                      header.id === 'diskSizeMB'
                         ? 'right'
                         : 'left'
                     }

--- a/src/ui/pagination-buttons.tsx
+++ b/src/ui/pagination-buttons.tsx
@@ -1,0 +1,41 @@
+'use client'
+
+import { Loader } from '@/ui/primitives/loader'
+
+export function LoadMoreButton({
+  isLoading,
+  onLoadMore,
+}: {
+  isLoading: boolean
+  onLoadMore: () => void
+}) {
+  if (isLoading) {
+    return (
+      <span className="inline-flex items-center gap-1">
+        Loading
+        <Loader variant="dots" />
+      </span>
+    )
+  }
+  return (
+    <button
+      type="button"
+      onClick={onLoadMore}
+      className="underline text-fg-secondary hover:text-accent-main-highlight transition-colors"
+    >
+      Load more
+    </button>
+  )
+}
+
+export function BackToTopButton({ onBackToTop }: { onBackToTop: () => void }) {
+  return (
+    <button
+      type="button"
+      onClick={onBackToTop}
+      className="underline text-fg-secondary hover:text-accent-main-highlight transition-colors"
+    >
+      Back to top
+    </button>
+  )
+}


### PR DESCRIPTION
## Summary
Re-lands #352 (previously reverted in deca10d0) with follow-ups. The templates list is now paginated server-side (keyset cursor) instead of fetching everything and sorting/filtering in memory.

## Changes
- Templates list uses cursor pagination: first page prefetched on the server, more rows via "Load more"; search and visibility filter are handled server-side.
- Sorting is limited to Created and Updated — name/CPU/memory sorting dropped. Default sort is now `updated_at_desc` (recently built templates shown at the top)
- Removed the CPU/memory resource filter (was in-memory only, not supported by the backend).
- Old URLs with removed sort/filter state fall back to defaults.