### PR TITLE
feat: refactor builds table to tanstack table

### DIFF
--- a/src/core/modules/builds/models.ts
+++ b/src/core/modules/builds/models.ts
@@ -22,6 +22,7 @@ type _BuildStatusExhaustiveCheck = AssertTrue<
 // TypeCheck: End
 
 export const BuildStatusSchema = z.enum(BUILD_STATUS_VALUES)
+
 export interface ListedBuildModel {
   id: string
   // id or alias

--- a/src/features/dashboard/templates/builds/header.tsx
+++ b/src/features/dashboard/templates/builds/header.tsx
@@ -102,7 +102,7 @@ export default function BuildsHeader() {
   }
 
   return (
-    <div className="flex flex-col gap-3">
+    <div className="flex flex-row items-center gap-1">
       <Input
         placeholder="Build ID, Template ID or Name"
         className="w-full max-w-62"

--- a/src/features/dashboard/templates/builds/table-body.tsx
+++ b/src/features/dashboard/templates/builds/table-body.tsx
@@ -1,0 +1,74 @@
+import { flexRender, type Table } from '@tanstack/react-table'
+import type { RefObject } from 'react'
+import type { ListedBuildModel } from '@/core/modules/builds/models'
+import { useVirtualRows } from '@/lib/hooks/use-virtual-rows'
+import { cn } from '@/lib/utils'
+import { DataTableBody, DataTableCell, DataTableRow } from '@/ui/data-table'
+import { columnClassName, isRightAlignedColumn } from './table-config'
+
+const ROW_HEIGHT_PX = 40
+const VIRTUAL_OVERSCAN = 8
+const INITIAL_FALLBACK_ROW_COUNT = 100
+
+interface BuildsTableBodyProps {
+  table: Table<ListedBuildModel>
+  scrollRef: RefObject<HTMLDivElement | null>
+  onRowClick: (build: ListedBuildModel) => void
+}
+
+export function BuildsTableBody({
+  table,
+  scrollRef,
+  onRowClick,
+}: BuildsTableBodyProps) {
+  'use no memo'
+
+  const rows = table.getRowModel().rows
+  const {
+    virtualRows,
+    totalHeight: virtualizedTotalHeight,
+    paddingTop: virtualPaddingTop,
+  } = useVirtualRows<ListedBuildModel>({
+    rows,
+    scrollRef,
+    estimateSizePx: ROW_HEIGHT_PX,
+    overscan: VIRTUAL_OVERSCAN,
+  })
+
+  const renderedRows =
+    virtualRows.length > 0
+      ? virtualRows
+      : rows.slice(0, INITIAL_FALLBACK_ROW_COUNT)
+
+  return (
+    <DataTableBody virtualizedTotalHeight={virtualizedTotalHeight}>
+      {virtualPaddingTop > 0 && <div style={{ height: virtualPaddingTop }} />}
+      {renderedRows.map((row) => {
+        const isBuilding = row.original.status === 'building'
+
+        return (
+          <DataTableRow
+            key={row.id}
+            className={cn('h-10 cursor-pointer hover:bg-bg-hover', {
+              'bg-bg-1 animate-pulse': isBuilding,
+            })}
+            onClick={() => onRowClick(row.original)}
+          >
+            {row.getVisibleCells().map((cell) => (
+              <DataTableCell
+                key={cell.id}
+                cell={cell}
+                className={cn(
+                  columnClassName(cell.column.id),
+                  isRightAlignedColumn(cell.column.id) && 'justify-end'
+                )}
+              >
+                {flexRender(cell.column.columnDef.cell, cell.getContext())}
+              </DataTableCell>
+            ))}
+          </DataTableRow>
+        )
+      })}
+    </DataTableBody>
+  )
+}

--- a/src/features/dashboard/templates/builds/table-body.tsx
+++ b/src/features/dashboard/templates/builds/table-body.tsx
@@ -4,7 +4,7 @@ import type { ListedBuildModel } from '@/core/modules/builds/models'
 import { useVirtualRows } from '@/lib/hooks/use-virtual-rows'
 import { cn } from '@/lib/utils'
 import { DataTableBody, DataTableCell, DataTableRow } from '@/ui/data-table'
-import { columnClassName, isRightAlignedColumn } from './table-config'
+import { isRightAlignedColumn } from './table-config'
 
 const ROW_HEIGHT_PX = 40
 const VIRTUAL_OVERSCAN = 8
@@ -59,7 +59,7 @@ export function BuildsTableBody({
                 key={cell.id}
                 cell={cell}
                 className={cn(
-                  columnClassName(cell.column.id),
+                  'shrink-0',
                   isRightAlignedColumn(cell.column.id) && 'justify-end'
                 )}
               >

--- a/src/features/dashboard/templates/builds/table-cells.tsx
+++ b/src/features/dashboard/templates/builds/table-cells.tsx
@@ -31,9 +31,10 @@ export function BuildId({ id }: { id: string }) {
   return (
     <CopyButtonInline
       value={id}
+      truncate={false}
       className="w-full text-left text-fg-tertiary font-mono prose-table-numeric"
     >
-      {id.slice(0, 6)}...{id.slice(-6)}
+      {id.slice(0, 7)}...{id.slice(-5)}
     </CopyButtonInline>
   )
 }
@@ -160,7 +161,7 @@ export function Status({ status, statusMessage }: StatusProps) {
   const showReason = status === 'failed' && Boolean(statusMessage)
 
   return (
-    <div className="flex items-center gap-3 min-w-0">
+    <div className="flex items-center gap-3 min-w-0 shrink-0">
       {showReason ? (
         <Tooltip>
           <TooltipTrigger asChild>{badge}</TooltipTrigger>
@@ -177,7 +178,7 @@ export function Status({ status, statusMessage }: StatusProps) {
 
 export function Cpu({ cpuCount }: { cpuCount: number }) {
   return (
-    <div className="w-full flex justify-center">
+    <div className="w-full flex justify-end">
       <ResourceUsage type="cpu" total={cpuCount} mode="simple" />
     </div>
   )

--- a/src/features/dashboard/templates/builds/table-cells.tsx
+++ b/src/features/dashboard/templates/builds/table-cells.tsx
@@ -18,7 +18,6 @@ import CopyButtonInline from '@/ui/copy-button-inline'
 import { Badge } from '@/ui/primitives/badge'
 import { Button } from '@/ui/primitives/button'
 import { CheckmarkIcon, CloseIcon } from '@/ui/primitives/icons'
-import { Loader } from '@/ui/primitives/loader'
 import {
   Tooltip,
   TooltipContent,

--- a/src/features/dashboard/templates/builds/table-config.tsx
+++ b/src/features/dashboard/templates/builds/table-config.tsx
@@ -1,0 +1,124 @@
+'use client'
+
+import {
+  type ColumnDef,
+  getCoreRowModel,
+  type TableOptions,
+} from '@tanstack/react-table'
+import type { ListedBuildModel } from '@/core/modules/builds/models'
+import {
+  BuildId,
+  Cpu,
+  Duration,
+  Envd,
+  Memory,
+  StartedAt,
+  Status,
+  Storage,
+  Template,
+} from './table-cells'
+
+export const fallbackData: ListedBuildModel[] = []
+
+const RIGHT_ALIGNED_COLUMNS = new Set([
+  'cpuCount',
+  'memoryMB',
+  'diskSizeMB',
+  'envdVersion',
+  'createdAt',
+  'duration',
+])
+
+export const isRightAlignedColumn = (id: string) =>
+  RIGHT_ALIGNED_COLUMNS.has(id)
+
+// Flex behavior per column, applied to both header and body cells. Columns are
+// fixed-width by default (shrink-0 → horizontal scroll); Template grows to fill
+// the leftover space.
+const COLUMN_CLASSNAMES: Record<string, string> = {
+  template: 'flex-1 min-w-[160px]',
+}
+
+export const columnClassName = (id: string) =>
+  COLUMN_CLASSNAMES[id] ?? 'shrink-0'
+
+export const buildsColumns: ColumnDef<ListedBuildModel>[] = [
+  {
+    accessorKey: 'status',
+    header: 'Status',
+    size: 76,
+    cell: ({ row }) => (
+      <Status
+        status={row.original.status}
+        statusMessage={row.original.statusMessage}
+      />
+    ),
+  },
+  {
+    accessorKey: 'template',
+    header: 'Template',
+    size: 160,
+    cell: ({ row }) => (
+      <Template
+        template={row.original.template}
+        templateId={row.original.templateId}
+      />
+    ),
+  },
+  {
+    accessorKey: 'id',
+    header: 'ID',
+    size: 128,
+    cell: ({ row }) => <BuildId id={row.original.id} />,
+  },
+  {
+    accessorKey: 'cpuCount',
+    header: 'CPU',
+    size: 64,
+    cell: ({ row }) => <Cpu cpuCount={row.original.cpuCount} />,
+  },
+  {
+    accessorKey: 'memoryMB',
+    header: 'Memory',
+    size: 80,
+    cell: ({ row }) => <Memory memoryMB={row.original.memoryMB} />,
+  },
+  {
+    accessorKey: 'diskSizeMB',
+    header: 'Storage',
+    size: 80,
+    cell: ({ row }) => <Storage diskSizeMB={row.original.diskSizeMB} />,
+  },
+  {
+    accessorKey: 'envdVersion',
+    header: 'ENVD Ver.',
+    size: 96,
+    cell: ({ row }) => <Envd version={row.original.envdVersion} />,
+  },
+  {
+    accessorKey: 'createdAt',
+    header: 'Started',
+    size: 110,
+    cell: ({ row }) => <StartedAt timestamp={row.original.createdAt} />,
+  },
+  {
+    accessorKey: 'duration',
+    header: 'Duration',
+    size: 110,
+    cell: ({ row }) => (
+      <div className="w-full text-end">
+        <Duration
+          createdAt={row.original.createdAt}
+          finishedAt={row.original.finishedAt}
+          isBuilding={row.original.status === 'building'}
+        />
+      </div>
+    ),
+  },
+]
+
+export const buildsTableConfig: Partial<TableOptions<ListedBuildModel>> = {
+  getCoreRowModel: getCoreRowModel(),
+  enableSorting: false,
+  enableColumnResizing: false,
+}

--- a/src/features/dashboard/templates/builds/table-config.tsx
+++ b/src/features/dashboard/templates/builds/table-config.tsx
@@ -32,21 +32,12 @@ const RIGHT_ALIGNED_COLUMNS = new Set([
 export const isRightAlignedColumn = (id: string) =>
   RIGHT_ALIGNED_COLUMNS.has(id)
 
-// Flex behavior per column, applied to both header and body cells. Columns are
-// fixed-width by default (shrink-0 → horizontal scroll); Template grows to fill
-// the leftover space.
-const COLUMN_CLASSNAMES: Record<string, string> = {
-  template: 'flex-1 min-w-[160px]',
-}
-
-export const columnClassName = (id: string) =>
-  COLUMN_CLASSNAMES[id] ?? 'shrink-0'
-
 export const buildsColumns: ColumnDef<ListedBuildModel>[] = [
   {
     accessorKey: 'status',
     header: 'Status',
     size: 76,
+    enableResizing: false,
     cell: ({ row }) => (
       <Status
         status={row.original.status}
@@ -57,7 +48,10 @@ export const buildsColumns: ColumnDef<ListedBuildModel>[] = [
   {
     accessorKey: 'template',
     header: 'Template',
-    size: 160,
+    size: 240,
+    minSize: 160,
+    maxSize: 480,
+    enableResizing: true,
     cell: ({ row }) => (
       <Template
         template={row.original.template}
@@ -69,42 +63,49 @@ export const buildsColumns: ColumnDef<ListedBuildModel>[] = [
     accessorKey: 'id',
     header: 'ID',
     size: 128,
+    enableResizing: false,
     cell: ({ row }) => <BuildId id={row.original.id} />,
   },
   {
     accessorKey: 'cpuCount',
     header: 'CPU',
     size: 64,
+    enableResizing: false,
     cell: ({ row }) => <Cpu cpuCount={row.original.cpuCount} />,
   },
   {
     accessorKey: 'memoryMB',
     header: 'Memory',
     size: 80,
+    enableResizing: false,
     cell: ({ row }) => <Memory memoryMB={row.original.memoryMB} />,
   },
   {
     accessorKey: 'diskSizeMB',
     header: 'Storage',
     size: 80,
+    enableResizing: false,
     cell: ({ row }) => <Storage diskSizeMB={row.original.diskSizeMB} />,
   },
   {
     accessorKey: 'envdVersion',
     header: 'ENVD Ver.',
     size: 96,
+    enableResizing: false,
     cell: ({ row }) => <Envd version={row.original.envdVersion} />,
   },
   {
     accessorKey: 'createdAt',
     header: 'Started',
     size: 110,
+    enableResizing: false,
     cell: ({ row }) => <StartedAt timestamp={row.original.createdAt} />,
   },
   {
     accessorKey: 'duration',
     header: 'Duration',
     size: 110,
+    enableResizing: false,
     cell: ({ row }) => (
       <div className="w-full text-end">
         <Duration
@@ -120,5 +121,6 @@ export const buildsColumns: ColumnDef<ListedBuildModel>[] = [
 export const buildsTableConfig: Partial<TableOptions<ListedBuildModel>> = {
   getCoreRowModel: getCoreRowModel(),
   enableSorting: false,
-  enableColumnResizing: false,
+  columnResizeMode: 'onChange',
+  enableColumnResizing: true,
 }

--- a/src/features/dashboard/templates/builds/table.tsx
+++ b/src/features/dashboard/templates/builds/table.tsx
@@ -7,12 +7,14 @@ import {
   useQueryClient,
 } from '@tanstack/react-query'
 import {
+  type ColumnSizingState,
   flexRender,
   type TableOptions,
   useReactTable,
 } from '@tanstack/react-table'
 import { useRouter } from 'next/navigation'
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import { useLocalStorage } from 'usehooks-ts'
 import { PROTECTED_URLS } from '@/configs/urls'
 import type {
   ListedBuildModel,
@@ -36,7 +38,6 @@ import { BuildsTableBody } from './table-body'
 import {
   buildsColumns,
   buildsTableConfig,
-  columnClassName,
   fallbackData,
   isRightAlignedColumn,
 } from './table-config'
@@ -47,12 +48,22 @@ const RUNNING_BUILD_POLL_INTERVAL_MS = 3_000
 const MAX_CACHED_PAGES = 3
 
 const BuildsTable = () => {
+  'use no memo'
+
   const trpc = useTRPC()
   const queryClient = useQueryClient()
   const router = useRouter()
   const scrollContainerRef = useRef<HTMLDivElement>(null)
 
   const { teamSlug } = useRouteParams<'/dashboard/[teamSlug]/templates'>()
+  const [columnSizing, setColumnSizing] = useLocalStorage<ColumnSizingState>(
+    'builds:columnSizing:v1',
+    {},
+    {
+      deserializer: (value) => JSON.parse(value),
+      serializer: (value) => JSON.stringify(value),
+    }
+  )
   const { statuses, buildIdOrTemplate } = useFilters()
   const { isFilterRefetching, clearFilterRefetching } = useFilterChangeTracking(
     statuses,
@@ -132,6 +143,10 @@ const BuildsTable = () => {
     ...buildsTableConfig,
     data: buildsWithLiveStatus ?? fallbackData,
     columns: buildsColumns,
+    state: {
+      columnSizing,
+    },
+    onColumnSizingChange: setColumnSizing,
   } as TableOptions<ListedBuildModel>)
 
   const columnSizeVars = useColumnSizeVars(table)
@@ -187,7 +202,7 @@ const BuildsTable = () => {
                 <DataTableHead
                   key={header.id}
                   header={header}
-                  className={columnClassName(header.id)}
+                  className="shrink-0"
                   align={isRightAlignedColumn(header.id) ? 'right' : 'left'}
                 >
                   <span>

--- a/src/features/dashboard/templates/builds/table.tsx
+++ b/src/features/dashboard/templates/builds/table.tsx
@@ -6,6 +6,11 @@ import {
   useQuery,
   useQueryClient,
 } from '@tanstack/react-query'
+import {
+  flexRender,
+  type TableOptions,
+  useReactTable,
+} from '@tanstack/react-table'
 import { useRouter } from 'next/navigation'
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { PROTECTED_URLS } from '@/configs/urls'
@@ -13,49 +18,33 @@ import type {
   ListedBuildModel,
   RunningBuildStatusModel,
 } from '@/core/modules/builds/models'
+import { useColumnSizeVars } from '@/lib/hooks/use-column-size-vars'
 import { useRouteParams } from '@/lib/hooks/use-route-params'
-import { cn } from '@/lib/utils/ui'
+import { cn } from '@/lib/utils'
 import { useTRPC } from '@/trpc/client'
+import {
+  DataTable,
+  DataTableHead,
+  DataTableHeader,
+  DataTableRow,
+} from '@/ui/data-table'
 import { BackToTopButton, LoadMoreButton } from '@/ui/pagination-buttons'
-import { ArrowDownIcon } from '@/ui/primitives/icons'
 import { Loader } from '@/ui/primitives/loader'
-import {
-  Table,
-  TableBody,
-  TableCell,
-  TableHead,
-  TableHeader,
-  TableRow,
-} from '@/ui/primitives/table'
+import { SIDEBAR_TRANSITION_CLASSNAMES } from '@/ui/primitives/sidebar'
 import BuildsEmpty from './empty'
+import { BuildsTableBody } from './table-body'
 import {
-  BuildId,
-  Cpu,
-  Duration,
-  Envd,
-  Memory,
-  StartedAt,
-  Status,
-  Storage,
-  Template,
-} from './table-cells'
+  buildsColumns,
+  buildsTableConfig,
+  columnClassName,
+  fallbackData,
+  isRightAlignedColumn,
+} from './table-config'
 import useFilters from './use-filters'
 
 const BUILDS_REFETCH_INTERVAL_MS = 15_000
 const RUNNING_BUILD_POLL_INTERVAL_MS = 3_000
 const MAX_CACHED_PAGES = 3
-
-const COLUMN_WIDTHS = {
-  id: 152,
-  status: 96,
-  template: 192,
-  cpu: 72,
-  memory: 88,
-  storage: 88,
-  envd: 98,
-  started: 126,
-  duration: 96,
-} as const
 
 const BuildsTable = () => {
   const trpc = useTRPC()
@@ -70,6 +59,12 @@ const BuildsTable = () => {
     buildIdOrTemplate
   )
 
+  const queryInput = {
+    teamSlug,
+    statuses,
+    buildIdOrTemplate,
+  }
+
   // Builds list query
   const {
     data: paginatedBuilds,
@@ -80,17 +75,14 @@ const BuildsTable = () => {
     isPending: isInitialLoad,
     error: buildsError,
   } = useInfiniteQuery(
-    trpc.builds.list.infiniteQueryOptions(
-      { teamSlug, statuses, buildIdOrTemplate },
-      {
-        getNextPageParam: (page) => page.nextCursor ?? undefined,
-        placeholderData: keepPreviousData,
-        retry: 3,
-        refetchInterval: BUILDS_REFETCH_INTERVAL_MS,
-        refetchIntervalInBackground: false,
-        maxPages: MAX_CACHED_PAGES,
-      }
-    )
+    trpc.builds.list.infiniteQueryOptions(queryInput, {
+      getNextPageParam: (page) => page.nextCursor ?? undefined,
+      placeholderData: keepPreviousData,
+      retry: 3,
+      refetchInterval: BUILDS_REFETCH_INTERVAL_MS,
+      refetchIntervalInBackground: false,
+      maxPages: MAX_CACHED_PAGES,
+    })
   )
 
   const builds = useMemo(
@@ -136,12 +128,17 @@ const BuildsTable = () => {
     [builds, runningStatusesData]
   )
 
+  const table = useReactTable<ListedBuildModel>({
+    ...buildsTableConfig,
+    data: buildsWithLiveStatus ?? fallbackData,
+    columns: buildsColumns,
+  } as TableOptions<ListedBuildModel>)
+
+  const columnSizeVars = useColumnSizeVars(table)
+
   // Handlers
-  const buildsQueryKey = trpc.builds.list.infiniteQueryOptions({
-    teamSlug,
-    statuses,
-    buildIdOrTemplate,
-  }).queryKey
+  const buildsQueryKey =
+    trpc.builds.list.infiniteQueryOptions(queryInput).queryKey
 
   const handleLoadMore = useCallback(() => {
     fetchNextPage()
@@ -154,6 +151,14 @@ const BuildsTable = () => {
     }
   }, [queryClient, buildsQueryKey])
 
+  // Reset scroll when the query inputs change.
+  // biome-ignore lint/correctness/useExhaustiveDependencies: these are change triggers, not values read in the effect
+  useEffect(() => {
+    if (scrollContainerRef.current) {
+      scrollContainerRef.current.scrollTop = 0
+    }
+  }, [statuses, buildIdOrTemplate])
+
   // Derived UI state
   const hasData = buildsWithLiveStatus.length > 0
   const showLoader = isInitialLoad && !hasData
@@ -161,181 +166,94 @@ const BuildsTable = () => {
   const showFilterRefetchingOverlay = isFilterRefetching && hasData
 
   return (
-    <div className="flex h-full min-h-0 flex-col overflow-hidden relative">
-      <div
+    <div
+      className={cn(
+        'flex-1 min-h-0 w-full overflow-x-auto md:max-w-[calc(calc(100svw-48px)-var(--sidebar-width-active))]',
+        SIDEBAR_TRANSITION_CLASSNAMES
+      )}
+    >
+      <DataTable
         ref={scrollContainerRef}
-        className="min-h-0 flex-1 overflow-y-auto overflow-x-auto lg:overflow-x-hidden"
+        className={cn(
+          'h-full overflow-y-auto md:min-w-[calc(100svw-48px-var(--sidebar-width-active))]',
+          SIDEBAR_TRANSITION_CLASSNAMES
+        )}
+        style={{ ...columnSizeVars }}
       >
-        <Table suppressHydrationWarning>
-          <colgroup>
-            <col style={colStyle(COLUMN_WIDTHS.status)} />
-            <col style={colStyle(COLUMN_WIDTHS.template)} />
-            <col style={colStyle(COLUMN_WIDTHS.id)} />
-            <col style={colStyle(COLUMN_WIDTHS.cpu)} />
-            <col style={colStyle(COLUMN_WIDTHS.memory)} />
-            <col style={colStyle(COLUMN_WIDTHS.storage)} />
-            <col style={colStyle(COLUMN_WIDTHS.envd)} />
-            <col style={colStyle(COLUMN_WIDTHS.started)} />
-            <col style={colStyle(COLUMN_WIDTHS.duration)} />
-            <col />
-          </colgroup>
+        <DataTableHeader className="sticky top-0 z-10 bg-bg">
+          {table.getHeaderGroups().map((headerGroup) => (
+            <DataTableRow key={headerGroup.id} className="border-b-0">
+              {headerGroup.headers.map((header) => (
+                <DataTableHead
+                  key={header.id}
+                  header={header}
+                  className={columnClassName(header.id)}
+                  align={isRightAlignedColumn(header.id) ? 'right' : 'left'}
+                >
+                  <span>
+                    {header.isPlaceholder
+                      ? null
+                      : flexRender(
+                          header.column.columnDef.header,
+                          header.getContext()
+                        )}
+                  </span>
+                </DataTableHead>
+              ))}
+            </DataTableRow>
+          ))}
+        </DataTableHeader>
 
-          <TableHeader className="sticky top-0 z-10 bg-bg">
-            <TableRow>
-              <TableHead>Status</TableHead>
-              <TableHead>Template</TableHead>
-              <TableHead>ID</TableHead>
-              <TableHead className="text-end">CPU</TableHead>
-              <TableHead className="text-end">Memory</TableHead>
-              <TableHead className="text-end">Storage</TableHead>
-              <TableHead className="text-end">ENVD Ver.</TableHead>
-              <TableHead>
-                <span className="inline-flex items-center gap-1 text-fg">
-                  Started
-                  <ArrowDownIcon className="size-3" />
-                </span>
-              </TableHead>
-              <TableHead className="text-end">Duration</TableHead>
-              <th />
-            </TableRow>
-          </TableHeader>
+        {showLoader && (
+          <div className="h-[35svh] w-full flex justify-center items-center">
+            <Loader variant="slash" size="lg" />
+          </div>
+        )}
 
-          <TableBody
+        {showEmpty && <BuildsEmpty error={buildsError?.message} />}
+
+        {hasData && (
+          <div
             className={
               showFilterRefetchingOverlay ? 'opacity-70 transition-opacity' : ''
             }
           >
-            {showLoader && (
-              <TableRow>
-                <TableCell colSpan={10}>
-                  <div className="h-[35svh] w-full flex justify-center items-center">
-                    <Loader variant="slash" size="lg" />
-                  </div>
-                </TableCell>
-              </TableRow>
+            {hasScrolledPastInitialPages && (
+              <div className="py-2 text-center text-fg-tertiary">
+                <BackToTopButton onBackToTop={handleBackToTop} />
+              </div>
             )}
 
-            {showEmpty && (
-              <TableRow>
-                <TableCell colSpan={10}>
-                  <BuildsEmpty error={buildsError?.message} />
-                </TableCell>
-              </TableRow>
-            )}
-
-            {hasData && (
-              <>
-                {hasScrolledPastInitialPages && (
-                  <TableRow>
-                    <TableCell
-                      colSpan={10}
-                      className="text-center max-lg:text-start text-fg-tertiary"
-                    >
-                      <BackToTopButton onBackToTop={handleBackToTop} />
-                    </TableCell>
-                  </TableRow>
-                )}
-
-                {buildsWithLiveStatus.map((build) => {
-                  const isBuilding = build.status === 'building'
-
-                  return (
-                    <TableRow
-                      key={build.id}
-                      className={cn(
-                        'transition-colors cursor-pointer hover:bg-bg-hover',
-                        {
-                          'bg-bg-1 animate-pulse': isBuilding,
-                        }
-                      )}
-                      onClick={() => {
-                        router.push(
-                          PROTECTED_URLS.TEMPLATE_BUILD(
-                            teamSlug,
-                            build.templateId,
-                            build.id
-                          )
-                        )
-                      }}
-                    >
-                      <TableCell
-                        className="py-1.5"
-                        style={{ maxWidth: COLUMN_WIDTHS.status }}
-                      >
-                        <Status
-                          status={build.status}
-                          statusMessage={build.statusMessage}
-                        />
-                      </TableCell>
-                      <TableCell
-                        className="py-1.5 overflow-hidden"
-                        style={{ maxWidth: COLUMN_WIDTHS.template }}
-                      >
-                        <Template
-                          template={build.template}
-                          templateId={build.templateId}
-                        />
-                      </TableCell>
-                      <TableCell
-                        className="py-1.5 overflow-hidden"
-                        style={{ maxWidth: COLUMN_WIDTHS.id }}
-                      >
-                        <BuildId id={build.id} />
-                      </TableCell>
-                      <TableCell className="py-1.5">
-                        <Cpu cpuCount={build.cpuCount} />
-                      </TableCell>
-                      <TableCell className="py-1.5">
-                        <Memory memoryMB={build.memoryMB} />
-                      </TableCell>
-                      <TableCell className="py-1.5">
-                        <Storage diskSizeMB={build.diskSizeMB} />
-                      </TableCell>
-                      <TableCell className="py-1.5">
-                        <Envd version={build.envdVersion} />
-                      </TableCell>
-                      <TableCell className="py-1.5">
-                        <StartedAt timestamp={build.createdAt} />
-                      </TableCell>
-                      <TableCell className="py-1.5 text-end">
-                        <Duration
-                          createdAt={build.createdAt}
-                          finishedAt={build.finishedAt}
-                          isBuilding={isBuilding}
-                        />
-                      </TableCell>
-                      <TableCell className="py-1.5 w-full" />
-                    </TableRow>
+            <BuildsTableBody
+              table={table}
+              scrollRef={scrollContainerRef}
+              onRowClick={(build) =>
+                router.push(
+                  PROTECTED_URLS.TEMPLATE_BUILD(
+                    teamSlug,
+                    build.templateId,
+                    build.id
                   )
-                })}
+                )
+              }
+            />
 
-                {hasNextPage && (
-                  <TableRow>
-                    <TableCell
-                      colSpan={10}
-                      className="text-center max-lg:text-start text-fg-tertiary"
-                    >
-                      <LoadMoreButton
-                        isLoading={isFetchingNextPage}
-                        onLoadMore={handleLoadMore}
-                      />
-                    </TableCell>
-                  </TableRow>
-                )}
-              </>
+            {hasNextPage && (
+              <div className="py-2 text-center text-fg-tertiary">
+                <LoadMoreButton
+                  isLoading={isFetchingNextPage}
+                  onLoadMore={handleLoadMore}
+                />
+              </div>
             )}
-          </TableBody>
-        </Table>
-      </div>
+          </div>
+        )}
+      </DataTable>
     </div>
   )
 }
 
 export default BuildsTable
-
-function colStyle(width: number) {
-  return { width, minWidth: width, maxWidth: width }
-}
 
 function useFilterChangeTracking(
   statuses: string[],
@@ -344,6 +262,7 @@ function useFilterChangeTracking(
   const [isFilterRefetching, setIsFilterRefetching] = useState(false)
   const isFirstRender = useRef(true)
 
+  // biome-ignore lint/correctness/useExhaustiveDependencies: these are change triggers, not values read in the effect
   useEffect(() => {
     if (isFirstRender.current) {
       isFirstRender.current = false


### PR DESCRIPTION
## Refactor builds table & add resource filtering

Rebuilds the builds table on TanStack Table

### Changes

- **Builds table rebuilt on TanStack Table** — replaced the hand-rolled `<table>`/colgroup layout with `useReactTable` + virtualized rows, extracting `table-config.tsx` and `table-body.tsx`.
- **Cell tweaks** — failed-build statuses show their status message in a tooltip; resource cells right-aligned; build ID truncation adjusted.