### PR TITLE
fix: shared UI tweaks

### DIFF
--- a/src/lib/utils/ui.ts
+++ b/src/lib/utils/ui.ts
@@ -7,7 +7,9 @@ export function cn(...inputs: ClassValue[]) {
 
 /**
  * Animation easing curves
- * ⚠️ Must be kept in sync with theme.css utilities (anim-ease-appear, anim-ease-transform)
+ * ⚠️ Must be kept in sync with theme.css `--ease-*` tokens.
  */
 export const EASE_APPEAR = [0.23, 1, 0.32, 1] as const // ease-out-quint
 export const EASE_TRANSFORM = [0.79, 0.14, 0.15, 0.86] as const // ease-in-out-circ
+export const EASE_IN_OUT_QUART = [0.77, 0, 0.18, 1] as const // ease-in-out-quart
+export const EASE_IN_OUT_QUINT = [0.83, 0, 0.17, 1] as const // ease-in-out-quint

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -10,6 +10,10 @@
   border-radius: 2px;
 }
 
+html {
+  caret-color: var(--accent-main-highlight);
+}
+
 *::selection {
   background-color: var(--accent-main-bg);
 }

--- a/src/styles/theme.css
+++ b/src/styles/theme.css
@@ -12,16 +12,23 @@
     @apply bg-bg text-fg prose-body antialiased;
   }
 
+  /* Inline heading styles to allow utility overrides. */
   h1,
   h2,
   h3 {
-    @apply prose-headline uppercase;
+    font-size: 1.25rem;
+    line-height: 1.25rem;
+    font-weight: 700;
+    text-transform: uppercase;
   }
 
   h4,
   h5,
   h6 {
-    @apply prose-headline-small uppercase;
+    font-size: 1rem;
+    line-height: 1.25rem;
+    font-weight: 700;
+    text-transform: uppercase;
   }
 
   .font-mono {
@@ -480,6 +487,10 @@
   --animate-shiny-text: shiny-text 0.5s linear infinite;
   --animate-loader-slash: loader-slash 0.4s linear infinite;
   --animate-loader-square: loader-square 0.4s linear infinite;
+
+  /* Easings (kept in sync with src/lib/utils/ui.ts) */
+  --ease-out-quint: cubic-bezier(0.23, 1, 0.32, 1);
+  --ease-in-out-quint: cubic-bezier(0.83, 0, 0.17, 1);
 }
 
 /* Container */

--- a/src/ui/copy-button-inline.tsx
+++ b/src/ui/copy-button-inline.tsx
@@ -10,12 +10,14 @@ export default function CopyButtonInline({
   children,
   className,
   iconPosition = 'right',
+  truncate = true,
   'aria-label': ariaLabel,
 }: {
   value: string
   children: React.ReactNode
   className?: string
   iconPosition?: 'left' | 'right'
+  truncate?: boolean
   'aria-label'?: string
 }) {
   const [wasCopied, copy] = useClipboard(1000)
@@ -72,7 +74,9 @@ export default function CopyButtonInline({
       )}
     >
       {iconPosition === 'left' && icon}
-      <span className="truncate">{children}</span>
+      <span className={truncate ? 'truncate' : 'whitespace-nowrap'}>
+        {children}
+      </span>
       {iconPosition === 'right' && icon}
     </button>
   )

--- a/src/ui/hover-prefetch-link.tsx
+++ b/src/ui/hover-prefetch-link.tsx
@@ -1,11 +1,16 @@
 'use client'
 
-import Link, { type LinkProps } from 'next/link'
-import { forwardRef, useState } from 'react'
+import Link from 'next/link'
+import { type ComponentPropsWithoutRef, forwardRef, useState } from 'react'
+
+type HoverPrefetchLinkProps = Omit<
+  ComponentPropsWithoutRef<typeof Link>,
+  'prefetch' | 'onMouseEnter'
+>
 
 export const HoverPrefetchLink = forwardRef<
   HTMLAnchorElement,
-  Omit<LinkProps, 'prefetch' | 'onMouseEnter'> & { children: React.ReactNode }
+  HoverPrefetchLinkProps
 >(function HoverPrefetchLink({ href, children, ...props }, ref) {
   const [active, setActive] = useState(false)
 

--- a/src/ui/primitives/button.tsx
+++ b/src/ui/primitives/button.tsx
@@ -72,6 +72,7 @@ const buttonVariants = cva(
       size: {
         default:
           '[&_svg]:size-4 h-9 py-1.5 gap-1 [&:has(svg)]:pr-3 [&:has(svg)]:pl-2.5 px-4',
+        small: 'h-7 py-1.5 gap-1 [&_svg]:size-4 px-2.5',
         none: 'gap-1 [&_svg]:size-4',
       },
     },

--- a/src/ui/primitives/dialog.tsx
+++ b/src/ui/primitives/dialog.tsx
@@ -72,7 +72,7 @@ function DialogContent({
             'bg-bg-1 text-body text-fg-secondary',
             'fixed top-[50%] left-[50%] translate-x-[-50%] translate-y-[-50%]',
             'z-50 grid w-[calc(100%-2rem)] max-h-[calc(100svh-2rem)] overflow-y-auto sm:w-full sm:max-w-lg',
-            'gap-3 border p-5 pt-4 focus:ring-0 focus:outline-none',
+            'gap-3 border px-5 py-4 focus:ring-0 focus:outline-none',
             'data-[state=open]:animate-in data-[state=closed]:animate-out',
             'anim-ease-appear anim-duration-normal', // exit animation is faster
             'data-[state=open]:anim-duration-slow',
@@ -88,8 +88,8 @@ function DialogContent({
           <DialogPrimitive.Close
             className={cn(
               [
-                'absolute top-4 right-4',
-                'text-icon-tertiary transition-colors hover:text-icon',
+                'absolute top-[18px] right-[20px]',
+                'text-icon-tertiary transition-colors hover:text-icon cursor-pointer',
                 'outline-none focus-visible:ring-1 focus-visible:ring-accent-main-highlight',
                 'disabled:pointer-events-none',
                 "[&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
@@ -135,7 +135,7 @@ function DialogTitle({
   return (
     <DialogPrimitive.Title
       data-slot="dialog-title"
-      className={cn('text-headline-small! uppercase', className)}
+      className={cn('prose-headline-small! uppercase', className)}
       {...props}
     />
   )


### PR DESCRIPTION
### Changes
- **dialog**: paddings, close-button position, title style (`prose-headline-small`)
- **theme**: inline `h1`–`h6` styles so utilities can override (fixes dialog title clashing with heading styles) + easing tokens
- **globals**: `caret-color` → accent
- **ui utils**: `EASE_IN_OUT_QUART` / `EASE_IN_OUT_QUINT` constants
- **button**: add `small` size variant
- **copy-button-inline**: add optional `truncate` prop
- **hover-prefetch-link**: accept full anchor props instead of bare `LinkProps`