### PR TITLE
feat: make templates list build-agnostic, move resources to builds

### DIFF
--- a/src/core/modules/builds/models.ts
+++ b/src/core/modules/builds/models.ts
@@ -31,6 +31,10 @@ export interface ListedBuildModel {
   statusMessage: string | null
   createdAt: number
   finishedAt: number | null
+  cpuCount: number
+  memoryMB: number
+  diskSizeMB: number | null
+  envdVersion: string | null
 }
 
 export interface RunningBuildStatusModel {

--- a/src/core/modules/builds/models.ts
+++ b/src/core/modules/builds/models.ts
@@ -22,6 +22,7 @@ type _BuildStatusExhaustiveCheck = AssertTrue<
 // TypeCheck: End
 
 export const BuildStatusSchema = z.enum(BUILD_STATUS_VALUES)
+
 export interface ListedBuildModel {
   id: string
   // id or alias

--- a/src/core/modules/builds/repository.server.ts
+++ b/src/core/modules/builds/repository.server.ts
@@ -149,6 +149,10 @@ export function createBuildsRepository(
             finishedAt: build.finishedAt
               ? new Date(build.finishedAt).getTime()
               : null,
+            cpuCount: build.cpuCount,
+            memoryMB: build.memoryMB,
+            diskSizeMB: build.diskSizeMB,
+            envdVersion: build.envdVersion,
           })
         ),
         nextCursor: result.data?.nextCursor ?? null,

--- a/src/features/dashboard/common/envd-version.tsx
+++ b/src/features/dashboard/common/envd-version.tsx
@@ -1,0 +1,39 @@
+import { cn } from '@/lib/utils'
+import { isVersionCompatible } from '@/lib/utils/version'
+import HelpTooltip from '@/ui/help-tooltip'
+
+const INVALID_ENVD_VERSION = '0.0.1'
+const SDK_V2_MINIMAL_ENVD_VERSION = '0.2.0'
+
+export function EnvdVersion({
+  version,
+  className,
+}: {
+  version: string | null | undefined
+  className?: string
+}) {
+  const versionValue =
+    version && version !== INVALID_ENVD_VERSION ? version : null
+
+  const isNotV2Compatible = versionValue
+    ? isVersionCompatible(versionValue, SDK_V2_MINIMAL_ENVD_VERSION) === false
+    : false
+
+  return (
+    <div
+      className={cn(
+        'text-fg-tertiary whitespace-nowrap font-mono flex flex-row gap-1.5',
+        { 'text-accent-error-highlight': isNotV2Compatible },
+        className
+      )}
+    >
+      {versionValue ?? '--'}
+      {isNotV2Compatible && (
+        <HelpTooltip>
+          The envd version is not compatible with the SDK v2. To update the envd
+          version, you need to rebuild the template.
+        </HelpTooltip>
+      )}
+    </div>
+  )
+}

--- a/src/features/dashboard/templates/builds/header.tsx
+++ b/src/features/dashboard/templates/builds/header.tsx
@@ -102,7 +102,7 @@ export default function BuildsHeader() {
   }
 
   return (
-    <div className="flex flex-col gap-3">
+    <div className="flex flex-row items-center gap-1">
       <Input
         placeholder="Build ID, Template ID or Name"
         className="w-full max-w-62"

--- a/src/features/dashboard/templates/builds/table-body.tsx
+++ b/src/features/dashboard/templates/builds/table-body.tsx
@@ -1,0 +1,74 @@
+import { flexRender, type Table } from '@tanstack/react-table'
+import type { RefObject } from 'react'
+import type { ListedBuildModel } from '@/core/modules/builds/models'
+import { useVirtualRows } from '@/lib/hooks/use-virtual-rows'
+import { cn } from '@/lib/utils'
+import { DataTableBody, DataTableCell, DataTableRow } from '@/ui/data-table'
+import { isRightAlignedColumn } from './table-config'
+
+const ROW_HEIGHT_PX = 40
+const VIRTUAL_OVERSCAN = 8
+const INITIAL_FALLBACK_ROW_COUNT = 100
+
+interface BuildsTableBodyProps {
+  table: Table<ListedBuildModel>
+  scrollRef: RefObject<HTMLDivElement | null>
+  onRowClick: (build: ListedBuildModel) => void
+}
+
+export function BuildsTableBody({
+  table,
+  scrollRef,
+  onRowClick,
+}: BuildsTableBodyProps) {
+  'use no memo'
+
+  const rows = table.getRowModel().rows
+  const {
+    virtualRows,
+    totalHeight: virtualizedTotalHeight,
+    paddingTop: virtualPaddingTop,
+  } = useVirtualRows<ListedBuildModel>({
+    rows,
+    scrollRef,
+    estimateSizePx: ROW_HEIGHT_PX,
+    overscan: VIRTUAL_OVERSCAN,
+  })
+
+  const renderedRows =
+    virtualRows.length > 0
+      ? virtualRows
+      : rows.slice(0, INITIAL_FALLBACK_ROW_COUNT)
+
+  return (
+    <DataTableBody virtualizedTotalHeight={virtualizedTotalHeight}>
+      {virtualPaddingTop > 0 && <div style={{ height: virtualPaddingTop }} />}
+      {renderedRows.map((row) => {
+        const isBuilding = row.original.status === 'building'
+
+        return (
+          <DataTableRow
+            key={row.id}
+            className={cn('h-10 cursor-pointer hover:bg-bg-hover', {
+              'bg-bg-1 animate-pulse': isBuilding,
+            })}
+            onClick={() => onRowClick(row.original)}
+          >
+            {row.getVisibleCells().map((cell) => (
+              <DataTableCell
+                key={cell.id}
+                cell={cell}
+                className={cn(
+                  'shrink-0',
+                  isRightAlignedColumn(cell.column.id) && 'justify-end'
+                )}
+              >
+                {flexRender(cell.column.columnDef.cell, cell.getContext())}
+              </DataTableCell>
+            ))}
+          </DataTableRow>
+        )
+      })}
+    </DataTableBody>
+  )
+}

--- a/src/features/dashboard/templates/builds/table-cells.tsx
+++ b/src/features/dashboard/templates/builds/table-cells.tsx
@@ -18,7 +18,6 @@ import CopyButtonInline from '@/ui/copy-button-inline'
 import { Badge } from '@/ui/primitives/badge'
 import { Button } from '@/ui/primitives/button'
 import { CheckmarkIcon, CloseIcon } from '@/ui/primitives/icons'
-import { Loader } from '@/ui/primitives/loader'
 import {
   Tooltip,
   TooltipContent,
@@ -31,9 +30,10 @@ export function BuildId({ id }: { id: string }) {
   return (
     <CopyButtonInline
       value={id}
+      truncate={false}
       className="w-full text-left text-fg-tertiary font-mono prose-table-numeric"
     >
-      {id.slice(0, 6)}...{id.slice(-6)}
+      {id.slice(0, 7)}...{id.slice(-5)}
     </CopyButtonInline>
   )
 }
@@ -160,7 +160,7 @@ export function Status({ status, statusMessage }: StatusProps) {
   const showReason = status === 'failed' && Boolean(statusMessage)
 
   return (
-    <div className="flex items-center gap-3 min-w-0">
+    <div className="flex items-center gap-3 min-w-0 shrink-0">
       {showReason ? (
         <Tooltip>
           <TooltipTrigger asChild>{badge}</TooltipTrigger>
@@ -177,7 +177,7 @@ export function Status({ status, statusMessage }: StatusProps) {
 
 export function Cpu({ cpuCount }: { cpuCount: number }) {
   return (
-    <div className="w-full flex justify-center">
+    <div className="w-full flex justify-end">
       <ResourceUsage type="cpu" total={cpuCount} mode="simple" />
     </div>
   )

--- a/src/features/dashboard/templates/builds/table-cells.tsx
+++ b/src/features/dashboard/templates/builds/table-cells.tsx
@@ -164,7 +164,12 @@ export function Status({ status, statusMessage }: StatusProps) {
       {showReason ? (
         <Tooltip>
           <TooltipTrigger asChild>{badge}</TooltipTrigger>
-          <TooltipContent className="max-w-[360px] whitespace-pre-wrap break-words text-left font-mono text-xs normal-case text-fg-secondary">
+          <TooltipContent
+            align="start"
+            side="top"
+            sideOffset={8}
+            className="max-w-[360px] whitespace-pre-wrap break-words text-left font-mono text-xs normal-case text-fg-secondary"
+          >
             {statusMessage}
           </TooltipContent>
         </Tooltip>

--- a/src/features/dashboard/templates/builds/table-cells.tsx
+++ b/src/features/dashboard/templates/builds/table-cells.tsx
@@ -19,6 +19,13 @@ import { Badge } from '@/ui/primitives/badge'
 import { Button } from '@/ui/primitives/button'
 import { CheckmarkIcon, CloseIcon } from '@/ui/primitives/icons'
 import { Loader } from '@/ui/primitives/loader'
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from '@/ui/primitives/tooltip'
+import { EnvdVersion } from '../../common/envd-version'
+import ResourceUsage from '../../common/resource-usage'
 
 export function BuildId({ id }: { id: string }) {
   return (
@@ -107,9 +114,10 @@ export function StartedAt({ timestamp }: { timestamp: number }) {
 
 interface StatusProps {
   status: BuildStatus
+  statusMessage?: ListedBuildModel['statusMessage']
 }
 
-export function Status({ status }: StatusProps) {
+export function Status({ status, statusMessage }: StatusProps) {
   const config: Record<
     BuildStatus,
     {
@@ -137,31 +145,65 @@ export function Status({ status }: StatusProps) {
 
   const { label, icon, variant } = config[status]!
 
+  const badge = (
+    <Badge
+      variant={variant}
+      className={cn('select-none shrink-0 uppercase', {
+        'bg-bg-inverted/10': variant === 'default',
+      })}
+    >
+      {icon}
+      {label}
+    </Badge>
+  )
+
+  const showReason = status === 'failed' && Boolean(statusMessage)
+
   return (
     <div className="flex items-center gap-3 min-w-0">
-      <Badge
-        variant={variant}
-        className={cn('select-none shrink-0 uppercase', {
-          'bg-bg-inverted/10': variant === 'default',
-        })}
-      >
-        {icon}
-        {label}
-      </Badge>
+      {showReason ? (
+        <Tooltip>
+          <TooltipTrigger asChild>{badge}</TooltipTrigger>
+          <TooltipContent className="max-w-[360px] whitespace-pre-wrap break-words text-left font-mono text-xs normal-case text-fg-secondary">
+            {statusMessage}
+          </TooltipContent>
+        </Tooltip>
+      ) : (
+        badge
+      )}
     </div>
   )
 }
 
-export function Reason({
-  statusMessage,
-}: {
-  statusMessage: ListedBuildModel['statusMessage']
-}) {
-  if (!statusMessage) return null
-
+export function Cpu({ cpuCount }: { cpuCount: number }) {
   return (
-    <span className="block truncate max-w-0 min-w-full text-left text-fg-tertiary">
-      {statusMessage}
-    </span>
+    <div className="w-full flex justify-center">
+      <ResourceUsage type="cpu" total={cpuCount} mode="simple" />
+    </div>
+  )
+}
+
+export function Memory({ memoryMB }: { memoryMB: number }) {
+  return (
+    <div className="w-full flex justify-end">
+      <ResourceUsage type="mem" total={memoryMB} mode="simple" />
+    </div>
+  )
+}
+
+export function Storage({ diskSizeMB }: { diskSizeMB: number | null }) {
+  const diskSizeGB = diskSizeMB != null ? diskSizeMB / 1024 : null
+  return (
+    <div className="w-full flex justify-end">
+      <ResourceUsage type="disk" total={diskSizeGB} mode="simple" />
+    </div>
+  )
+}
+
+export function Envd({ version }: { version: string | null }) {
+  return (
+    <div className="w-full flex justify-end">
+      <EnvdVersion version={version} />
+    </div>
   )
 }

--- a/src/features/dashboard/templates/builds/table-config.tsx
+++ b/src/features/dashboard/templates/builds/table-config.tsx
@@ -1,0 +1,126 @@
+'use client'
+
+import {
+  type ColumnDef,
+  getCoreRowModel,
+  type TableOptions,
+} from '@tanstack/react-table'
+import type { ListedBuildModel } from '@/core/modules/builds/models'
+import {
+  BuildId,
+  Cpu,
+  Duration,
+  Envd,
+  Memory,
+  StartedAt,
+  Status,
+  Storage,
+  Template,
+} from './table-cells'
+
+export const fallbackData: ListedBuildModel[] = []
+
+const RIGHT_ALIGNED_COLUMNS = new Set([
+  'cpuCount',
+  'memoryMB',
+  'diskSizeMB',
+  'envdVersion',
+  'createdAt',
+  'duration',
+])
+
+export const isRightAlignedColumn = (id: string) =>
+  RIGHT_ALIGNED_COLUMNS.has(id)
+
+export const buildsColumns: ColumnDef<ListedBuildModel>[] = [
+  {
+    accessorKey: 'status',
+    header: 'Status',
+    size: 76,
+    enableResizing: false,
+    cell: ({ row }) => (
+      <Status
+        status={row.original.status}
+        statusMessage={row.original.statusMessage}
+      />
+    ),
+  },
+  {
+    accessorKey: 'template',
+    header: 'Template',
+    size: 240,
+    minSize: 160,
+    maxSize: 480,
+    enableResizing: true,
+    cell: ({ row }) => (
+      <Template
+        template={row.original.template}
+        templateId={row.original.templateId}
+      />
+    ),
+  },
+  {
+    accessorKey: 'id',
+    header: 'ID',
+    size: 128,
+    enableResizing: false,
+    cell: ({ row }) => <BuildId id={row.original.id} />,
+  },
+  {
+    accessorKey: 'cpuCount',
+    header: 'CPU',
+    size: 64,
+    enableResizing: false,
+    cell: ({ row }) => <Cpu cpuCount={row.original.cpuCount} />,
+  },
+  {
+    accessorKey: 'memoryMB',
+    header: 'Memory',
+    size: 80,
+    enableResizing: false,
+    cell: ({ row }) => <Memory memoryMB={row.original.memoryMB} />,
+  },
+  {
+    accessorKey: 'diskSizeMB',
+    header: 'Storage',
+    size: 80,
+    enableResizing: false,
+    cell: ({ row }) => <Storage diskSizeMB={row.original.diskSizeMB} />,
+  },
+  {
+    accessorKey: 'envdVersion',
+    header: 'ENVD Ver.',
+    size: 96,
+    enableResizing: false,
+    cell: ({ row }) => <Envd version={row.original.envdVersion} />,
+  },
+  {
+    accessorKey: 'createdAt',
+    header: 'Started',
+    size: 110,
+    enableResizing: false,
+    cell: ({ row }) => <StartedAt timestamp={row.original.createdAt} />,
+  },
+  {
+    accessorKey: 'duration',
+    header: 'Duration',
+    size: 110,
+    enableResizing: false,
+    cell: ({ row }) => (
+      <div className="w-full text-end">
+        <Duration
+          createdAt={row.original.createdAt}
+          finishedAt={row.original.finishedAt}
+          isBuilding={row.original.status === 'building'}
+        />
+      </div>
+    ),
+  },
+]
+
+export const buildsTableConfig: Partial<TableOptions<ListedBuildModel>> = {
+  getCoreRowModel: getCoreRowModel(),
+  enableSorting: false,
+  columnResizeMode: 'onChange',
+  enableColumnResizing: true,
+}

--- a/src/features/dashboard/templates/builds/table.tsx
+++ b/src/features/dashboard/templates/builds/table.tsx
@@ -6,69 +6,75 @@ import {
   useQuery,
   useQueryClient,
 } from '@tanstack/react-query'
+import {
+  type ColumnSizingState,
+  flexRender,
+  type TableOptions,
+  useReactTable,
+} from '@tanstack/react-table'
 import { useRouter } from 'next/navigation'
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import { useLocalStorage } from 'usehooks-ts'
 import { PROTECTED_URLS } from '@/configs/urls'
 import type {
   ListedBuildModel,
   RunningBuildStatusModel,
 } from '@/core/modules/builds/models'
+import { useColumnSizeVars } from '@/lib/hooks/use-column-size-vars'
 import { useRouteParams } from '@/lib/hooks/use-route-params'
-import { cn } from '@/lib/utils/ui'
+import { cn } from '@/lib/utils'
 import { useTRPC } from '@/trpc/client'
+import {
+  DataTable,
+  DataTableHead,
+  DataTableHeader,
+  DataTableRow,
+} from '@/ui/data-table'
 import { BackToTopButton, LoadMoreButton } from '@/ui/pagination-buttons'
-import { ArrowDownIcon } from '@/ui/primitives/icons'
 import { Loader } from '@/ui/primitives/loader'
-import {
-  Table,
-  TableBody,
-  TableCell,
-  TableHead,
-  TableHeader,
-  TableRow,
-} from '@/ui/primitives/table'
+import { SIDEBAR_TRANSITION_CLASSNAMES } from '@/ui/primitives/sidebar'
 import BuildsEmpty from './empty'
+import { BuildsTableBody } from './table-body'
 import {
-  BuildId,
-  Cpu,
-  Duration,
-  Envd,
-  Memory,
-  StartedAt,
-  Status,
-  Storage,
-  Template,
-} from './table-cells'
+  buildsColumns,
+  buildsTableConfig,
+  fallbackData,
+  isRightAlignedColumn,
+} from './table-config'
 import useFilters from './use-filters'
 
 const BUILDS_REFETCH_INTERVAL_MS = 15_000
 const RUNNING_BUILD_POLL_INTERVAL_MS = 3_000
 const MAX_CACHED_PAGES = 3
 
-const COLUMN_WIDTHS = {
-  id: 152,
-  status: 96,
-  template: 192,
-  cpu: 72,
-  memory: 88,
-  storage: 88,
-  envd: 98,
-  started: 126,
-  duration: 96,
-} as const
-
 const BuildsTable = () => {
+  'use no memo'
+
   const trpc = useTRPC()
   const queryClient = useQueryClient()
   const router = useRouter()
   const scrollContainerRef = useRef<HTMLDivElement>(null)
 
   const { teamSlug } = useRouteParams<'/dashboard/[teamSlug]/templates'>()
+  const [columnSizing, setColumnSizing] = useLocalStorage<ColumnSizingState>(
+    'builds:columnSizing:v1',
+    {},
+    {
+      deserializer: (value) => JSON.parse(value),
+      serializer: (value) => JSON.stringify(value),
+    }
+  )
   const { statuses, buildIdOrTemplate } = useFilters()
   const { isFilterRefetching, clearFilterRefetching } = useFilterChangeTracking(
     statuses,
     buildIdOrTemplate
   )
+
+  const queryInput = {
+    teamSlug,
+    statuses,
+    buildIdOrTemplate,
+  }
 
   // Builds list query
   const {
@@ -80,17 +86,14 @@ const BuildsTable = () => {
     isPending: isInitialLoad,
     error: buildsError,
   } = useInfiniteQuery(
-    trpc.builds.list.infiniteQueryOptions(
-      { teamSlug, statuses, buildIdOrTemplate },
-      {
-        getNextPageParam: (page) => page.nextCursor ?? undefined,
-        placeholderData: keepPreviousData,
-        retry: 3,
-        refetchInterval: BUILDS_REFETCH_INTERVAL_MS,
-        refetchIntervalInBackground: false,
-        maxPages: MAX_CACHED_PAGES,
-      }
-    )
+    trpc.builds.list.infiniteQueryOptions(queryInput, {
+      getNextPageParam: (page) => page.nextCursor ?? undefined,
+      placeholderData: keepPreviousData,
+      retry: 3,
+      refetchInterval: BUILDS_REFETCH_INTERVAL_MS,
+      refetchIntervalInBackground: false,
+      maxPages: MAX_CACHED_PAGES,
+    })
   )
 
   const builds = useMemo(
@@ -136,12 +139,21 @@ const BuildsTable = () => {
     [builds, runningStatusesData]
   )
 
+  const table = useReactTable<ListedBuildModel>({
+    ...buildsTableConfig,
+    data: buildsWithLiveStatus ?? fallbackData,
+    columns: buildsColumns,
+    state: {
+      columnSizing,
+    },
+    onColumnSizingChange: setColumnSizing,
+  } as TableOptions<ListedBuildModel>)
+
+  const columnSizeVars = useColumnSizeVars(table)
+
   // Handlers
-  const buildsQueryKey = trpc.builds.list.infiniteQueryOptions({
-    teamSlug,
-    statuses,
-    buildIdOrTemplate,
-  }).queryKey
+  const buildsQueryKey =
+    trpc.builds.list.infiniteQueryOptions(queryInput).queryKey
 
   const handleLoadMore = useCallback(() => {
     fetchNextPage()
@@ -154,6 +166,14 @@ const BuildsTable = () => {
     }
   }, [queryClient, buildsQueryKey])
 
+  // Reset scroll when the query inputs change.
+  // biome-ignore lint/correctness/useExhaustiveDependencies: these are change triggers, not values read in the effect
+  useEffect(() => {
+    if (scrollContainerRef.current) {
+      scrollContainerRef.current.scrollTop = 0
+    }
+  }, [statuses, buildIdOrTemplate])
+
   // Derived UI state
   const hasData = buildsWithLiveStatus.length > 0
   const showLoader = isInitialLoad && !hasData
@@ -161,181 +181,94 @@ const BuildsTable = () => {
   const showFilterRefetchingOverlay = isFilterRefetching && hasData
 
   return (
-    <div className="flex h-full min-h-0 flex-col overflow-hidden relative">
-      <div
+    <div
+      className={cn(
+        'flex-1 min-h-0 w-full overflow-x-auto md:max-w-[calc(calc(100svw-48px)-var(--sidebar-width-active))]',
+        SIDEBAR_TRANSITION_CLASSNAMES
+      )}
+    >
+      <DataTable
         ref={scrollContainerRef}
-        className="min-h-0 flex-1 overflow-y-auto overflow-x-auto lg:overflow-x-hidden"
+        className={cn(
+          'h-full overflow-y-auto md:min-w-[calc(100svw-48px-var(--sidebar-width-active))]',
+          SIDEBAR_TRANSITION_CLASSNAMES
+        )}
+        style={{ ...columnSizeVars }}
       >
-        <Table suppressHydrationWarning>
-          <colgroup>
-            <col style={colStyle(COLUMN_WIDTHS.status)} />
-            <col style={colStyle(COLUMN_WIDTHS.template)} />
-            <col style={colStyle(COLUMN_WIDTHS.id)} />
-            <col style={colStyle(COLUMN_WIDTHS.cpu)} />
-            <col style={colStyle(COLUMN_WIDTHS.memory)} />
-            <col style={colStyle(COLUMN_WIDTHS.storage)} />
-            <col style={colStyle(COLUMN_WIDTHS.envd)} />
-            <col style={colStyle(COLUMN_WIDTHS.started)} />
-            <col style={colStyle(COLUMN_WIDTHS.duration)} />
-            <col />
-          </colgroup>
+        <DataTableHeader className="sticky top-0 z-10 bg-bg">
+          {table.getHeaderGroups().map((headerGroup) => (
+            <DataTableRow key={headerGroup.id} className="border-b-0">
+              {headerGroup.headers.map((header) => (
+                <DataTableHead
+                  key={header.id}
+                  header={header}
+                  className="shrink-0"
+                  align={isRightAlignedColumn(header.id) ? 'right' : 'left'}
+                >
+                  <span>
+                    {header.isPlaceholder
+                      ? null
+                      : flexRender(
+                          header.column.columnDef.header,
+                          header.getContext()
+                        )}
+                  </span>
+                </DataTableHead>
+              ))}
+            </DataTableRow>
+          ))}
+        </DataTableHeader>
 
-          <TableHeader className="sticky top-0 z-10 bg-bg">
-            <TableRow>
-              <TableHead>Status</TableHead>
-              <TableHead>Template</TableHead>
-              <TableHead>ID</TableHead>
-              <TableHead className="text-end">CPU</TableHead>
-              <TableHead className="text-end">Memory</TableHead>
-              <TableHead className="text-end">Storage</TableHead>
-              <TableHead className="text-end">ENVD Ver.</TableHead>
-              <TableHead>
-                <span className="inline-flex items-center gap-1 text-fg">
-                  Started
-                  <ArrowDownIcon className="size-3" />
-                </span>
-              </TableHead>
-              <TableHead className="text-end">Duration</TableHead>
-              <th />
-            </TableRow>
-          </TableHeader>
+        {showLoader && (
+          <div className="h-[35svh] w-full flex justify-center items-center">
+            <Loader variant="slash" size="lg" />
+          </div>
+        )}
 
-          <TableBody
+        {showEmpty && <BuildsEmpty error={buildsError?.message} />}
+
+        {hasData && (
+          <div
             className={
               showFilterRefetchingOverlay ? 'opacity-70 transition-opacity' : ''
             }
           >
-            {showLoader && (
-              <TableRow>
-                <TableCell colSpan={10}>
-                  <div className="h-[35svh] w-full flex justify-center items-center">
-                    <Loader variant="slash" size="lg" />
-                  </div>
-                </TableCell>
-              </TableRow>
+            {hasScrolledPastInitialPages && (
+              <div className="py-2 text-center text-fg-tertiary">
+                <BackToTopButton onBackToTop={handleBackToTop} />
+              </div>
             )}
 
-            {showEmpty && (
-              <TableRow>
-                <TableCell colSpan={10}>
-                  <BuildsEmpty error={buildsError?.message} />
-                </TableCell>
-              </TableRow>
-            )}
-
-            {hasData && (
-              <>
-                {hasScrolledPastInitialPages && (
-                  <TableRow>
-                    <TableCell
-                      colSpan={10}
-                      className="text-center max-lg:text-start text-fg-tertiary"
-                    >
-                      <BackToTopButton onBackToTop={handleBackToTop} />
-                    </TableCell>
-                  </TableRow>
-                )}
-
-                {buildsWithLiveStatus.map((build) => {
-                  const isBuilding = build.status === 'building'
-
-                  return (
-                    <TableRow
-                      key={build.id}
-                      className={cn(
-                        'transition-colors cursor-pointer hover:bg-bg-hover',
-                        {
-                          'bg-bg-1 animate-pulse': isBuilding,
-                        }
-                      )}
-                      onClick={() => {
-                        router.push(
-                          PROTECTED_URLS.TEMPLATE_BUILD(
-                            teamSlug,
-                            build.templateId,
-                            build.id
-                          )
-                        )
-                      }}
-                    >
-                      <TableCell
-                        className="py-1.5"
-                        style={{ maxWidth: COLUMN_WIDTHS.status }}
-                      >
-                        <Status
-                          status={build.status}
-                          statusMessage={build.statusMessage}
-                        />
-                      </TableCell>
-                      <TableCell
-                        className="py-1.5 overflow-hidden"
-                        style={{ maxWidth: COLUMN_WIDTHS.template }}
-                      >
-                        <Template
-                          template={build.template}
-                          templateId={build.templateId}
-                        />
-                      </TableCell>
-                      <TableCell
-                        className="py-1.5 overflow-hidden"
-                        style={{ maxWidth: COLUMN_WIDTHS.id }}
-                      >
-                        <BuildId id={build.id} />
-                      </TableCell>
-                      <TableCell className="py-1.5">
-                        <Cpu cpuCount={build.cpuCount} />
-                      </TableCell>
-                      <TableCell className="py-1.5">
-                        <Memory memoryMB={build.memoryMB} />
-                      </TableCell>
-                      <TableCell className="py-1.5">
-                        <Storage diskSizeMB={build.diskSizeMB} />
-                      </TableCell>
-                      <TableCell className="py-1.5">
-                        <Envd version={build.envdVersion} />
-                      </TableCell>
-                      <TableCell className="py-1.5">
-                        <StartedAt timestamp={build.createdAt} />
-                      </TableCell>
-                      <TableCell className="py-1.5 text-end">
-                        <Duration
-                          createdAt={build.createdAt}
-                          finishedAt={build.finishedAt}
-                          isBuilding={isBuilding}
-                        />
-                      </TableCell>
-                      <TableCell className="py-1.5 w-full" />
-                    </TableRow>
+            <BuildsTableBody
+              table={table}
+              scrollRef={scrollContainerRef}
+              onRowClick={(build) =>
+                router.push(
+                  PROTECTED_URLS.TEMPLATE_BUILD(
+                    teamSlug,
+                    build.templateId,
+                    build.id
                   )
-                })}
+                )
+              }
+            />
 
-                {hasNextPage && (
-                  <TableRow>
-                    <TableCell
-                      colSpan={10}
-                      className="text-center max-lg:text-start text-fg-tertiary"
-                    >
-                      <LoadMoreButton
-                        isLoading={isFetchingNextPage}
-                        onLoadMore={handleLoadMore}
-                      />
-                    </TableCell>
-                  </TableRow>
-                )}
-              </>
+            {hasNextPage && (
+              <div className="py-2 text-center text-fg-tertiary">
+                <LoadMoreButton
+                  isLoading={isFetchingNextPage}
+                  onLoadMore={handleLoadMore}
+                />
+              </div>
             )}
-          </TableBody>
-        </Table>
-      </div>
+          </div>
+        )}
+      </DataTable>
     </div>
   )
 }
 
 export default BuildsTable
-
-function colStyle(width: number) {
-  return { width, minWidth: width, maxWidth: width }
-}
 
 function useFilterChangeTracking(
   statuses: string[],
@@ -344,6 +277,7 @@ function useFilterChangeTracking(
   const [isFilterRefetching, setIsFilterRefetching] = useState(false)
   const isFirstRender = useRef(true)
 
+  // biome-ignore lint/correctness/useExhaustiveDependencies: these are change triggers, not values read in the effect
   useEffect(() => {
     if (isFirstRender.current) {
       isFirstRender.current = false

--- a/src/features/dashboard/templates/builds/table.tsx
+++ b/src/features/dashboard/templates/builds/table.tsx
@@ -30,10 +30,13 @@ import {
 import BuildsEmpty from './empty'
 import {
   BuildId,
+  Cpu,
   Duration,
-  Reason,
+  Envd,
+  Memory,
   StartedAt,
   Status,
+  Storage,
   Template,
 } from './table-cells'
 import useFilters from './use-filters'
@@ -46,6 +49,10 @@ const COLUMN_WIDTHS = {
   id: 152,
   status: 96,
   template: 192,
+  cpu: 72,
+  memory: 88,
+  storage: 88,
+  envd: 98,
   started: 126,
   duration: 96,
 } as const
@@ -163,16 +170,25 @@ const BuildsTable = () => {
           <colgroup>
             <col style={colStyle(COLUMN_WIDTHS.status)} />
             <col style={colStyle(COLUMN_WIDTHS.template)} />
+            <col style={colStyle(COLUMN_WIDTHS.id)} />
+            <col style={colStyle(COLUMN_WIDTHS.cpu)} />
+            <col style={colStyle(COLUMN_WIDTHS.memory)} />
+            <col style={colStyle(COLUMN_WIDTHS.storage)} />
+            <col style={colStyle(COLUMN_WIDTHS.envd)} />
             <col style={colStyle(COLUMN_WIDTHS.started)} />
             <col style={colStyle(COLUMN_WIDTHS.duration)} />
-            <col style={colStyle(COLUMN_WIDTHS.id)} />
-            <col className="max-lg:min-w-[500px]" />
+            <col />
           </colgroup>
 
           <TableHeader className="sticky top-0 z-10 bg-bg">
             <TableRow>
               <TableHead>Status</TableHead>
               <TableHead>Template</TableHead>
+              <TableHead>ID</TableHead>
+              <TableHead className="text-end">CPU</TableHead>
+              <TableHead className="text-end">Memory</TableHead>
+              <TableHead className="text-end">Storage</TableHead>
+              <TableHead className="text-end">ENVD Ver.</TableHead>
               <TableHead>
                 <span className="inline-flex items-center gap-1 text-fg">
                   Started
@@ -180,7 +196,6 @@ const BuildsTable = () => {
                 </span>
               </TableHead>
               <TableHead className="text-end">Duration</TableHead>
-              <TableHead>ID</TableHead>
               <th />
             </TableRow>
           </TableHeader>
@@ -192,7 +207,7 @@ const BuildsTable = () => {
           >
             {showLoader && (
               <TableRow>
-                <TableCell colSpan={6}>
+                <TableCell colSpan={10}>
                   <div className="h-[35svh] w-full flex justify-center items-center">
                     <Loader variant="slash" size="lg" />
                   </div>
@@ -202,7 +217,7 @@ const BuildsTable = () => {
 
             {showEmpty && (
               <TableRow>
-                <TableCell colSpan={6}>
+                <TableCell colSpan={10}>
                   <BuildsEmpty error={buildsError?.message} />
                 </TableCell>
               </TableRow>
@@ -213,7 +228,7 @@ const BuildsTable = () => {
                 {hasScrolledPastInitialPages && (
                   <TableRow>
                     <TableCell
-                      colSpan={6}
+                      colSpan={10}
                       className="text-center max-lg:text-start text-fg-tertiary"
                     >
                       <BackToTopButton onBackToTop={handleBackToTop} />
@@ -247,7 +262,10 @@ const BuildsTable = () => {
                         className="py-1.5"
                         style={{ maxWidth: COLUMN_WIDTHS.status }}
                       >
-                        <Status status={build.status} />
+                        <Status
+                          status={build.status}
+                          statusMessage={build.statusMessage}
+                        />
                       </TableCell>
                       <TableCell
                         className="py-1.5 overflow-hidden"
@@ -257,6 +275,24 @@ const BuildsTable = () => {
                           template={build.template}
                           templateId={build.templateId}
                         />
+                      </TableCell>
+                      <TableCell
+                        className="py-1.5 overflow-hidden"
+                        style={{ maxWidth: COLUMN_WIDTHS.id }}
+                      >
+                        <BuildId id={build.id} />
+                      </TableCell>
+                      <TableCell className="py-1.5">
+                        <Cpu cpuCount={build.cpuCount} />
+                      </TableCell>
+                      <TableCell className="py-1.5">
+                        <Memory memoryMB={build.memoryMB} />
+                      </TableCell>
+                      <TableCell className="py-1.5">
+                        <Storage diskSizeMB={build.diskSizeMB} />
+                      </TableCell>
+                      <TableCell className="py-1.5">
+                        <Envd version={build.envdVersion} />
                       </TableCell>
                       <TableCell className="py-1.5">
                         <StartedAt timestamp={build.createdAt} />
@@ -268,15 +304,7 @@ const BuildsTable = () => {
                           isBuilding={isBuilding}
                         />
                       </TableCell>
-                      <TableCell
-                        className="py-1.5 overflow-hidden"
-                        style={{ maxWidth: COLUMN_WIDTHS.id }}
-                      >
-                        <BuildId id={build.id} />
-                      </TableCell>
-                      <TableCell className="py-1.5 w-full">
-                        <Reason statusMessage={build.statusMessage} />
-                      </TableCell>
+                      <TableCell className="py-1.5 w-full" />
                     </TableRow>
                   )
                 })}
@@ -284,7 +312,7 @@ const BuildsTable = () => {
                 {hasNextPage && (
                   <TableRow>
                     <TableCell
-                      colSpan={6}
+                      colSpan={10}
                       className="text-center max-lg:text-start text-fg-tertiary"
                     >
                       <LoadMoreButton

--- a/src/features/dashboard/templates/list/table-cells.tsx
+++ b/src/features/dashboard/templates/list/table-cells.tsx
@@ -12,7 +12,6 @@ import {
 } from '@/lib/hooks/use-toast'
 import { cn } from '@/lib/utils'
 import { formatLocalLogStyleTimestamp } from '@/lib/utils/formatting'
-import { isVersionCompatible } from '@/lib/utils/version'
 import { useTRPC } from '@/trpc/client'
 import { AlertDialog } from '@/ui/alert-dialog'
 import { E2BBadge } from '@/ui/brand'
@@ -36,7 +35,6 @@ import {
   UnlockIcon,
 } from '@/ui/primitives/icons'
 import { Loader } from '@/ui/primitives/loader'
-import ResourceUsage from '../../common/resource-usage'
 import { useDashboard } from '../../context'
 
 function E2BTemplateBadge() {
@@ -311,28 +309,6 @@ export function TemplateNameCell({
   )
 }
 
-export function CpuCell({
-  row,
-}: CellContext<Template | DefaultTemplate, unknown>) {
-  const cpuCount = row.getValue('cpuCount') as number
-  return (
-    <div className="w-full flex justify-end">
-      <ResourceUsage type="cpu" total={cpuCount} mode="simple" />
-    </div>
-  )
-}
-
-export function MemoryCell({
-  row,
-}: CellContext<Template | DefaultTemplate, unknown>) {
-  const memoryMB = row.getValue('memoryMB') as number
-  return (
-    <div className="w-full flex justify-end">
-      <ResourceUsage type="mem" total={memoryMB} mode="simple" />
-    </div>
-  )
-}
-
 export function CreatedAtCell({
   getValue,
 }: CellContext<Template | DefaultTemplate, unknown>) {
@@ -404,38 +380,5 @@ export function VisibilityCell({
       {!isPublic && <PrivateIcon className="size-3 text-fg-tertiary" />}
       {isPublic ? 'Public' : 'Internal'}
     </Badge>
-  )
-}
-
-const INVALID_ENVD_VERSION = '0.0.1'
-const SDK_V2_MINIMAL_ENVD_VERSION = '0.2.0'
-
-export function EnvdVersionCell({
-  getValue,
-}: CellContext<Template | DefaultTemplate, unknown>) {
-  const valueString = getValue() as string
-  const versionValue =
-    valueString && valueString !== INVALID_ENVD_VERSION ? valueString : null
-
-  const isNotV2Compatible = versionValue
-    ? isVersionCompatible(versionValue, SDK_V2_MINIMAL_ENVD_VERSION) === false
-    : false
-  return (
-    <div
-      className={cn(
-        'text-fg-tertiary whitespace-nowrap font-mono flex flex-row gap-1.5',
-        {
-          'text-accent-error-highlight': isNotV2Compatible,
-        }
-      )}
-    >
-      {versionValue ?? '--'}
-      {isNotV2Compatible && (
-        <HelpTooltip>
-          The envd version is not compatible with the SDK v2. To update the envd
-          version, you need to rebuild the template.
-        </HelpTooltip>
-      )}
-    </div>
   )
 }

--- a/src/features/dashboard/templates/list/table-config.tsx
+++ b/src/features/dashboard/templates/list/table-config.tsx
@@ -10,10 +10,7 @@ import { useMemo } from 'react'
 import type { DefaultTemplate, Template } from '@/core/modules/templates/models'
 import {
   ActionsCell,
-  CpuCell,
   CreatedAtCell,
-  EnvdVersionCell,
-  MemoryCell,
   TemplateIdCell,
   TemplateNameCell,
   UpdatedAtCell,
@@ -56,22 +53,6 @@ export const useColumns = (deps: unknown[]) => {
         cell: TemplateIdCell,
       },
       {
-        accessorKey: 'cpuCount',
-        header: 'CPU',
-        size: 64,
-        enableResizing: false,
-        cell: CpuCell,
-        enableSorting: false,
-      },
-      {
-        accessorKey: 'memoryMB',
-        header: 'Memory',
-        size: 80,
-        enableResizing: false,
-        cell: MemoryCell,
-        enableSorting: false,
-      },
-      {
         accessorKey: 'createdAt',
         enableGlobalFilter: true,
         id: 'createdAt',
@@ -105,14 +86,6 @@ export const useColumns = (deps: unknown[]) => {
         cell: VisibilityCell,
         enableSorting: false,
         filterFn: 'equals',
-      },
-      {
-        accessorKey: 'envdVersion',
-        header: 'ENVD Ver.',
-        size: 40,
-        enableResizing: false,
-        cell: EnvdVersionCell,
-        enableSorting: false,
       },
       {
         id: 'actions',


### PR DESCRIPTION
Templates list no longer shows build-derived columns; builds page now carries the per-build resources and surfaces failure reasons inline.

- templates list: drop CPU, Memory, ENVD columns
- builds: add CPU, Memory, Storage, ENVD columns (sorting disabled)
- builds: drop the Reason column; show the error in a tooltip on the Failed badge