### PR TITLE
fix: prevent copy button overlapping E2B badge in template name cell

### DIFF
--- a/src/features/dashboard/templates/list/table-cells.tsx
+++ b/src/features/dashboard/templates/list/table-cells.tsx
@@ -296,7 +296,7 @@ export function TemplateNameCell({
           type="button"
           onClick={handleCopy}
           className={cn(
-            'group/copy absolute right-0 z-10 p-1.5 rounded cursor-pointer',
+            'group/copy relative z-10 ml-auto shrink-0 p-1.5 rounded cursor-pointer',
             'opacity-0 group-hover/row:opacity-100',
             'focus-visible:opacity-100 focus-visible:outline-none'
           )}


### PR DESCRIPTION
The copy button in the templates list Name cell was absolutely positioned (`absolute right-0`), so it reserved no horizontal space and the in-flow E2B/`+N` badges slid underneath it whenever the name filled the cell (narrow Name column or default-template rows). This moves the button back into flow with `ml-auto shrink-0` so it reserves its own space and the badges can no longer collide with it, while keeping `relative z-10` so it stays clickable above the row's overlay navigation link.

Fixes EN-1115.

🤖 Generated with [Claude Code](https://claude.com/claude-code)