### PR TITLE
fix(auth): make AuthUser.id the public.users.id and add identity_id

### DIFF
--- a/src/core/modules/auth/models.ts
+++ b/src/core/modules/auth/models.ts
@@ -2,7 +2,7 @@ export type AuthUser = {
   // public.users.id, sourced from the Kratos identity's external_id.
   id: string
   // Ory Kratos identity id (the OAuth2 subject).
-  identity_id: string
+  identityId: string
   email: string | null
   name: string | null
   avatarUrl: string | null

--- a/src/core/modules/auth/models.ts
+++ b/src/core/modules/auth/models.ts
@@ -1,5 +1,8 @@
 export type AuthUser = {
+  // public.users.id, sourced from the Kratos identity's external_id.
   id: string
+  // Ory Kratos identity id (the OAuth2 subject).
+  identity_id: string
   email: string | null
   name: string | null
   avatarUrl: string | null

--- a/src/core/server/auth/ory/authjs-boundary.ts
+++ b/src/core/server/auth/ory/authjs-boundary.ts
@@ -43,8 +43,9 @@ export type OryAuthJsJwt = JWT & {
   idToken?: string
   // Kratos identity id resolved at sign-in for admin IdentityApi operations.
   identityId?: string
-  // public.users.id, read from the access token's external_id claim. This is
-  // the dashboard AuthUser.id; token.sub stays the Kratos identity id.
+  // public.users.id, sourced from the Kratos identity's external_id (Hydra does
+  // not project it into the access token). This is the dashboard AuthUser.id;
+  // token.sub stays the Kratos identity id.
   externalId?: string
   // Bounds the per-request Kratos lookups used to backfill a missing externalId
   // (e.g. on sessions that predate this field).

--- a/src/core/server/auth/ory/authjs-boundary.ts
+++ b/src/core/server/auth/ory/authjs-boundary.ts
@@ -43,6 +43,12 @@ export type OryAuthJsJwt = JWT & {
   idToken?: string
   // Kratos identity id resolved at sign-in for admin IdentityApi operations.
   identityId?: string
+  // public.users.id, read from the access token's external_id claim. This is
+  // the dashboard AuthUser.id; token.sub stays the Kratos identity id.
+  externalId?: string
+  // Bounds the per-request Kratos lookups used to backfill a missing externalId
+  // (e.g. on sessions that predate this field).
+  externalIdResolveAttempts?: number
   // Auth.js absolute expiration timestamp, in seconds.
   expiresAt?: number | null
   error?: string

--- a/src/core/server/auth/ory/authjs-callbacks.ts
+++ b/src/core/server/auth/ory/authjs-callbacks.ts
@@ -46,6 +46,11 @@ const ACCESS_TOKEN_REFRESH_SKEW_SECONDS = 60
 
 const BOOTSTRAP_FAILURE_COOKIE_MAX_AGE_SECONDS = 60
 
+// external_id is read from the Kratos identity at sign-in (after bootstrap), so
+// it is normally already on the token. This caps the per-request Kratos
+// re-resolution used to backfill sessions that predate the externalId field.
+const MAX_EXTERNAL_ID_RESOLVE_ATTEMPTS = 1
+
 // Implements the Auth.js `signIn` callback. This is intentionally a callback,
 // not an event: returning a URL here denies the sign-in before Auth.js finalizes
 // the new session cookie. On failure, we hand the id_token to a local route via
@@ -112,7 +117,37 @@ export async function persistOryTokensInAuthJsJwt(
     return refreshOryToken(token)
   }
 
+  if (shouldResolveExternalId(token)) {
+    return resolveExternalIdFromKratos(token)
+  }
+
   return token
+}
+
+// True when external_id is still missing but we have a Kratos identity to look
+// it up against and remaining budget. Normally external_id is already on the
+// token from sign-in; this backfills sessions that predate the field.
+function shouldResolveExternalId(token: OryAuthJsJwt): boolean {
+  return (
+    !token.externalId &&
+    !!token.identityId &&
+    (token.externalIdResolveAttempts ?? 0) < MAX_EXTERNAL_ID_RESOLVE_ATTEMPTS
+  )
+}
+
+// Hydra does not project external_id into the access token, so we re-read it
+// from the Kratos identity rather than refreshing the OAuth token.
+async function resolveExternalIdFromKratos(
+  token: OryAuthJsJwt
+): Promise<OryAuthJsJwt> {
+  const identity = token.identityId
+    ? await resolveOryIdentity({ subjects: [token.identityId] })
+    : null
+  return {
+    ...token,
+    externalId: identity?.external_id ?? token.externalId,
+    externalIdResolveAttempts: (token.externalIdResolveAttempts ?? 0) + 1,
+  }
 }
 
 // Implements the Auth.js `session` callback: project the persisted token fields
@@ -122,10 +157,13 @@ export function projectOryJwtToAuthJsSession({
   token,
 }: OryAuthJsSessionInput) {
   const orySession = session as OryInternalAuthJsSession
-  orySession.user.id = token.sub ?? orySession.user.id
+  // AuthUser.id is the public.users.id (external_id). token.sub stays the
+  // Kratos identity id, surfaced as identityId for admin/OAuth operations.
+  orySession.user.id = token.externalId ?? token.sub ?? orySession.user.id
   orySession.accessToken = token.accessToken
   orySession.idToken = token.idToken
-  orySession.identityId = token.identityId
+  orySession.identityId = token.identityId ?? token.sub
+  orySession.externalId = token.externalId
   orySession.error = token.error
   return orySession
 }
@@ -143,7 +181,11 @@ async function buildSignInToken(
     ...token,
     sub: userId,
   }
-  const identityId = await resolveKratosIdentityId(nextToken, account, profile)
+  const { identityId, externalId } = await resolveKratosIdentity(
+    nextToken,
+    account,
+    profile
+  )
 
   await persistOrySignupMetadataFromCookie(identityId)
 
@@ -154,27 +196,32 @@ async function buildSignInToken(
     idToken: account.id_token,
     expiresAt: account.expires_at ?? null,
     identityId,
+    externalId,
+    externalIdResolveAttempts: 0,
     error: undefined,
   }
 }
 
-// The Kratos identity id is NOT the OIDC subject the dashboard uses as the E2B
-// user id (`token.sub`, consumed by dashboard-api and infra). It is surfaced via
-// the OIDC profile `sub`. Resolve it once at sign-in — by profile.sub, then
-// token.sub, then the verified email — so account operations can use a stable
-// Kratos id without a per-request lookup. Returns undefined on failure; the
-// provider then falls back to a per-request lookup, so sign-in is never blocked.
-async function resolveKratosIdentityId(
+// Resolve the Kratos identity once at sign-in — by profile.sub, then token.sub,
+// then the verified email. We read two things off it:
+//   - `id`: the Kratos identity id (the OAuth2 subject), used for admin and
+//     Hydra operations without a per-request lookup.
+//   - `external_id`: the dashboard public.users.id. Hydra does not project this
+//     into the OAuth2 access token, so the Kratos identity is the source of
+//     truth. Bootstrap (in the signIn callback) sets it before this runs, so it
+//     is present even for brand-new users. Returns undefined on failure; the
+//     provider falls back to per-request lookups, so sign-in is never blocked.
+async function resolveKratosIdentity(
   token: OryAuthJsJwt,
   account: OryAuthJsAccount,
   profile: OryAuthJsJwtInput['profile']
-): Promise<string | undefined> {
+): Promise<{ identityId?: string; externalId?: string }> {
   const identity = await resolveOryIdentity({
     subjects: [readOryProfileSubject(profile), token.sub],
     email: readOryEmailClaim(account),
   })
 
-  return identity?.id
+  return { identityId: identity?.id, externalId: identity?.external_id }
 }
 
 async function prepareBootstrapFailureRedirect(

--- a/src/core/server/auth/ory/authjs-callbacks.ts
+++ b/src/core/server/auth/ory/authjs-callbacks.ts
@@ -113,40 +113,54 @@ export async function persistOryTokensInAuthJsJwt(
     return token
   }
 
-  if (isAccessTokenExpiring(token)) {
-    return refreshOryToken(token)
+  let next = token
+  if (isAccessTokenExpiring(next)) {
+    next = await refreshOryToken(next)
+    if (next.error) return next
   }
 
-  if (shouldResolveExternalId(token)) {
-    return resolveExternalIdFromKratos(token)
+  // Resolve external_id on the same tick as a refresh so a legacy session is
+  // never left half-authenticated for a request.
+  if (shouldResolveExternalId(next)) {
+    next = await resolveExternalIdFromKratos(next)
   }
 
-  return token
+  return next
 }
 
-// True when external_id is still missing but we have a Kratos identity to look
-// it up against and remaining budget. Normally external_id is already on the
-// token from sign-in; this backfills sessions that predate the field.
+// True when external_id is still missing but we have a subject to look it up
+// against and remaining budget. Normally external_id is already on the token
+// from sign-in; this backfills sessions that predate the field.
 function shouldResolveExternalId(token: OryAuthJsJwt): boolean {
   return (
     !token.externalId &&
-    !!token.identityId &&
+    !!(token.identityId ?? token.sub) &&
     (token.externalIdResolveAttempts ?? 0) < MAX_EXTERNAL_ID_RESOLVE_ATTEMPTS
   )
 }
 
 // Hydra does not project external_id into the access token, so we re-read it
-// from the Kratos identity rather than refreshing the OAuth token.
+// from the Kratos identity rather than refreshing the OAuth token. The Kratos
+// id may be stored as identityId or, on older tokens, only as the sub.
 async function resolveExternalIdFromKratos(
   token: OryAuthJsJwt
 ): Promise<OryAuthJsJwt> {
-  const identity = token.identityId
-    ? await resolveOryIdentity({ subjects: [token.identityId] })
-    : null
+  const identity = await resolveOryIdentity({
+    subjects: [token.identityId, token.sub],
+  })
+
+  if (identity?.external_id) {
+    return { ...token, externalId: identity.external_id }
+  }
+
+  // Only spend budget on a definitive outcome (identity resolved but has no
+  // external_id). A null identity is likely a transient Kratos failure
+  // (find-identity swallows non-404s), so leave the budget to retry next tick.
   return {
     ...token,
-    externalId: identity?.external_id ?? token.externalId,
-    externalIdResolveAttempts: (token.externalIdResolveAttempts ?? 0) + 1,
+    externalIdResolveAttempts: identity
+      ? (token.externalIdResolveAttempts ?? 0) + 1
+      : (token.externalIdResolveAttempts ?? 0),
   }
 }
 

--- a/src/core/server/auth/ory/authjs-session-boundary.ts
+++ b/src/core/server/auth/ory/authjs-session-boundary.ts
@@ -11,6 +11,7 @@ export type OrySessionFields = {
   accessToken?: string
   idToken?: string
   identityId?: string
+  externalId?: string
   error?: string
 }
 
@@ -24,6 +25,7 @@ const ORY_TOKEN_SESSION_KEYS = [
   'idToken',
   'refreshToken',
   'identityId',
+  'externalId',
 ] as const
 
 export function readOrySessionFields(
@@ -36,6 +38,7 @@ export function readOrySessionFields(
     accessToken: internalSession.accessToken,
     idToken: internalSession.idToken,
     identityId: internalSession.identityId,
+    externalId: internalSession.externalId,
     error: internalSession.error,
   }
 }

--- a/src/core/server/auth/ory/authjs-session-boundary.ts
+++ b/src/core/server/auth/ory/authjs-session-boundary.ts
@@ -47,7 +47,15 @@ export function isOrySessionAuthenticated(
   session: Session | null | undefined
 ): boolean {
   const fields = readOrySessionFields(session)
-  return !!session?.user?.id && !!fields?.accessToken && !fields.error
+  // externalId is required to mirror getAuthContextFromOrySession: without it
+  // the proxy and the server-side auth context would disagree and loop a
+  // half-authenticated user between /sign-in and /dashboard.
+  return (
+    !!session?.user?.id &&
+    !!fields?.accessToken &&
+    !!fields.externalId &&
+    !fields.error
+  )
 }
 
 export function withSanitizedOryAuthJsHandler(

--- a/src/core/server/auth/ory/identity.ts
+++ b/src/core/server/auth/ory/identity.ts
@@ -3,6 +3,7 @@ import 'server-only'
 import type { Identity } from '@ory/client-fetch'
 import type { Session } from 'next-auth'
 import type { AuthUser } from '../types'
+import { readOrySessionFields } from './authjs-session-boundary'
 
 type FromOryIdentityOptions = {
   userId?: string
@@ -12,8 +13,10 @@ type FromOryIdentityOptions = {
 // at request time by getAuthContext. `providers` is empty because the session
 // doesn't carry credential info — use fromOryIdentity when that's needed.
 export function fromAuthSession(session: Session): AuthUser {
+  const identityId = readOrySessionFields(session)?.identityId
   return {
     id: session.user.id,
+    identity_id: identityId ?? session.user.id,
     email: session.user.email ?? null,
     name: session.user.name ?? null,
     avatarUrl: session.user.image ?? null,
@@ -43,7 +46,8 @@ export function fromOryIdentity(
   const canChangePassword = hasPasswordCredential && !hasOidcCredential
 
   return {
-    id: options.userId ?? identity.id,
+    id: identity.external_id ?? options.userId ?? identity.id,
+    identity_id: identity.id,
     email,
     name,
     avatarUrl,

--- a/src/core/server/auth/ory/identity.ts
+++ b/src/core/server/auth/ory/identity.ts
@@ -16,7 +16,7 @@ export function fromAuthSession(session: Session): AuthUser {
   const identityId = readOrySessionFields(session)?.identityId
   return {
     id: session.user.id,
-    identity_id: identityId ?? session.user.id,
+    identityId: identityId ?? session.user.id,
     email: session.user.email ?? null,
     name: session.user.name ?? null,
     avatarUrl: session.user.image ?? null,
@@ -47,7 +47,7 @@ export function fromOryIdentity(
 
   return {
     id: identity.external_id ?? options.userId ?? identity.id,
-    identity_id: identity.id,
+    identityId: identity.id,
     email,
     name,
     avatarUrl,

--- a/src/core/server/auth/ory/session.ts
+++ b/src/core/server/auth/ory/session.ts
@@ -88,22 +88,12 @@ export async function updateUser(
     )
   }
 
-  const result = await oryAuthFlows.updateUser({
+  return oryAuthFlows.updateUser({
     identityId,
     name: input.name,
     email: input.email,
     password: input.password,
   })
-
-  if (!result.ok) return result
-
-  return {
-    ...result,
-    user: {
-      ...result.user,
-      id: session.user.id,
-    },
-  }
 }
 
 export async function startReauthForAccountSettings(): Promise<ReauthDispatch> {
@@ -118,10 +108,11 @@ export async function handleCredentialChangeSuccess(
   const session = await readCurrentSession(authSession)
   if (!session?.user?.id) return
 
-  await revokeOryOAuthSessionsForSubject(session.user.id)
-
+  // Hydra's OAuth2 subject is the Kratos identity id, not AuthUser.id, so both
+  // revocations key off the resolved identity id.
   const identityId = await resolveIdentityId(session)
   if (identityId) {
+    await revokeOryOAuthSessionsForSubject(identityId)
     await revokeKratosSessionsForIdentity(identityId)
   }
 
@@ -154,6 +145,20 @@ export function getAuthContextFromOrySession(
         context: { error: serverFields.error },
       },
       `Auth.js session reports error '${serverFields.error}'; treating as unauthenticated`
+    )
+    return null
+  }
+
+  // Without external_id we cannot resolve the public.users.id; the jwt callback
+  // has already tried to backfill it from Kratos, so force a re-auth rather than
+  // expose the Kratos identity id as AuthUser.id.
+  if (!serverFields.externalId) {
+    l.warn(
+      {
+        key: 'auth_provider:ory_session_missing_external_id',
+        user_id: session.user.id,
+      },
+      'Auth.js session has no external_id; treating as unauthenticated'
     )
     return null
   }

--- a/src/core/server/auth/ory/signout-flow.ts
+++ b/src/core/server/auth/ory/signout-flow.ts
@@ -10,13 +10,11 @@ import { ORY_POST_LOGOUT_PATH } from './signout'
 
 export async function completeOrySignOut(origin = BASE_URL): Promise<string> {
   let identityId: string | undefined
-  let userId: string | undefined
   try {
     const session = await auth()
     const serverFields = readOrySessionFields(session)
-    userId = session?.user?.id
-    // The Kratos identity id resolved at sign-in — NOT the OIDC subject (which
-    // is the E2B user id) — so we revoke the right identity's Kratos sessions.
+    // Hydra's OAuth2 subject and Kratos both key off the identity id, not
+    // AuthUser.id (which is the public.users.id / external_id).
     identityId = serverFields?.identityId
   } catch (error) {
     l.warn(
@@ -45,7 +43,7 @@ export async function completeOrySignOut(origin = BASE_URL): Promise<string> {
   // log-and-swallow their own errors, and the Kratos helper retries 429
   // contention, so Promise.all never rejects here.
   await Promise.all([
-    userId ? revokeOryOAuthSessionsForSubject(userId) : null,
+    identityId ? revokeOryOAuthSessionsForSubject(identityId) : null,
     identityId ? revokeKratosSessionsForIdentity(identityId) : null,
   ])
 

--- a/tests/integration/auth-ory-account-security.test.ts
+++ b/tests/integration/auth-ory-account-security.test.ts
@@ -127,7 +127,7 @@ describe('Ory account security', () => {
 
     await handleCredentialChangeSuccess()
 
-    expect(revokeOAuthSessionsMock).toHaveBeenCalledWith('e2b-user-id')
+    expect(revokeOAuthSessionsMock).toHaveBeenCalledWith('kratos-uuid')
     expect(revokeKratosSessionsMock).toHaveBeenCalledWith('kratos-uuid')
     expect(authjsSignOutMock).toHaveBeenCalledWith({ redirect: false })
   })

--- a/tests/unit/user-router.test.ts
+++ b/tests/unit/user-router.test.ts
@@ -26,7 +26,7 @@ const createCaller = createCallerFactory(userRouter)
 
 const authUser = {
   id: 'user-1',
-  identity_id: 'identity-1',
+  identityId: 'identity-1',
   email: 'old@example.test',
   name: 'Ada',
   avatarUrl: null,

--- a/tests/unit/user-router.test.ts
+++ b/tests/unit/user-router.test.ts
@@ -26,6 +26,7 @@ const createCaller = createCallerFactory(userRouter)
 
 const authUser = {
   id: 'user-1',
+  identity_id: 'identity-1',
   email: 'old@example.test',
   name: 'Ada',
   avatarUrl: null,


### PR DESCRIPTION
## Problem

`AuthUser.id` resolved to the Ory **Kratos identity id** (the OAuth2 subject) instead of the dashboard **public.users.id**. As a result:

- PostHog `identify(user.id)` registered the Kratos id, not the public user id.
- tRPC telemetry `user_id`, LaunchDarkly targeting key, terminal/sandbox metadata, and the team **"is current user"** check (`member.info.id === user.id`) all compared against the wrong id namespace.

## Change

Split `AuthUser` into two ids:

- `id` -> `public.users.id`, sourced from the Kratos identity's `external_id`
- `identity_id` -> the Kratos identity id

### Where `external_id` comes from

We confirmed via the live token that the **Hydra OAuth2 access token does not carry `external_id`** (its `ext` claim is empty, no token webhook configured). The only source of truth today is the **Kratos identity** (`identity.external_id`), which we already resolve at sign-in. Bootstrap runs in the `signIn` callback before the `jwt` callback, so `external_id` is present even for brand-new users, no token refresh needed.