### PR TITLE
[codex] Allow public templates in dashboard terminal

### DIFF
--- a/src/app/dashboard/[teamSlug]/terminal/page.tsx
+++ b/src/app/dashboard/[teamSlug]/terminal/page.tsx
@@ -13,7 +13,10 @@ import type { components as InfraComponents } from '@/core/shared/contracts/infr
 import { createSandboxManagementAuth } from '@/core/shared/sandbox-management-auth.server'
 import { SandboxIdSchema } from '@/core/shared/schemas/api'
 import DashboardTerminal from '@/features/dashboard/terminal/dashboard-terminal'
-import { normalizeTerminalTemplate } from '@/features/dashboard/terminal/template'
+import {
+  isPublicTemplateReference,
+  normalizeTerminalTemplate,
+} from '@/features/dashboard/terminal/template'
 import { Button } from '@/ui/primitives/button'
 
 export const metadata: Metadata = {
@@ -189,6 +192,10 @@ async function isTerminalTemplateAvailable({
   template: string
 }) {
   if (template === 'base') {
+    return { ok: true as const, available: true }
+  }
+
+  if (isPublicTemplateReference(template)) {
     return { ok: true as const, available: true }
   }
 

--- a/src/features/dashboard/terminal/template.ts
+++ b/src/features/dashboard/terminal/template.ts
@@ -15,6 +15,12 @@ export function normalizeTerminalTemplate(template?: string) {
   return value
 }
 
+export function isPublicTemplateReference(template: string) {
+  const [owner, name, ...rest] = template.split('/')
+
+  return Boolean(owner && name && rest.length === 0)
+}
+
 export function resolveTerminalTemplateOverride(
   template: string | undefined,
   fallback: string

--- a/tests/unit/dashboard-terminal.test.ts
+++ b/tests/unit/dashboard-terminal.test.ts
@@ -12,6 +12,7 @@ import {
   writeStoredTerminalSession,
 } from '@/features/dashboard/terminal/storage'
 import {
+  isPublicTemplateReference,
   normalizeTerminalTemplate,
   resolveTerminalTemplateOverride,
 } from '@/features/dashboard/terminal/template'
@@ -82,6 +83,21 @@ describe('dashboard terminal helpers', () => {
       )
       expect(normalizeTerminalTemplate('base; echo nope')).toBeNull()
       expect(normalizeTerminalTemplate('../base')).toBeNull()
+    })
+  })
+
+  describe('isPublicTemplateReference', () => {
+    it('detects owner-qualified public template references', () => {
+      expect(isPublicTemplateReference('team-slug/python:default')).toBe(true)
+      expect(
+        isPublicTemplateReference('aiengineer-d56d/aiengineer-guide')
+      ).toBe(true)
+    })
+
+    it('does not treat bare or multi-path template names as public references', () => {
+      expect(isPublicTemplateReference('base')).toBe(false)
+      expect(isPublicTemplateReference('python_3.12-dev')).toBe(false)
+      expect(isPublicTemplateReference('owner/nested/template')).toBe(false)
     })
   })
 


### PR DESCRIPTION
## What changed

- Allows `owner/template` references through the dashboard terminal template preflight.
- Keeps local/default template availability checks for bare template names.
- Adds unit coverage for public template reference detection.

## Why

`/sbx/new?template=owner/template` worked because it calls `Sandbox.create(template)` directly. The dashboard terminal page rejected the same public template reference before launch because it only checked default templates and templates owned by the current team.

This made public workshop links like `aiengineer-d56d/aiengineer-guide` show as unavailable in the terminal UI even though the SDK could create them.

## Validation

- `bunx vitest run tests/unit/dashboard-terminal.test.ts`
- `bunx biome check 'src/app/dashboard/[teamSlug]/terminal/page.tsx' src/features/dashboard/terminal/template.ts tests/unit/dashboard-terminal.test.ts`
