### PR TITLE
feat: avoid nav item icon animation

### DIFF
--- a/src/features/dashboard/sidebar/content.tsx
+++ b/src/features/dashboard/sidebar/content.tsx
@@ -86,7 +86,7 @@ export default function DashboardSidebarContent() {
                     >
                       <item.icon
                         className={cn(
-                          'transition-[size,color]',
+                          'transition-[size]',
                           SIDEBAR_TRANSITION_CLASSNAMES,
                           isActive(item) && 'text-accent-main-highlight'
                         )}


### PR DESCRIPTION
Avoid icon animation in sidebar nav item so it's synced with instant label color change.
| Before | After |
| ------- | ------- |
| <img width="200" alt="CleanShot 2026-06-24 at 14 00 42" src="https://github.com/user-attachments/assets/8968e119-5d30-41f0-a492-c0eb2e9ca093" /> | <img width="200" alt="CleanShot 2026-06-24 at 14 00 17" src="https://github.com/user-attachments/assets/f26db41e-129b-4531-8356-b820c0d13ceb" /> |

