### PR TITLE
fix: polish tags tab header spacing

### DIFF
--- a/src/features/dashboard/templates/tags/header.tsx
+++ b/src/features/dashboard/templates/tags/header.tsx
@@ -45,7 +45,7 @@ export default function TagsHeader({
   )
 
   return (
-    <div className="flex flex-col gap-3">
+    <div className="flex flex-col gap-6">
       <div className="flex items-center gap-2 justify-between">
         <div className="w-full max-w-70">
           <label
@@ -97,7 +97,7 @@ export default function TagsHeader({
             rel="noopener"
             className="underline-offset-2 underline hover:text-fg transition-colors"
           >
-            Read more
+            Read&nbsp;more
           </a>
           .
         </p>


### PR DESCRIPTION
| Before | After |
| ------- | ------- |
| <img width="1832" height="672" alt="CleanShot 2026-06-23 at 16 42 00@2x" src="https://github.com/user-attachments/assets/1b47e5dc-7021-4a44-a4ce-f2e07722d084" /> | <img width="1828" height="516" alt="CleanShot 2026-06-23 at 16 41 53@2x" src="https://github.com/user-attachments/assets/7874a11c-f6a5-4412-8d47-7b3a041c2f4a" /> |
  