### PR TITLE
fix: add collision padding to tooltips for safe viewport margins

### DIFF
--- a/src/ui/primitives/tooltip.tsx
+++ b/src/ui/primitives/tooltip.tsx
@@ -38,6 +38,7 @@ function TooltipTrigger({
 function TooltipContent({
   className,
   sideOffset = 4,
+  collisionPadding = 8,
   children,
   ...props
 }: React.ComponentProps<typeof TooltipPrimitive.Content>) {
@@ -46,6 +47,7 @@ function TooltipContent({
       <TooltipPrimitive.Content
         data-slot="tooltip-content"
         sideOffset={sideOffset}
+        collisionPadding={collisionPadding}
         className={cn(
           cardVariants({ variant: 'layer' }),
           'border-stroke-active text-fg animate-in fade-in-0 zoom-in-95 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-[999] overflow-hidden  border px-3 py-1.5 ',


### PR DESCRIPTION
Adds a default `collisionPadding` of 8px to the `TooltipContent` primitive so tooltips keep a safe margin from viewport edges instead of rendering flush against them. This matches the existing convention in `popover.tsx` and `dropdown-menu.tsx`, which already default `collisionPadding`. The value remains overridable per-usage.

Closes EN-653.

🤖 Generated with [Claude Code](https://claude.com/claude-code)