### PR TITLE
fix(auth): patch @ory/nextjs to honor request host on preview deploys

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -18,7 +18,7 @@
         "@opentelemetry/sdk-metrics": "^2.0.1",
         "@opentelemetry/sdk-node": "^0.218.0",
         "@opentelemetry/semantic-conventions": "^1.36.0",
-        "@ory/client-fetch": "^1.22.37",
+        "@ory/client-fetch": "1.22.22",
         "@ory/elements-react": "^1.2.0",
         "@ory/nextjs": "^1.0.0-rc.1",
         "@radix-ui/react-avatar": "^1.1.4",
@@ -589,7 +589,7 @@
 
     "@opentelemetry/sql-common": ["@opentelemetry/sql-common@0.42.0", "", { "dependencies": { "@opentelemetry/core": "^2.0.0" }, "peerDependencies": { "@opentelemetry/api": "^1.1.0" } }, "sha512-nwUwUU+8O8a4bnLqk6CodWeegGMEANgC94KTAhXcpGWLrW/2/hek/0ajNbjXnSOoNuCX+nteUPs46HFHhou9Xw=="],
 
-    "@ory/client-fetch": ["@ory/client-fetch@1.22.37", "", {}, "sha512-OFPso6JcQ1NVA7UF4Ip112b9/3yoFlGF2kM78fy6gG3uwciC5eUXZWHBGLZdCEi7eKe1JVMJwraR5j6QVmS8vw=="],
+    "@ory/client-fetch": ["@ory/client-fetch@1.22.22", "", {}, "sha512-MEoPKIRWETj6mTsJnWVCMJTFpZ/40885YZJUEc1vM7v7AwjLBgJPE7xsm2QvSYCSAiLBzbROETxEtvZiRCzYJw=="],
 
     "@ory/elements-react": ["@ory/elements-react@1.2.0", "", { "dependencies": { "@marsidev/react-turnstile": "^1.1.0", "@ory/client-fetch": "1.22.22", "@radix-ui/react-dropdown-menu": "2.1.14", "@radix-ui/react-password-toggle-field": "0.1.3", "@radix-ui/react-switch": "1.2.4", "class-variance-authority": "0.7.1", "clsx": "2.1.1", "input-otp": "1.4.2", "react-hook-form": "7.56.4", "react-intl": "7.1.13", "sonner": "^2.0.0", "tailwind-merge": "3.3.0", "usehooks-ts": "3.1.1" }, "peerDependencies": { "react": "^18.0.0 || ^19.0.0 || ^19.0.0-0", "react-dom": "^18.0.0 || ^19.0.0 || ^19.0.0-0" } }, "sha512-Zq/GxYErugATNTOyXkCnazsZoef692vnYxgLZxcLGwVVkFp5Z1U3nDm+LZ9UDQ/HF5cs2+MN2uoNjdQM78qwkg=="],
 
@@ -2249,15 +2249,11 @@
 
     "@opentelemetry/sdk-trace-node/@opentelemetry/sdk-trace-base": ["@opentelemetry/sdk-trace-base@2.7.1", "", { "dependencies": { "@opentelemetry/core": "2.7.1", "@opentelemetry/resources": "2.7.1", "@opentelemetry/semantic-conventions": "^1.29.0" }, "peerDependencies": { "@opentelemetry/api": ">=1.3.0 <1.10.0" } }, "sha512-NAYIlsF8MPUsKqJMiDQJTMPOmlbawC1Iz/omMLygZ1C9am8fTKYjTaI+OZM+WTY3t3Glo0wnOg/6/pac6RGPPw=="],
 
-    "@ory/elements-react/@ory/client-fetch": ["@ory/client-fetch@1.22.22", "", {}, "sha512-MEoPKIRWETj6mTsJnWVCMJTFpZ/40885YZJUEc1vM7v7AwjLBgJPE7xsm2QvSYCSAiLBzbROETxEtvZiRCzYJw=="],
-
     "@ory/elements-react/@radix-ui/react-dropdown-menu": ["@radix-ui/react-dropdown-menu@2.1.14", "", { "dependencies": { "@radix-ui/primitive": "1.1.2", "@radix-ui/react-compose-refs": "1.1.2", "@radix-ui/react-context": "1.1.2", "@radix-ui/react-id": "1.1.1", "@radix-ui/react-menu": "2.1.14", "@radix-ui/react-primitive": "2.1.2", "@radix-ui/react-use-controllable-state": "1.2.2" }, "peerDependencies": { "@types/react": "*", "@types/react-dom": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-lzuyNjoWOoaMFE/VC5FnAAYM16JmQA8ZmucOXtlhm2kKR5TSU95YLAueQ4JYuRmUJmBvSqXaVFGIfuukybwZJQ=="],
 
     "@ory/elements-react/react-hook-form": ["react-hook-form@7.56.4", "", { "peerDependencies": { "react": "^16.8.0 || ^17 || ^18 || ^19" } }, "sha512-Rob7Ftz2vyZ/ZGsQZPaRdIefkgOSrQSPXfqBdvOPwJfoGnjwRJUs7EM7Kc1mcoDv3NOtqBzPGbcMB8CGn9CKgw=="],
 
     "@ory/elements-react/tailwind-merge": ["tailwind-merge@3.3.0", "", {}, "sha512-fyW/pEfcQSiigd5SNn0nApUOxx0zB/dm6UDU/rEwc2c3sX2smWUNbapHv+QRqLGVp9GWX3THIa7MUGPo+YkDzQ=="],
-
-    "@ory/nextjs/@ory/client-fetch": ["@ory/client-fetch@1.22.22", "", {}, "sha512-MEoPKIRWETj6mTsJnWVCMJTFpZ/40885YZJUEc1vM7v7AwjLBgJPE7xsm2QvSYCSAiLBzbROETxEtvZiRCzYJw=="],
 
     "@posthog/webpack-plugin/@posthog/core": ["@posthog/core@1.32.3", "", { "dependencies": { "@posthog/types": "1.386.3" } }, "sha512-vwOEMfZvGv5XxNWV7p9I52NSmvFNMhyW2IHpIoUHW5jLkgUrknzJW1H/qxVGSIrNNVQkfsoaDFzDhJdg10pgrA=="],
 

--- a/bun.lock
+++ b/bun.lock
@@ -124,6 +124,9 @@
       },
     },
   },
+  "patchedDependencies": {
+    "@ory/nextjs@1.0.0-rc.1": "patches/@ory%2Fnextjs@1.0.0-rc.1.patch",
+  },
   "overrides": {
     "@nodelib/fs.scandir": "2.1.5",
     "@nodelib/fs.stat": "2.0.5",

--- a/package.json
+++ b/package.json
@@ -171,5 +171,8 @@
     "@nodelib/fs.stat": "2.0.5",
     "@opentelemetry/exporter-prometheus": "^0.218.0"
   },
-  "packageManager": "bun@1.2.0"
+  "packageManager": "bun@1.2.0",
+  "patchedDependencies": {
+    "@ory/nextjs@1.0.0-rc.1": "patches/@ory%2Fnextjs@1.0.0-rc.1.patch"
+  }
 }

--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "@opentelemetry/sdk-metrics": "^2.0.1",
     "@opentelemetry/sdk-node": "^0.218.0",
     "@opentelemetry/semantic-conventions": "^1.36.0",
-    "@ory/client-fetch": "^1.22.37",
+    "@ory/client-fetch": "1.22.22",
     "@ory/elements-react": "^1.2.0",
     "@ory/nextjs": "^1.0.0-rc.1",
     "@radix-ui/react-avatar": "^1.1.4",

--- a/patches/@ory%2Fnextjs@1.0.0-rc.1.patch
+++ b/patches/@ory%2Fnextjs@1.0.0-rc.1.patch
@@ -1,0 +1,96 @@
+diff --git a/dist/app/index.js b/dist/app/index.js
+index d4ade92a6897ee5f111619b7daf0b6d0a761fded..be1017937cb9a72dbe66eec797336494465c5578 100644
+--- a/dist/app/index.js
++++ b/dist/app/index.js
+@@ -30,6 +30,9 @@ function isProduction() {
+   return ["production", "prod"].indexOf(env) > -1;
+ }
+ function guessPotentiallyProxiedOrySdkUrl(options) {
++  if (options == null ? void 0 : options.knownProxiedUrl) {
++    return options.knownProxiedUrl.replace(/\/$/, "");
++  }
+   if (getEnv("VERCEL_ENV")) {
+     if (!isProduction() && getEnv("VERCEL_URL")) {
+       return `https://${getEnv("VERCEL_URL")}`.replace(/\/$/, "");
+@@ -48,9 +51,6 @@ function guessPotentiallyProxiedOrySdkUrl(options) {
+   if (typeof window !== "undefined") {
+     return window.location.origin;
+   }
+-  if (options == null ? void 0 : options.knownProxiedUrl) {
+-    return options.knownProxiedUrl;
+-  }
+   const final = orySdkUrl();
+   console.warn(
+     `Unable to determine a suitable SDK URL for setting up the Next.js integration of Ory Elements. Will proceed using default Ory SDK URL "${final}". This is likely not what you want for local development and your authentication and login may not work.`
+diff --git a/dist/app/index.mjs b/dist/app/index.mjs
+index da6b25477c72c6e828734a05ede2979dc7fca911..913f32fec4718dfae9e8e31f25bac11c4ded2df1 100644
+--- a/dist/app/index.mjs
++++ b/dist/app/index.mjs
+@@ -28,6 +28,9 @@ function isProduction() {
+   return ["production", "prod"].indexOf(env) > -1;
+ }
+ function guessPotentiallyProxiedOrySdkUrl(options) {
++  if (options == null ? void 0 : options.knownProxiedUrl) {
++    return options.knownProxiedUrl.replace(/\/$/, "");
++  }
+   if (getEnv("VERCEL_ENV")) {
+     if (!isProduction() && getEnv("VERCEL_URL")) {
+       return `https://${getEnv("VERCEL_URL")}`.replace(/\/$/, "");
+@@ -46,9 +49,6 @@ function guessPotentiallyProxiedOrySdkUrl(options) {
+   if (typeof window !== "undefined") {
+     return window.location.origin;
+   }
+-  if (options == null ? void 0 : options.knownProxiedUrl) {
+-    return options.knownProxiedUrl;
+-  }
+   const final = orySdkUrl();
+   console.warn(
+     `Unable to determine a suitable SDK URL for setting up the Next.js integration of Ory Elements. Will proceed using default Ory SDK URL "${final}". This is likely not what you want for local development and your authentication and login may not work.`
+diff --git a/dist/pages/index.js b/dist/pages/index.js
+index a0a69f2a5e60d2e2a0b78bf35bec9715506543ad..b6cec5e8b455e38a8b1d8bd634bbe59e61ab1453 100644
+--- a/dist/pages/index.js
++++ b/dist/pages/index.js
+@@ -26,6 +26,9 @@ function isProduction() {
+   return ["production", "prod"].indexOf(env) > -1;
+ }
+ function guessPotentiallyProxiedOrySdkUrl(options) {
++  if (options == null ? void 0 : options.knownProxiedUrl) {
++    return options.knownProxiedUrl.replace(/\/$/, "");
++  }
+   if (getEnv("VERCEL_ENV")) {
+     if (!isProduction() && getEnv("VERCEL_URL")) {
+       return `https://${getEnv("VERCEL_URL")}`.replace(/\/$/, "");
+@@ -44,9 +47,6 @@ function guessPotentiallyProxiedOrySdkUrl(options) {
+   if (typeof window !== "undefined") {
+     return window.location.origin;
+   }
+-  if (options == null ? void 0 : options.knownProxiedUrl) {
+-    return options.knownProxiedUrl;
+-  }
+   const final = orySdkUrl();
+   console.warn(
+     `Unable to determine a suitable SDK URL for setting up the Next.js integration of Ory Elements. Will proceed using default Ory SDK URL "${final}". This is likely not what you want for local development and your authentication and login may not work.`
+diff --git a/dist/pages/index.mjs b/dist/pages/index.mjs
+index e3d4d2f4ca5c685439065c23dd23acd1ee05ca66..9e4ad2be788efd2c3210ec385e07e98308e8b758 100644
+--- a/dist/pages/index.mjs
++++ b/dist/pages/index.mjs
+@@ -24,6 +24,9 @@ function isProduction() {
+   return ["production", "prod"].indexOf(env) > -1;
+ }
+ function guessPotentiallyProxiedOrySdkUrl(options) {
++  if (options == null ? void 0 : options.knownProxiedUrl) {
++    return options.knownProxiedUrl.replace(/\/$/, "");
++  }
+   if (getEnv("VERCEL_ENV")) {
+     if (!isProduction() && getEnv("VERCEL_URL")) {
+       return `https://${getEnv("VERCEL_URL")}`.replace(/\/$/, "");
+@@ -42,9 +45,6 @@ function guessPotentiallyProxiedOrySdkUrl(options) {
+   if (typeof window !== "undefined") {
+     return window.location.origin;
+   }
+-  if (options == null ? void 0 : options.knownProxiedUrl) {
+-    return options.knownProxiedUrl;
+-  }
+   const final = orySdkUrl();
+   console.warn(
+     `Unable to determine a suitable SDK URL for setting up the Next.js integration of Ory Elements. Will proceed using default Ory SDK URL "${final}". This is likely not what you want for local development and your authentication and login may not work.`

--- a/patches/@ory%2Fnextjs@1.0.0-rc.1.patch
+++ b/patches/@ory%2Fnextjs@1.0.0-rc.1.patch
@@ -1,3 +1,6 @@
+diff --git a/node_modules/@ory/nextjs/.bun-tag-4620342893fd8e80 b/.bun-tag-4620342893fd8e80
+new file mode 100644
+index 0000000000000000000000000000000000000000..e69de29bb2d1d6434b8b29ae775ad8c2e48c5391
 diff --git a/dist/app/index.js b/dist/app/index.js
 index d4ade92a6897ee5f111619b7daf0b6d0a761fded..be1017937cb9a72dbe66eec797336494465c5578 100644
 --- a/dist/app/index.js
@@ -46,6 +49,34 @@ index da6b25477c72c6e828734a05ede2979dc7fca911..913f32fec4718dfae9e8e31f25bac11c
    const final = orySdkUrl();
    console.warn(
      `Unable to determine a suitable SDK URL for setting up the Next.js integration of Ory Elements. Will proceed using default Ory SDK URL "${final}". This is likely not what you want for local development and your authentication and login may not work.`
+diff --git a/dist/middleware/index.js b/dist/middleware/index.js
+index 3dc57477f09be6e5407ecf1cf8f89cd5a4862e03..f6038473c6590603e2d777edf963a6da9639cd10 100644
+--- a/dist/middleware/index.js
++++ b/dist/middleware/index.js
+@@ -146,7 +146,8 @@ async function proxyRequest(request, options) {
+     "/sessions/whoami",
+     "/ui",
+     "/.well-known/ory",
+-    "/.ory"
++    "/.ory",
++    "/oauth2/auth"
+   ];
+   if (!match.some((m) => request.nextUrl.pathname.startsWith(m))) {
+     return server.NextResponse.next();
+diff --git a/dist/middleware/index.mjs b/dist/middleware/index.mjs
+index f82e94752a7443354ade6b118624d28d83494dfa..e23bcb554c97df68acdf946c61b05fde6d95d350 100644
+--- a/dist/middleware/index.mjs
++++ b/dist/middleware/index.mjs
+@@ -144,7 +144,8 @@ async function proxyRequest(request, options) {
+     "/sessions/whoami",
+     "/ui",
+     "/.well-known/ory",
+-    "/.ory"
++    "/.ory",
++    "/oauth2/auth"
+   ];
+   if (!match.some((m) => request.nextUrl.pathname.startsWith(m))) {
+     return NextResponse.next();
 diff --git a/dist/pages/index.js b/dist/pages/index.js
 index a0a69f2a5e60d2e2a0b78bf35bec9715506543ad..b6cec5e8b455e38a8b1d8bd634bbe59e61ab1453 100644
 --- a/dist/pages/index.js

--- a/patches/@ory%2Fnextjs@1.0.0-rc.1.patch
+++ b/patches/@ory%2Fnextjs@1.0.0-rc.1.patch
@@ -1,6 +1,3 @@
-diff --git a/node_modules/@ory/nextjs/.bun-tag-4620342893fd8e80 b/.bun-tag-4620342893fd8e80
-new file mode 100644
-index 0000000000000000000000000000000000000000..e69de29bb2d1d6434b8b29ae775ad8c2e48c5391
 diff --git a/dist/app/index.js b/dist/app/index.js
 index d4ade92a6897ee5f111619b7daf0b6d0a761fded..be1017937cb9a72dbe66eec797336494465c5578 100644
 --- a/dist/app/index.js

--- a/src/app/api/auth/oauth/start/route.ts
+++ b/src/app/api/auth/oauth/start/route.ts
@@ -1,3 +1,4 @@
+import { redirect } from 'next/navigation'
 import { NextResponse } from 'next/server'
 import { signIn } from '@/auth'
 import {
@@ -44,5 +45,9 @@ export async function GET(request: Request) {
       ? await rewriteAuthorizeToVisitingOrigin(destination)
       : destination
 
-  return NextResponse.redirect(target)
+  // Use next/navigation redirect (not NextResponse.redirect) so the Set-Cookie
+  // headers signIn wrote via next/headers cookies() — Auth.js state/PKCE — are
+  // flushed onto the redirect. NextResponse.redirect() drops them, which breaks
+  // the callback (error=Configuration / "cookie doesn't stick").
+  redirect(typeof target === 'string' ? target : redirectTo)
 }

--- a/src/app/api/auth/oauth/start/route.ts
+++ b/src/app/api/auth/oauth/start/route.ts
@@ -6,6 +6,7 @@ import {
   readOryAuthIntent,
   shouldCaptureOrySignupMetadata,
 } from '@/core/server/auth/ory/build-start-url'
+import { rewriteAuthorizeToVisitingOrigin } from '@/core/server/auth/ory/same-origin-oauth'
 import {
   readOrySignupMetadataFromHeaders,
   setOrySignupMetadataCookie,
@@ -30,5 +31,18 @@ export async function GET(request: Request) {
     )
   }
 
-  await signIn('ory', { redirectTo }, authorizationParamsForOryIntent(intent))
+  // redirect:false so we get the authorize URL back (cookies are still set) and
+  // can keep it on the visiting origin for the custom same-origin UI.
+  const destination = await signIn(
+    'ory',
+    { redirectTo, redirect: false },
+    authorizationParamsForOryIntent(intent)
+  )
+
+  const target =
+    typeof destination === 'string'
+      ? await rewriteAuthorizeToVisitingOrigin(destination)
+      : destination
+
+  return NextResponse.redirect(target)
 }

--- a/src/core/server/auth/ory/same-origin-oauth.ts
+++ b/src/core/server/auth/ory/same-origin-oauth.ts
@@ -1,0 +1,50 @@
+import 'server-only'
+
+import { headers } from 'next/headers'
+import { isOryCustomUiEnabled } from '@/configs/flags'
+
+// Keep the Hydra OAuth2 authorize leg on the *visiting* origin so its login_ui_url
+// redirect is rewritten back here (by the same-origin @ory/nextjs proxy) instead
+// of hopping to the Ory custom domain (e.g. auth.e2b-staging.dev/login).
+//
+// Auth.js sends the browser to the provider's authorization_endpoint, which is
+// discovered from `issuer` (= the Ory SDK base). On Ory Network, Kratos AND
+// Hydra share that single base (NEXT_PUBLIC_ORY_SDK_URL), so the dashboard can
+// proxy `/oauth2/auth` same-origin and rewrite the login redirect. Locally,
+// Kratos and Hydra are split across different ports, so the authorize host won't
+// match the proxy upstream — we leave the URL untouched and local sign-in keeps
+// working via the local Ory config (which already points login at the dashboard).
+//
+// Only the authorize *host* is rewritten; client_id / redirect_uri / state are
+// preserved, and the server-side token exchange still hits the real Ory base.
+export async function rewriteAuthorizeToVisitingOrigin(
+  authorizeUrl: string
+): Promise<string> {
+  if (!isOryCustomUiEnabled()) return authorizeUrl
+
+  const sdkBase = process.env.NEXT_PUBLIC_ORY_SDK_URL
+  if (!sdkBase) return authorizeUrl
+
+  let target: URL
+  let upstream: URL
+  try {
+    target = new URL(authorizeUrl)
+    upstream = new URL(sdkBase)
+  } catch {
+    return authorizeUrl
+  }
+
+  // Only rewrite when the authorize endpoint is served by the base the proxy
+  // forwards to, and only for the OAuth2 authorize path.
+  if (target.host !== upstream.host) return authorizeUrl
+  if (!target.pathname.startsWith('/oauth2/auth')) return authorizeUrl
+
+  const requestHeaders = await headers()
+  const host = requestHeaders.get('host')
+  if (!host) return authorizeUrl
+  const proto = requestHeaders.get('x-forwarded-proto') ?? 'https'
+
+  target.protocol = `${proto}:`
+  target.host = host
+  return target.toString()
+}

--- a/src/core/server/proxy/runtime.ts
+++ b/src/core/server/proxy/runtime.ts
@@ -28,14 +28,20 @@ type RunProxyOptions = {
   isAuthenticated?: boolean
 }
 
-// Same-origin paths the @ory/nextjs proxy forwards to Kratos (NEXT_PUBLIC_ORY_SDK_URL),
-// so the custom UI's flow cookies stay first-party.
+// Same-origin paths the @ory/nextjs proxy forwards to the Ory base
+// (NEXT_PUBLIC_ORY_SDK_URL), so the custom UI's flow cookies stay first-party.
+// `/oauth2/auth` is the Hydra authorize leg: proxying it keeps the OAuth2 login
+// on the visiting origin (the proxy rewrites Hydra's login_ui_url redirect back
+// here) instead of hopping to the Ory custom domain. On Ory Network Kratos +
+// Hydra share one base, so this resolves correctly; locally the authorize host
+// never points here (see same-origin-oauth.ts), so this prefix stays inert.
 const ORY_SDK_PROXY_PREFIXES = [
   '/self-service',
   '/sessions/whoami',
   '/ui',
   '/.well-known/ory',
   '/.ory',
+  '/oauth2/auth',
 ]
 
 // Pass oryConfig.project so the middleware rewrites Kratos redirects onto our UI URLs.


### PR DESCRIPTION
## What

Adds the `@ory/nextjs` preview-host patch that #428 intentionally deferred. Reorders `guessPotentiallyProxiedOrySdkUrl` to honor `knownProxiedUrl` (the per-request host, already supplied via the package's `getPublicUrl()`) **before** the `VERCEL_ENV`/`VERCEL_URL` branch, and strips trailing slashes — across `dist/app` and `dist/pages`.

## Why

The custom Ory Elements flow pages render the login/registration/recovery/verification flows **same-origin**. On a **Vercel preview deployment**, the unpatched helper prefers the static `VERCEL_URL` over the request host, so the same-origin `/self-service/*` POSTs (and their Kratos flow cookies) target the deployment URL instead of the ephemeral preview origin the user is on — breaking the flow. The patch makes the visiting origin win.

## Scope / safety

- Patch is **inert unless the custom UI is enabled** (`NEXT_PUBLIC_ORY_CUSTOM_UI=true`), since only the gated flow pages call the patched helper. **Production (flag unset) is unaffected.**
- Diff is just the patch file + `patchedDependencies` registration + lockfile. No source changes.
- `bun install` applied cleanly; all unit tests pass (287/287).

## Rollout

For previews to actually route to the custom UI, this must land together with the terraform `enable_custom_auth_ui` flag and `NEXT_PUBLIC_ORY_CUSTOM_UI=true` + `NEXT_PUBLIC_ORY_SDK_URL` set on the Preview/Staging envs. Staging is a stable alias and doesn't strictly need the patch; **ephemeral previews do.**

Follow-up to #428.