### PR TITLE
fix: inline proxy `config` so Next can statically read the matcher

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -1,5 +1,6 @@
 {
   "lockfileVersion": 1,
+  "configVersion": 0,
   "workspaces": {
     "": {
       "name": "@e2b/dashboard",

--- a/src/core/server/proxy/runtime.ts
+++ b/src/core/server/proxy/runtime.ts
@@ -84,9 +84,3 @@ async function runProxyConcerns(
     return NextResponse.next({ request })
   }
 }
-
-export const proxyConfig = {
-  matcher: [
-    '/((?!_next/|.*\\.(?:ico|svg|png|jpg|jpeg|gif|webp)$|_vercel/|ingest/|ph-proxy/|array/|mintlify-assets/|_mintlify/).*)',
-  ],
-}

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -1,4 +1,7 @@
-export {
-  proxyConfig as config,
-  runDashboardProxy as proxy,
-} from '@/core/server/proxy/runtime'
+export { runDashboardProxy as proxy } from '@/core/server/proxy/runtime'
+
+export const config = {
+  matcher: [
+    '/((?!_next/|.*\\.(?:ico|svg|png|jpg|jpeg|gif|webp)$|_vercel/|ingest/|ph-proxy/|array/|mintlify-assets/|_mintlify/).*)',
+  ],
+}


### PR DESCRIPTION
Next statically parses `config` from `proxy.ts` at build time and can't follow a re-export. The #417 refactor re-exported `config` from `runtime.ts`, breaking the parse — dev 500'd and prod dropped the matcher (proxy ran on all requests). Inline `config` as a literal in `proxy.ts` and remove the duplicate from `runtime.ts`. The `proxy` function re-export is fine (resolved at runtime).