### PR TITLE
feat: add /settings page for recovery flows

### DIFF
--- a/src/app/api/auth/recovery-complete/route.ts
+++ b/src/app/api/auth/recovery-complete/route.ts
@@ -1,0 +1,22 @@
+import 'server-only'
+
+import { type NextRequest, NextResponse } from 'next/server'
+import { AUTH_URLS } from '@/configs/urls'
+import { handleCredentialChangeSuccess } from '@/core/server/auth'
+import { clearAppSessionCookies } from '@/core/server/auth/ory/clear-session-cookies'
+
+// Post-recovery password reset on /settings completed. The Kratos session minted
+// by the recovery flow is still live, so a bare redirect to /sign-in lets Hydra
+// silently mint tokens off it without a password prompt. Revoke every session
+// for the identity (this device plus any other live session, e.g. a takeover's
+// session elsewhere) and clear cookies before sending the user to /sign-in to
+// authenticate with the new password.
+export async function GET(request: NextRequest) {
+  await handleCredentialChangeSuccess()
+
+  const response = NextResponse.redirect(
+    new URL(AUTH_URLS.SIGN_IN, request.nextUrl.origin)
+  )
+  clearAppSessionCookies(request, response)
+  return response
+}

--- a/src/app/api/auth/sign-out/route.ts
+++ b/src/app/api/auth/sign-out/route.ts
@@ -9,7 +9,13 @@ import { clearAppSessionCookies } from '@/core/server/auth/ory/clear-session-coo
 // tokens and the Kratos identity session server-side, and the redirect ends
 // Hydra's OAuth2 session; we drop the browser cookies here.
 export async function GET(request: NextRequest) {
-  const { redirectTo } = await signOut({ origin: request.nextUrl.origin })
+  // `return_to` steers the post-logout landing for sessions without a Hydra
+  // id_token (e.g. signing out of /settings mid-recovery → back to sign-in).
+  const returnTo = request.nextUrl.searchParams.get('return_to') ?? undefined
+  const { redirectTo } = await signOut({
+    origin: request.nextUrl.origin,
+    returnTo,
+  })
   const response = NextResponse.redirect(
     new URL(redirectTo, request.nextUrl.origin)
   )

--- a/src/app/login/components/custom-button.tsx
+++ b/src/app/login/components/custom-button.tsx
@@ -13,7 +13,11 @@ export function OryButton({
   const { flowType } = useOryFlow()
   const label = node.meta?.label?.text
   const loadingLabel =
-    flowType === FlowType.Registration ? 'Signing up…' : 'Signing in…'
+    flowType === FlowType.Registration
+      ? 'Signing up…'
+      : flowType === FlowType.Settings
+        ? 'Saving…'
+        : 'Signing in…'
 
   return (
     <Button {...buttonProps} loading={isSubmitting ? loadingLabel : undefined}>

--- a/src/app/login/components/custom-card-header.tsx
+++ b/src/app/login/components/custom-card-header.tsx
@@ -10,6 +10,7 @@ const TITLE_BY_FLOW: Partial<Record<FlowType, string>> = {
   [FlowType.Registration]: 'Sign up',
   [FlowType.Recovery]: 'Reset your password',
   [FlowType.Verification]: 'Verify your email',
+  [FlowType.Settings]: 'Set a new password',
 }
 
 const REAUTH_DESCRIPTION: Record<ReauthCredential, string> = {
@@ -22,6 +23,7 @@ const DESCRIPTION_BY_FLOW: Partial<Record<FlowType, string>> = {
   [FlowType.Registration]: 'Sign up with a social provider or your email.',
   [FlowType.Recovery]: 'Enter your email to recover your account.',
   [FlowType.Verification]: 'Enter your email to verify your account.',
+  [FlowType.Settings]: 'Choose a new password for your account.',
 }
 
 export function OryCardHeader() {

--- a/src/app/login/components/custom-input.tsx
+++ b/src/app/login/components/custom-input.tsx
@@ -1,15 +1,49 @@
 'use client'
 
 import type { OryNodeInputProps } from '@ory/elements-react'
+import { useState } from 'react'
+import { EyeClosedIcon, EyeOpenIcon } from '@/ui/primitives/icons'
 import { Input } from '@/ui/primitives/input'
 
 export function OryInput({ inputProps, node }: OryNodeInputProps) {
+  const isPassword = inputProps.type === 'password'
+  const [revealed, setRevealed] = useState(false)
+
   const placeholder =
     node.attributes.name === 'identifier' || inputProps.type === 'email'
       ? 'you@example.com'
-      : inputProps.type === 'password'
+      : isPassword
         ? '••••••••••••'
         : undefined
 
-  return <Input {...inputProps} {...(placeholder ? { placeholder } : {})} />
+  const input = (
+    <Input
+      {...inputProps}
+      {...(placeholder ? { placeholder } : {})}
+      {...(isPassword
+        ? { type: revealed ? 'text' : 'password', className: 'pr-8' }
+        : {})}
+    />
+  )
+
+  if (!isPassword) return input
+
+  return (
+    <div className="relative w-full">
+      {input}
+      <button
+        type="button"
+        aria-label={revealed ? 'Hide password' : 'Show password'}
+        aria-pressed={revealed}
+        onClick={() => setRevealed((value) => !value)}
+        className="text-fg-tertiary hover:text-fg absolute top-1/2 right-2 flex size-5 -translate-y-1/2 cursor-pointer items-center justify-center"
+      >
+        {revealed ? (
+          <EyeClosedIcon className="size-4" />
+        ) : (
+          <EyeOpenIcon className="size-4" />
+        )}
+      </button>
+    </div>
+  )
 }

--- a/src/app/login/components/custom-label.tsx
+++ b/src/app/login/components/custom-label.tsx
@@ -6,9 +6,20 @@ import Link from 'next/link'
 import { AUTH_URLS } from '@/configs/urls'
 import { cn } from '@/lib/utils'
 import { Label } from '@/ui/primitives/label'
+import { getReauthInfo } from './reauth'
 
 export function OryLabel({ node, children, fieldError }: OryNodeLabelProps) {
-  const { flowType } = useOryFlow()
+  const oryFlow = useOryFlow()
+  const { flowType } = oryFlow
+
+  // On a reauth screen the user already holds a Kratos session, so starting
+  // recovery directly bounces to the default return URL ("already logged in").
+  // Route through sign-out first to clear the session, then land on recovery.
+  const { isReauthLogin } = getReauthInfo(oryFlow)
+  const recoverHref = isReauthLogin
+    ? `${AUTH_URLS.SIGN_OUT}?return_to=${encodeURIComponent(AUTH_URLS.FORGOT_PASSWORD)}`
+    : AUTH_URLS.FORGOT_PASSWORD
+
   const label = node.meta?.label?.text
   const messages = node.messages ?? []
   const fieldErrorText =
@@ -37,7 +48,7 @@ export function OryLabel({ node, children, fieldError }: OryNodeLabelProps) {
             <Link
               prefetch={false}
               target="_top"
-              href={AUTH_URLS.FORGOT_PASSWORD}
+              href={recoverHref}
               tabIndex={-1}
               className="prose-label text-fg-secondary hover:text-fg underline underline-offset-[3px]"
             >

--- a/src/app/settings/layout.tsx
+++ b/src/app/settings/layout.tsx
@@ -1,0 +1,35 @@
+import { ALLOW_SEO_INDEXING } from '@/configs/env-flags'
+import { METADATA } from '@/configs/metadata'
+import { AUTH_URLS } from '@/configs/urls'
+import { buttonVariants } from '@/ui/primitives/button'
+
+export const metadata = {
+  title: METADATA.title,
+  description: METADATA.description,
+  robots: ALLOW_SEO_INDEXING ? 'index, follow' : 'noindex, nofollow',
+}
+
+// Shell-less: no sidebar/team chrome, so the page renders with only a Kratos
+// session (the post-recovery password reset has no e2b_session yet).
+export default function SettingsLayout({
+  children,
+}: {
+  children: React.ReactNode
+}) {
+  return (
+    <div className="relative flex min-h-svh flex-col">
+      <header className="bg-bg/40 sticky top-0 z-50 flex items-center justify-between gap-3 border-b px-4 py-4 backdrop-blur-md md:px-6">
+        <h1 className="truncate">Account</h1>
+        <a
+          href={`${AUTH_URLS.SIGN_OUT}?return_to=${encodeURIComponent(AUTH_URLS.SIGN_IN)}`}
+          className={`${buttonVariants({ variant: 'secondary' })} shrink-0`}
+        >
+          Sign out
+        </a>
+      </header>
+      <div className="flex w-full flex-1 justify-center px-4 py-8">
+        <div className="w-full max-w-2xl">{children}</div>
+      </div>
+    </div>
+  )
+}

--- a/src/app/settings/page.tsx
+++ b/src/app/settings/page.tsx
@@ -1,0 +1,35 @@
+import { getSettingsFlow, type OryPageParams } from '@ory/nextjs/app'
+import oryConfig from '@/configs/ory'
+import { getUserProfile } from '@/core/server/auth'
+import { getOryConfigForRequest } from '@/core/server/auth/ory/request-config'
+import { SettingsCards } from './settings-cards'
+
+export const dynamic = 'force-dynamic'
+
+// Ory-driven settings page, intentionally separate from /dashboard/account.
+// It needs only a Kratos session (getSettingsFlow + getUserProfile read the
+// session/identity, not e2b_session) — so the post-recovery password reset works
+// before any Hydra token exists. Name/e-mail are shown read-only for reference;
+// editing the account profile stays on the gated /dashboard/account page.
+export default async function SettingsPage(props: OryPageParams) {
+  const flow = await getSettingsFlow(oryConfig, props.searchParams)
+
+  // getSettingsFlow has already redirected (created a flow / surfaced login).
+  if (!flow) {
+    return null
+  }
+
+  const [config, user] = await Promise.all([
+    getOryConfigForRequest(),
+    getUserProfile(),
+  ])
+
+  return (
+    <SettingsCards
+      flow={flow}
+      config={config}
+      name={user?.name ?? null}
+      email={user?.email ?? null}
+    />
+  )
+}

--- a/src/app/settings/settings-cards.tsx
+++ b/src/app/settings/settings-cards.tsx
@@ -168,7 +168,7 @@ function PasswordChangedDialog({ open }: { open: boolean }) {
         <DialogFooter>
           <Button
             onClick={() => {
-              window.location.href = AUTH_URLS.SIGN_IN
+              window.location.href = AUTH_URLS.RECOVERY_COMPLETE
             }}
           >
             Sign in with new password
@@ -221,9 +221,11 @@ export function SettingsCards({
         </Settings>
       </SessionProvider>
 
-      {/* No silent mint under remember=false — the user must sign in with the
-          new password. The dialog can't be dismissed: the only way forward is
-          to sign in. */}
+      {/* The recovery Kratos session is still live, so "sign in" routes through
+          RECOVERY_COMPLETE, which revokes every session for the identity (this
+          device plus any other live session) and clears cookies before
+          /sign-in — forcing a real password entry. The dialog can't be
+          dismissed: the only way forward is to sign in. */}
       <PasswordChangedDialog open={passwordChanged} />
     </div>
   )

--- a/src/app/settings/settings-cards.tsx
+++ b/src/app/settings/settings-cards.tsx
@@ -1,0 +1,230 @@
+'use client'
+
+import {
+  Node,
+  type OryCardSettingsSectionProps,
+  OryCardValidationMessages,
+  type OryFlowComponentOverrides,
+  OrySettingsFormSection,
+  useOryFlow,
+} from '@ory/elements-react'
+import { SessionProvider } from '@ory/elements-react/client'
+import { Settings } from '@ory/elements-react/theme'
+import { type ComponentProps, useState } from 'react'
+import { oryComponents } from '@/app/login/components'
+import { AUTH_URLS } from '@/configs/urls'
+import { Button } from '@/ui/primitives/button'
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardFooter,
+  CardHeader,
+  CardTitle,
+} from '@/ui/primitives/card'
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/ui/primitives/dialog'
+import { Input } from '@/ui/primitives/input'
+
+type SettingsProps = ComponentProps<typeof Settings>
+
+interface SettingsCardsProps extends Pick<SettingsProps, 'flow' | 'config'> {
+  // Read-only Kratos identity traits, shown for reference during the reset.
+  name: string | null
+  email: string | null
+}
+
+// <Settings>'s default body (OryPageHeader + OrySettingsCard) and the form
+// wrapper (Card.SettingsSection) are unstyled without the Ory theme stylesheet,
+// which the dashboard never loads. We render our own dashboard card via the
+// `children` slot and only override the form wrapper Ory drives submission with;
+// inputs/buttons/messages already use the dashboard-themed oryComponents.
+function SettingsSectionForm({
+  children,
+  action,
+  method,
+  onSubmit,
+}: OryCardSettingsSectionProps) {
+  return (
+    <form
+      action={action}
+      method={method}
+      onSubmit={onSubmit}
+      className="w-full"
+    >
+      {children}
+    </form>
+  )
+}
+
+const settingsComponents: OryFlowComponentOverrides = {
+  ...oryComponents,
+  Card: {
+    ...oryComponents.Card,
+    SettingsSection: SettingsSectionForm,
+  },
+}
+
+type SettingsNode = ReturnType<typeof useOryFlow>['flow']['ui']['nodes'][number]
+
+// The submit ("Save") node; the cast sidesteps the union typing of node
+// attributes (and the dual @ory/client-fetch copies this repo installs).
+function isSubmitNode(node: SettingsNode): boolean {
+  return (
+    'type' in node.attributes &&
+    (node.attributes as { type?: string }).type === 'submit'
+  )
+}
+
+// Read-only reference field (name / e-mail). Shown for context during the
+// password reset — account edits live on the gated /dashboard/account page.
+function ReadOnlyField({
+  title,
+  description,
+  value,
+}: {
+  title: string
+  description: string
+  value: string | null
+}) {
+  return (
+    <Card className="overflow-hidden border-b md:border">
+      <CardHeader>
+        <CardTitle>{title}</CardTitle>
+        <CardDescription>{description}</CardDescription>
+      </CardHeader>
+      <CardContent className="flex flex-col gap-3">
+        <Input
+          value={value ?? ''}
+          readOnly
+          disabled
+          className="md:max-w-[17rem]"
+        />
+      </CardContent>
+    </Card>
+  )
+}
+
+// The Ory password method, rendered as a dashboard card via the settings flow.
+function PasswordCard() {
+  const { flow } = useOryFlow()
+  // `default` carries the CSRF hidden input the submission needs.
+  const nodes = flow.ui.nodes.filter(
+    (node) => node.group === 'password' || node.group === 'default'
+  )
+  const submitNodes = nodes.filter(isSubmitNode)
+  const fieldNodes = nodes.filter((node) => !isSubmitNode(node))
+
+  return (
+    <Card className="overflow-hidden md:border">
+      <CardHeader>
+        <CardTitle>Password</CardTitle>
+        <CardDescription>Set a new password for your account.</CardDescription>
+      </CardHeader>
+
+      <OrySettingsFormSection nodes={nodes}>
+        <CardContent className="flex max-w-90 flex-col gap-2">
+          <OryCardValidationMessages />
+          {fieldNodes.map((node, index) => (
+            <Node key={index} node={node} />
+          ))}
+        </CardContent>
+        <CardFooter className="bg-bg-1 justify-between gap-6">
+          <p className="text-fg-tertiary">
+            Your password must be at least 8 characters long.
+          </p>
+          {submitNodes.map((node, index) => (
+            <Node key={index} node={node} />
+          ))}
+        </CardFooter>
+      </OrySettingsFormSection>
+    </Card>
+  )
+}
+
+function PasswordChangedDialog({ open }: { open: boolean }) {
+  return (
+    // Controlled `open` with no onOpenChange + hideClose + blocked outside/esc:
+    // the dialog can't be dismissed, so the only way forward is sign-in.
+    <Dialog open={open}>
+      <DialogContent
+        hideClose
+        onEscapeKeyDown={(e) => e.preventDefault()}
+        onInteractOutside={(e) => e.preventDefault()}
+      >
+        <DialogHeader>
+          <DialogTitle>Password updated</DialogTitle>
+          <DialogDescription>
+            Your password has been changed. Sign in with your new password to
+            continue.
+          </DialogDescription>
+        </DialogHeader>
+        <DialogFooter>
+          <Button
+            onClick={() => {
+              window.location.href = AUTH_URLS.SIGN_IN
+            }}
+          >
+            Sign in with new password
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  )
+}
+
+export function SettingsCards({
+  flow,
+  config,
+  name,
+  email,
+}: SettingsCardsProps) {
+  const [passwordChanged, setPasswordChanged] = useState(false)
+
+  // Password is the only submittable method here, so any success is the password
+  // change. Take over from Ory: open our dialog and return a never-resolving
+  // promise. Per OrySuccessHandler, that suspends Ory's default post-success
+  // behavior — specifically the `continue_with` redirect (window.location.assign)
+  // that otherwise reloads the page to settings_ui_url. No reload; the user
+  // proceeds via the dialog.
+  const handleSuccess = () => {
+    setPasswordChanged(true)
+    return new Promise<void>(() => {})
+  }
+
+  return (
+    <div className="flex flex-col md:gap-6">
+      <ReadOnlyField
+        title="Name"
+        description="Your account name."
+        value={name}
+      />
+      <ReadOnlyField
+        title="E-Mail"
+        description="Your account e-mail."
+        value={email}
+      />
+      <SessionProvider>
+        <Settings
+          flow={flow}
+          config={config}
+          components={settingsComponents}
+          onSuccess={handleSuccess}
+        >
+          <PasswordCard />
+        </Settings>
+      </SessionProvider>
+
+      {/* No silent mint under remember=false — the user must sign in with the
+          new password. The dialog can't be dismissed: the only way forward is
+          to sign in. */}
+      <PasswordChangedDialog open={passwordChanged} />
+    </div>
+  )
+}

--- a/src/configs/ory.ts
+++ b/src/configs/ory.ts
@@ -1,5 +1,5 @@
 import type { OryClientConfiguration } from '@ory/elements-react'
-import { PROTECTED_URLS } from '@/configs/urls'
+import { AUTH_URLS, PROTECTED_URLS } from '@/configs/urls'
 
 // `sdk.url` must be the app's own origin so the Elements client's
 // /self-service/* calls stay same-origin (Kratos' wildcard CORS rejects
@@ -21,7 +21,7 @@ const oryConfig: OryClientConfiguration = {
     recovery_ui_url: '/recovery',
     verification_enabled: true,
     verification_ui_url: '/verification',
-    settings_ui_url: PROTECTED_URLS.ACCOUNT_SETTINGS,
+    settings_ui_url: AUTH_URLS.SETTINGS,
   },
 }
 

--- a/src/configs/urls.ts
+++ b/src/configs/urls.ts
@@ -4,6 +4,7 @@ export const AUTH_URLS = {
   SIGN_UP: '/sign-up',
   SIGN_OUT: '/api/auth/sign-out',
   SWITCH_ACCOUNT: '/api/auth/switch-account',
+  RECOVERY_COMPLETE: '/api/auth/recovery-complete',
   CLI: '/auth/cli',
   // Shell-less Ory settings page (password reset + account config). Reachable
   // with only a Kratos session, so the post-recovery password reset works

--- a/src/configs/urls.ts
+++ b/src/configs/urls.ts
@@ -2,8 +2,13 @@ export const AUTH_URLS = {
   FORGOT_PASSWORD: '/recovery',
   SIGN_IN: '/sign-in',
   SIGN_UP: '/sign-up',
+  SIGN_OUT: '/api/auth/sign-out',
   SWITCH_ACCOUNT: '/api/auth/switch-account',
   CLI: '/auth/cli',
+  // Shell-less Ory settings page (password reset + account config). Reachable
+  // with only a Kratos session, so the post-recovery password reset works
+  // before any e2b_session (Hydra token) exists. Kratos' settings_ui_url.
+  SETTINGS: '/settings',
 }
 
 export const PROTECTED_URLS = {

--- a/src/core/server/auth/ory/session.ts
+++ b/src/core/server/auth/ory/session.ts
@@ -113,7 +113,7 @@ export async function signOut(
   await revokeCurrentSession()
 
   return {
-    redirectTo: await completeOrySignOut(options?.origin),
+    redirectTo: await completeOrySignOut(options?.origin, options?.returnTo),
   }
 }
 

--- a/src/core/server/auth/ory/signout-flow.ts
+++ b/src/core/server/auth/ory/signout-flow.ts
@@ -7,20 +7,28 @@ import { normalizeOryReturnTo } from './build-start-url'
 import { E2B_SESSION_COOKIE, openSessionCookie } from './session-cookie'
 import { buildOryLogoutUrl, ORY_POST_LOGOUT_PATH } from './signout'
 
-// RP-initiated logout: hand Hydra the id_token so it ends its own OAuth2 session
-// and (since it delegates login to Kratos) the Kratos session, then returns to
-// post_logout_redirect_uri. The sign-out route clears e2b_session on the
-// redirect it emits.
+// Resolves the post-logout landing for the sign-out route.
 //
-// `returnTo` (a relative path) only steers the no-id_token fallback — e.g. a
-// recovery sign-out from /settings, which never had a Hydra session. The Hydra
-// path can't use it: post_logout_redirect_uri must be a pre-registered URI.
+// An explicit internal `returnTo` (reauth "Recover Account" → /recovery,
+// /settings sign-out → /sign-in) names where to go next. Hydra's RP-logout
+// can't honor it — post_logout_redirect_uri must be a pre-registered URI, so it
+// always lands on ORY_POST_LOGOUT_PATH and the path is dropped. signOut() has
+// already revoked the tokens + Kratos session (production accepts login with
+// remember=false, so Hydra holds no session of its own to end) and the route
+// clears the cookies, so we skip the Hydra round-trip and 302 straight to the
+// requested path.
+//
+// The default full sign-out passes no `returnTo` and falls through to Hydra's
+// RP-initiated logout: the id_token lets Hydra end its OAuth2 session and the
+// delegated Kratos session, then return to post_logout_redirect_uri.
 export async function completeOrySignOut(
   origin = BASE_URL,
   returnTo?: string
 ): Promise<string> {
-  const fallbackPath = normalizeOryReturnTo(returnTo) ?? ORY_POST_LOGOUT_PATH
-  const fallback = new URL(fallbackPath, origin).toString()
+  const target = normalizeOryReturnTo(returnTo)
+  if (target) return new URL(target, origin).toString()
+
+  const home = new URL(ORY_POST_LOGOUT_PATH, origin).toString()
 
   let idToken: string | undefined
   try {
@@ -39,8 +47,8 @@ export async function completeOrySignOut(
     )
   }
 
-  if (!idToken) return fallback
+  if (!idToken) return home
 
   const logoutUrl = await buildOryLogoutUrl({ idToken, origin })
-  return logoutUrl?.toString() ?? fallback
+  return logoutUrl?.toString() ?? home
 }

--- a/src/core/server/auth/ory/signout-flow.ts
+++ b/src/core/server/auth/ory/signout-flow.ts
@@ -3,15 +3,24 @@ import 'server-only'
 import { cookies } from 'next/headers'
 import { BASE_URL } from '@/configs/urls'
 import { l, serializeErrorForLog } from '@/core/shared/clients/logger/logger'
+import { normalizeOryReturnTo } from './build-start-url'
 import { E2B_SESSION_COOKIE, openSessionCookie } from './session-cookie'
 import { buildOryLogoutUrl, ORY_POST_LOGOUT_PATH } from './signout'
 
 // RP-initiated logout: hand Hydra the id_token so it ends its own OAuth2 session
 // and (since it delegates login to Kratos) the Kratos session, then returns to
 // post_logout_redirect_uri. The sign-out route clears e2b_session on the
-// redirect it emits. Falls back to home if there's no id_token to present.
-export async function completeOrySignOut(origin = BASE_URL): Promise<string> {
-  const fallback = new URL(ORY_POST_LOGOUT_PATH, origin).toString()
+// redirect it emits.
+//
+// `returnTo` (a relative path) only steers the no-id_token fallback — e.g. a
+// recovery sign-out from /settings, which never had a Hydra session. The Hydra
+// path can't use it: post_logout_redirect_uri must be a pre-registered URI.
+export async function completeOrySignOut(
+  origin = BASE_URL,
+  returnTo?: string
+): Promise<string> {
+  const fallbackPath = normalizeOryReturnTo(returnTo) ?? ORY_POST_LOGOUT_PATH
+  const fallback = new URL(fallbackPath, origin).toString()
 
   let idToken: string | undefined
   try {


### PR DESCRIPTION
## Fix password recovery flow (EN-1116)

### Problem
The account/password recovery flow was broken end-to-end. After clicking a
recovery email link, Kratos drops the user into a **settings flow** to set a new
password — but the dashboard had nowhere to handle it:

- `settings_ui_url` pointed at `/dashboard/account`, which is gated behind an
  `e2b_session` (Hydra token) that **doesn't exist yet** during recovery — so the
  user couldn't actually reach the password form.
- The reauth login screen's "Forgot password?" link started recovery directly,
  but the user already holds a Kratos session there, so Kratos bounced them with
  "already logged in" instead of starting recovery.

### Changes

**New shell-less `/settings` page** (`layout.tsx`, `page.tsx`, `settings-cards.tsx`)
- Renders the Ory settings flow, but needs **only a Kratos session** (reads
  session/identity via `getSettingsFlow` + `getUserProfile`, not `e2b_session`),
  so the post-recovery reset works before any Hydra token exists.
- No sidebar/team chrome — just an "Account" header with a sign-out button.
- The Ory password method is rendered as dashboard-themed cards (the `<Settings>`
  default body is unstyled without the Ory theme stylesheet, which we never load).
  Name/e-mail are shown read-only for reference; profile editing stays on the
  gated `/dashboard/account`.
- On success, a **non-dismissable dialog** takes over (suspends Ory's default
  `continue_with` reload) and routes the user to sign in with the new password.