### PR TITLE
feat: add Hydra OAuth flow for CLI authentication

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -14,8 +14,10 @@ ORY_SDK_URL=https://your-project.projects.oryapis.com
 ### OIDC issuer for the OAuth client. Falls back to ORY_SDK_URL on Ory Network;
 ### set explicitly for self-hosted Hydra (e.g. http://localhost:4444).
 # ORY_HYDRA_PUBLIC_URL=http://localhost:4444
-ORY_OAUTH2_CLIENT_ID=your_ory_oauth2_client_id
-ORY_OAUTH2_CLIENT_SECRET=your_ory_oauth2_client_secret
+ORY_OAUTH2_CLIENT_ID=*************************
+ORY_OAUTH2_CLIENT_SECRET=*****************************
+### OAuth2 public client for CLI token issuance (no secret needed)
+ORY_OAUTH2_CLI_CLIENT_ID=your_cli_public_client_id
 ### Access-token audience requested from Ory. Must match the backend JWT audience configuration.
 ORY_OAUTH2_AUDIENCE=https://api.e2b.dev
 ### Ory project admin API token used for IdentityApi lookups

--- a/.env.example
+++ b/.env.example
@@ -14,8 +14,8 @@ ORY_SDK_URL=https://your-project.projects.oryapis.com
 ### OIDC issuer for the OAuth client. Falls back to ORY_SDK_URL on Ory Network;
 ### set explicitly for self-hosted Hydra (e.g. http://localhost:4444).
 # ORY_HYDRA_PUBLIC_URL=http://localhost:4444
-ORY_OAUTH2_CLIENT_ID=*************************
-ORY_OAUTH2_CLIENT_SECRET=*****************************
+ORY_OAUTH2_CLIENT_ID=your_ory_oauth2_client_id
+ORY_OAUTH2_CLIENT_SECRET=your_ory_oauth2_client_secret
 ### OAuth2 public client for CLI token issuance (no secret needed)
 ORY_OAUTH2_CLI_CLIENT_ID=your_cli_public_client_id
 ### Access-token audience requested from Ory. Must match the backend JWT audience configuration.

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -49,6 +49,7 @@ jobs:
       ORY_SDK_URL: https://test-ory.projects.oryapis.com
       ORY_OAUTH2_CLIENT_ID: test-ory-client-id
       ORY_OAUTH2_CLIENT_SECRET: test-ory-client-secret
+      ORY_OAUTH2_CLI_CLIENT_ID: test-ory-cli-client-id
       ORY_OAUTH2_AUDIENCE: https://api.e2b-test.dev
       ORY_PROJECT_API_TOKEN: test-ory-project-api-token
       DASHBOARD_API_ADMIN_TOKEN: test-dashboard-admin-token

--- a/src/app/(auth)/auth/cli/page.tsx
+++ b/src/app/(auth)/auth/cli/page.tsx
@@ -1,25 +1,56 @@
 import { redirect } from 'next/navigation'
 import { Suspense } from 'react'
 import { AUTH_URLS, PROTECTED_URLS } from '@/configs/urls'
+import type { FeatureFlagContext } from '@/core/modules/feature-flags/context'
+import { featureFlags } from '@/core/modules/feature-flags/feature-flags.server'
 import { createUserTeamsRepository } from '@/core/modules/teams/user-teams-repository.server'
 import { getAuthContext } from '@/core/server/auth'
 import { l, serializeErrorForLog } from '@/core/shared/clients/logger/logger'
 import { isLoopbackUrl } from '@/core/shared/schemas/url'
 import { encodedRedirect } from '@/lib/utils/auth'
 import { generateE2BUserAccessToken } from '@/lib/utils/server'
+import { isVersionGreaterOrEqual } from '@/lib/utils/version'
 import { Alert, AlertDescription, AlertTitle } from '@/ui/primitives/alert'
-import { CloudIcon, LaptopIcon, LinkIcon } from '@/ui/primitives/icons'
+import {
+  CloudIcon,
+  LaptopIcon,
+  LinkIcon,
+  TerminalIcon,
+} from '@/ui/primitives/icons'
 
-// Types
+// Minimum CLI version that supports the Hydra JWT auth flow.
+// CLI versions >= this use the new public-client OAuth flow;
+// older versions fall back to the legacy e2b access token flow.
+//
+// Set to the current CLI version for development so the new flow
+// is exercised locally. Bump to the actual new CLI version when
+// shipping the refactor.
+const MIN_CLI_VERSION_FOR_HYDRA_FLOW = '2.12.2'
+
 type CLISearchParams = Promise<{
   next?: string
+  cliVersion?: string
   state?: string
   error?: string
 }>
 
-// Server Actions
+type CLIFlow = 'hydra' | 'legacy'
 
-async function handleCLIAuth(
+function resolveCLIFlow(cliVersion: string | undefined): CLIFlow {
+  if (!cliVersion) return 'legacy'
+  return isVersionGreaterOrEqual(cliVersion, MIN_CLI_VERSION_FOR_HYDRA_FLOW)
+    ? 'hydra'
+    : 'legacy'
+}
+
+function handleHydraCLIAuth(next: string) {
+  if (!isLoopbackUrl(next)) {
+    throw new Error('Invalid redirect URL')
+  }
+  return redirect(`/api/auth/oauth/cli-start?next=${encodeURIComponent(next)}`)
+}
+
+async function handleLegacyCLIAuth(
   next: string,
   userEmail: string,
   authProviderAccessToken: string
@@ -57,10 +88,9 @@ async function handleCLIAuth(
   return redirect(`${next}?${searchParams.toString()}`)
 }
 
-// UI Components
 function CLIIcons() {
   return (
-    <p className="flex items-center justify-center gap-4 text-3xl  tracking-tight sm:text-4xl">
+    <p className="flex items-center justify-center gap-4 text-3xl tracking-tight sm:text-4xl">
       <span className="text-fg-tertiary">
         <LaptopIcon className="size-8" />
       </span>
@@ -86,98 +116,141 @@ function ErrorAlert({ message }: { message: string }) {
 function SuccessState() {
   return (
     <>
-      <h2 className="text-brand-400 ">Successfully linked</h2>
+      <h2 className="text-brand-400">Successfully linked</h2>
       <div>You can close this page and start using CLI.</div>
     </>
   )
 }
 
-// Main Component
+function UpgradeCLIState() {
+  return (
+    <div className="p-6 text-center">
+      <CLIIcons />
+      <h2 className="mt-6 text-base leading-7">CLI update required</h2>
+      <p className="text-fg-tertiary mt-4 max-w-md leading-7 mx-auto">
+        Your E2B CLI version is outdated and no longer supported for
+        authentication. Please update to the latest version to continue.
+      </p>
+      <div className="mt-8 inline-flex items-center gap-2 rounded-md border bg-bg-hover px-4 py-2">
+        <TerminalIcon className="size-4 text-fg-tertiary" />
+        <code className="text-fg-secondary text-sm">
+          npm install -g @e2b/cli@latest
+        </code>
+      </div>
+      <p className="text-fg-tertiary mt-6 text-sm">
+        Then run <code className="text-fg-secondary">e2b auth login</code>{' '}
+        again.
+      </p>
+    </div>
+  )
+}
+
 export default async function CLIAuthPage({
   searchParams,
 }: {
   searchParams: CLISearchParams
 }) {
-  const { next, state, error } = await searchParams
+  const { next, cliVersion, state, error } = await searchParams
   const authContext = await getAuthContext()
 
   if (state === 'success') {
     return <SuccessState />
   }
 
-  // Validate redirect URL
   if (!next || !isLoopbackUrl(next)) {
     l.error(
       {
         key: 'cli_auth:invalid_redirect_url',
         user_id: authContext?.user.id,
-        context: {
-          next,
-        },
+        context: { next },
       },
       `Invalid redirect URL: ${next}`
     )
     redirect(PROTECTED_URLS.DASHBOARD)
   }
 
-  // If user is not authenticated, redirect to sign in with return URL
   if (!authContext) {
-    const searchParams = new URLSearchParams({
-      returnTo: `${AUTH_URLS.CLI}?${new URLSearchParams({ next }).toString()}`,
-    })
-    redirect(`${AUTH_URLS.SIGN_IN}?${searchParams.toString()}`)
+    const returnToParams = new URLSearchParams({ next })
+    if (cliVersion) returnToParams.set('cliVersion', cliVersion)
+    return redirect(
+      `${AUTH_URLS.SIGN_IN}?returnTo=${encodeURIComponent(
+        `${AUTH_URLS.CLI}?${returnToParams.toString()}`
+      )}`
+    )
   }
 
-  // Handle CLI callback if authenticated
-  if (!error && next && authContext) {
-    try {
-      if (!authContext.user.email) {
-        throw new Error('No user email found')
-      }
+  const flow = resolveCLIFlow(cliVersion)
 
-      return await handleCLIAuth(
-        next,
-        authContext.user.email,
-        authContext.accessToken
-      )
-    } catch (err) {
-      if (err instanceof Error && err.message.includes('NEXT_REDIRECT')) {
-        throw err
-      }
+  if (flow === 'legacy') {
+    const flagContext: FeatureFlagContext = {
+      user: {
+        id: authContext.user.id,
+        email: authContext.user.email ?? undefined,
+      },
+    }
+    const blockLegacy = await featureFlags.isEnabled(
+      'blockLegacyCliAuth',
+      flagContext
+    )
 
-      l.error(
-        {
-          key: 'cli_auth:unexpected_error',
-          error: serializeErrorForLog(err),
-          user_id: authContext.user.id,
-          context: {
-            next,
-          },
-        },
-        `Unexpected error during CLI authentication: ${err instanceof Error ? err.message : String(err)}`
-      )
-
-      return encodedRedirect('error', '/auth/cli', (err as Error).message, {
-        next,
-      })
+    if (blockLegacy) {
+      return <UpgradeCLIState />
     }
   }
 
-  return (
-    <div className="p-6 text-center">
-      <CLIIcons />
-      <h2 className="mt-6 text-base leading-7">
-        Linking CLI with your account
-      </h2>
-      <div className="text-fg-tertiary mt-12 leading-8">
-        <Suspense fallback={<div>Loading...</div>}>
-          {error ? (
+  if (error) {
+    return (
+      <div className="p-6 text-center">
+        <CLIIcons />
+        <h2 className="mt-6 text-base leading-7">
+          Linking CLI with your account
+        </h2>
+        <div className="text-fg-tertiary mt-12 leading-8">
+          <Suspense fallback={<div>Loading...</div>}>
             <ErrorAlert message={error} />
-          ) : (
-            <div>Authorizing CLI...</div>
-          )}
-        </Suspense>
+          </Suspense>
+        </div>
       </div>
-    </div>
-  )
+    )
+  }
+
+  try {
+    if (flow === 'hydra') {
+      return handleHydraCLIAuth(next)
+    }
+
+    if (!authContext.user.email) {
+      throw new Error('No user email found')
+    }
+
+    return await handleLegacyCLIAuth(
+      next,
+      authContext.user.email,
+      authContext.accessToken
+    )
+  } catch (err) {
+    if (err instanceof Error && err.message.includes('NEXT_REDIRECT')) {
+      throw err
+    }
+
+    l.error(
+      {
+        key: 'cli_auth:unexpected_error',
+        error: serializeErrorForLog(err),
+        user_id: authContext.user.id,
+        context: { next, flow },
+      },
+      `Unexpected error during CLI authentication: ${err instanceof Error ? err.message : String(err)}`
+    )
+
+    const redirectParams: Record<string, string> = { next }
+    if (cliVersion) redirectParams.cliVersion = cliVersion
+
+    return encodedRedirect(
+      'error',
+      '/auth/cli',
+      (err as Error).message,
+      redirectParams
+    )
+  }
 }

--- a/src/app/(auth)/auth/cli/page.tsx
+++ b/src/app/(auth)/auth/cli/page.tsx
@@ -191,7 +191,12 @@ export default async function CLIAuthPage({
       flagContext
     )
 
-    if (blockLegacy) {
+    const tokenProvisioningDisabled = await featureFlags.isEnabled(
+      'disableE2BAccessTokenProvisioning',
+      flagContext
+    )
+
+    if (blockLegacy || tokenProvisioningDisabled) {
       return <UpgradeCLIState />
     }
   }

--- a/src/app/(auth)/auth/cli/page.tsx
+++ b/src/app/(auth)/auth/cli/page.tsx
@@ -18,13 +18,12 @@ import {
   TerminalIcon,
 } from '@/ui/primitives/icons'
 
-// Minimum CLI version that supports the Hydra JWT auth flow.
+// Minimum CLI version that supports the OAuth JWT auth flow.
 // CLI versions >= this use the new public-client OAuth flow;
 // older versions fall back to the legacy e2b access token flow.
-// Old 2.12.2 binaries don't send cliVersion at all (it's a new param),
-// so they correctly fall to 'legacy'. The paired CLI PR ships as 2.12.2
-// with the new flow and sends cliVersion=2.12.2.
-const MIN_CLI_VERSION_FOR_HYDRA_FLOW = '2.12.2'
+// Old binaries (pre-2.13.0) don't send cliVersion at all (it's a new param),
+// so they correctly fall to 'legacy'.
+const MIN_CLI_VERSION_FOR_HYDRA_FLOW = '2.13.0'
 
 type CLISearchParams = Promise<{
   next?: string

--- a/src/app/(auth)/auth/cli/page.tsx
+++ b/src/app/(auth)/auth/cli/page.tsx
@@ -11,11 +11,7 @@ import { encodedRedirect } from '@/lib/utils/auth'
 import { generateE2BUserAccessToken } from '@/lib/utils/server'
 import { isVersionGreaterOrEqual } from '@/lib/utils/version'
 import { Alert, AlertDescription, AlertTitle } from '@/ui/primitives/alert'
-import {
-  CloudIcon,
-  LaptopIcon,
-  LinkIcon,
-} from '@/ui/primitives/icons'
+import { CloudIcon, LaptopIcon, LinkIcon } from '@/ui/primitives/icons'
 
 // Minimum CLI version that supports the OAuth JWT auth flow.
 // CLI versions >= this use the new public-client OAuth flow;

--- a/src/app/(auth)/auth/cli/page.tsx
+++ b/src/app/(auth)/auth/cli/page.tsx
@@ -186,17 +186,12 @@ export default async function CLIAuthPage({
         email: authContext.user.email ?? undefined,
       },
     }
-    const blockLegacy = await featureFlags.isEnabled(
-      'blockLegacyCliAuth',
-      flagContext
-    )
-
     const tokenProvisioningDisabled = await featureFlags.isEnabled(
       'disableE2BAccessTokenProvisioning',
       flagContext
     )
 
-    if (blockLegacy || tokenProvisioningDisabled) {
+    if (tokenProvisioningDisabled) {
       return <UpgradeCLIState />
     }
   }

--- a/src/app/(auth)/auth/cli/page.tsx
+++ b/src/app/(auth)/auth/cli/page.tsx
@@ -21,10 +21,9 @@ import {
 // Minimum CLI version that supports the Hydra JWT auth flow.
 // CLI versions >= this use the new public-client OAuth flow;
 // older versions fall back to the legacy e2b access token flow.
-//
-// Set to the current CLI version for development so the new flow
-// is exercised locally. Bump to the actual new CLI version when
-// shipping the refactor.
+// Old 2.12.2 binaries don't send cliVersion at all (it's a new param),
+// so they correctly fall to 'legacy'. The paired CLI PR ships as 2.12.2
+// with the new flow and sends cliVersion=2.12.2.
 const MIN_CLI_VERSION_FOR_HYDRA_FLOW = '2.12.2'
 
 type CLISearchParams = Promise<{

--- a/src/app/(auth)/auth/cli/page.tsx
+++ b/src/app/(auth)/auth/cli/page.tsx
@@ -15,7 +15,6 @@ import {
   CloudIcon,
   LaptopIcon,
   LinkIcon,
-  TerminalIcon,
 } from '@/ui/primitives/icons'
 
 // Minimum CLI version that supports the OAuth JWT auth flow.
@@ -120,29 +119,6 @@ function SuccessState() {
   )
 }
 
-function UpgradeCLIState() {
-  return (
-    <div className="p-6 text-center">
-      <CLIIcons />
-      <h2 className="mt-6 text-base leading-7">CLI update required</h2>
-      <p className="text-fg-tertiary mt-4 max-w-md leading-7 mx-auto">
-        Your E2B CLI version is outdated and no longer supported for
-        authentication. Please update to the latest version to continue.
-      </p>
-      <div className="mt-8 inline-flex items-center gap-2 rounded-md border bg-bg-hover px-4 py-2">
-        <TerminalIcon className="size-4 text-fg-tertiary" />
-        <code className="text-fg-secondary text-sm">
-          npm install -g @e2b/cli@latest
-        </code>
-      </div>
-      <p className="text-fg-tertiary mt-6 text-sm">
-        Then run <code className="text-fg-secondary">e2b auth login</code>{' '}
-        again.
-      </p>
-    </div>
-  )
-}
-
 export default async function CLIAuthPage({
   searchParams,
 }: {
@@ -192,7 +168,12 @@ export default async function CLIAuthPage({
     )
 
     if (tokenProvisioningDisabled) {
-      return <UpgradeCLIState />
+      const errorUrl = new URL(next)
+      errorUrl.searchParams.set(
+        'error',
+        'CLI update required. Run: npm install -g @e2b/cli@latest'
+      )
+      return redirect(errorUrl.toString())
     }
   }
 

--- a/src/app/api/auth/oauth/cli-callback/route.ts
+++ b/src/app/api/auth/oauth/cli-callback/route.ts
@@ -39,6 +39,13 @@ export async function GET(request: NextRequest) {
     )
   }
 
+  if (!authContext.user.email) {
+    return finalize(
+      redirectWithParams(flow.next, { error: 'No user email found' }),
+      origin
+    )
+  }
+
   let env: ReturnType<typeof readCliOAuthEnv>
   try {
     env = readCliOAuthEnv()
@@ -74,7 +81,7 @@ export async function GET(request: NextRequest) {
 
   return finalize(
     redirectWithParams(flow.next, {
-      email: authContext.user.email ?? '',
+      email: authContext.user.email,
       accessToken: tokens.accessToken,
       refreshToken: tokens.refreshToken ?? '',
       tokenEndpoint: tokenEndpoint,

--- a/src/app/api/auth/oauth/cli-callback/route.ts
+++ b/src/app/api/auth/oauth/cli-callback/route.ts
@@ -33,9 +33,7 @@ export async function GET(request: NextRequest) {
   const authContext = await getAuthContext()
   if (!authContext) {
     return finalize(
-      NextResponse.redirect(
-        `${flow.next}?${new URLSearchParams({ error: 'Not authenticated' }).toString()}`
-      ),
+      redirectWithParams(flow.next, { error: 'Not authenticated' }),
       origin
     )
   }
@@ -53,29 +51,36 @@ export async function GET(request: NextRequest) {
     })
   } catch (error) {
     return finalize(
-      NextResponse.redirect(
-        `${flow.next}?${new URLSearchParams({
-          error: `Token exchange failed: ${error instanceof Error ? error.message : String(error)}`,
-        }).toString()}`
-      ),
+      redirectWithParams(flow.next, {
+        error: `Token exchange failed: ${error instanceof Error ? error.message : String(error)}`,
+      }),
       origin
     )
   }
 
   const tokenEndpoint = buildTokenEndpoint(env.issuer.href)
 
-  const params = new URLSearchParams({
-    email: authContext.user.email ?? '',
-    accessToken: tokens.accessToken,
-    refreshToken: tokens.refreshToken ?? '',
-    oryTokenEndpoint: tokenEndpoint,
-    cliClientId: env.clientId,
-  })
-
   return finalize(
-    NextResponse.redirect(`${flow.next}?${params.toString()}`),
+    redirectWithParams(flow.next, {
+      email: authContext.user.email ?? '',
+      accessToken: tokens.accessToken,
+      refreshToken: tokens.refreshToken ?? '',
+      oryTokenEndpoint: tokenEndpoint,
+      cliClientId: env.clientId,
+    }),
     origin
   )
+}
+
+function redirectWithParams(
+  next: string,
+  params: Record<string, string>
+): NextResponse {
+  const url = new URL(next)
+  for (const [key, value] of Object.entries(params)) {
+    url.searchParams.set(key, value)
+  }
+  return NextResponse.redirect(url)
 }
 
 function finalize(response: NextResponse, _origin: string): NextResponse {

--- a/src/app/api/auth/oauth/cli-callback/route.ts
+++ b/src/app/api/auth/oauth/cli-callback/route.ts
@@ -33,7 +33,9 @@ export async function GET(request: NextRequest) {
   const authContext = await getAuthContext()
   if (!authContext) {
     return finalize(
-      new NextResponse('Not authenticated', { status: 401 }),
+      NextResponse.redirect(
+        `${flow.next}?${new URLSearchParams({ error: 'Not authenticated' }).toString()}`
+      ),
       origin
     )
   }
@@ -51,9 +53,10 @@ export async function GET(request: NextRequest) {
     })
   } catch (error) {
     return finalize(
-      new NextResponse(
-        `Token exchange failed: ${error instanceof Error ? error.message : String(error)}`,
-        { status: 502 }
+      NextResponse.redirect(
+        `${flow.next}?${new URLSearchParams({
+          error: `Token exchange failed: ${error instanceof Error ? error.message : String(error)}`,
+        }).toString()}`
       ),
       origin
     )

--- a/src/app/api/auth/oauth/cli-callback/route.ts
+++ b/src/app/api/auth/oauth/cli-callback/route.ts
@@ -67,8 +67,8 @@ export async function GET(request: NextRequest) {
       email: authContext.user.email ?? '',
       accessToken: tokens.accessToken,
       refreshToken: tokens.refreshToken ?? '',
-      oryTokenEndpoint: tokenEndpoint,
-      oryRevokeEndpoint: revokeEndpoint,
+      tokenEndpoint: tokenEndpoint,
+      revokeEndpoint: revokeEndpoint,
       cliClientId: env.clientId,
     }),
     origin

--- a/src/app/api/auth/oauth/cli-callback/route.ts
+++ b/src/app/api/auth/oauth/cli-callback/route.ts
@@ -3,6 +3,7 @@ import 'server-only'
 import { type NextRequest, NextResponse } from 'next/server'
 import { getAuthContext } from '@/core/server/auth'
 import {
+  buildRevokeEndpoint,
   buildTokenEndpoint,
   CLI_OAUTH_CALLBACK_PATH,
   CLI_OAUTH_FLOW_COOKIE,
@@ -59,6 +60,7 @@ export async function GET(request: NextRequest) {
   }
 
   const tokenEndpoint = buildTokenEndpoint(env.issuer.href)
+  const revokeEndpoint = buildRevokeEndpoint(env.issuer.href)
 
   return finalize(
     redirectWithParams(flow.next, {
@@ -66,6 +68,7 @@ export async function GET(request: NextRequest) {
       accessToken: tokens.accessToken,
       refreshToken: tokens.refreshToken ?? '',
       oryTokenEndpoint: tokenEndpoint,
+      oryRevokeEndpoint: revokeEndpoint,
       cliClientId: env.clientId,
     }),
     origin

--- a/src/app/api/auth/oauth/cli-callback/route.ts
+++ b/src/app/api/auth/oauth/cli-callback/route.ts
@@ -1,0 +1,80 @@
+import 'server-only'
+
+import { type NextRequest, NextResponse } from 'next/server'
+import { getAuthContext } from '@/core/server/auth'
+import {
+  buildTokenEndpoint,
+  CLI_OAUTH_CALLBACK_PATH,
+  CLI_OAUTH_FLOW_COOKIE,
+  exchangeCliCallback,
+  openCliFlowState,
+  readCliOAuthEnv,
+} from '@/core/server/auth/ory/cli-oauth'
+
+// Hydra redirects here with ?code after SSO. We exchange the code (validating
+// state + PKCE), then redirect to the CLI's localhost with the tokens.
+// The user must have an active Kratos session — Hydra used SSO to issue the
+// code without a login prompt.
+export async function GET(request: NextRequest) {
+  const origin = request.nextUrl.origin
+
+  const flow = await openCliFlowState(
+    request.cookies.get(CLI_OAUTH_FLOW_COOKIE)?.value
+  )
+
+  if (!flow) {
+    return finalize(
+      new NextResponse('Invalid or expired flow state', { status: 400 }),
+      origin
+    )
+  }
+
+  const authContext = await getAuthContext()
+  if (!authContext) {
+    return finalize(
+      new NextResponse('Not authenticated', { status: 401 }),
+      origin
+    )
+  }
+
+  const env = readCliOAuthEnv()
+  const redirectUri = `${origin}${CLI_OAUTH_CALLBACK_PATH}`
+
+  let tokens: Awaited<ReturnType<typeof exchangeCliCallback>>
+  try {
+    tokens = await exchangeCliCallback({
+      currentUrl: new URL(request.url),
+      expectedState: flow.state,
+      codeVerifier: flow.codeVerifier,
+      redirectUri,
+    })
+  } catch (error) {
+    return finalize(
+      new NextResponse(
+        `Token exchange failed: ${error instanceof Error ? error.message : String(error)}`,
+        { status: 502 }
+      ),
+      origin
+    )
+  }
+
+  const tokenEndpoint = buildTokenEndpoint(env.issuer.href)
+
+  const params = new URLSearchParams({
+    email: authContext.user.email ?? '',
+    accessToken: tokens.accessToken,
+    refreshToken: tokens.refreshToken ?? '',
+    oryTokenEndpoint: tokenEndpoint,
+    cliClientId: env.clientId,
+  })
+
+  return finalize(
+    NextResponse.redirect(`${flow.next}?${params.toString()}`),
+    origin
+  )
+}
+
+function finalize(response: NextResponse, _origin: string): NextResponse {
+  response.cookies.delete(CLI_OAUTH_FLOW_COOKIE)
+  return response
+}

--- a/src/app/api/auth/oauth/cli-callback/route.ts
+++ b/src/app/api/auth/oauth/cli-callback/route.ts
@@ -10,6 +10,7 @@ import {
   openCliFlowState,
   readCliOAuthEnv,
 } from '@/core/server/auth/ory/cli-oauth'
+import { isLoopbackUrl } from '@/core/shared/schemas/url'
 
 // Hydra redirects here with ?code after SSO. We exchange the code (validating
 // state + PKCE), then redirect to the CLI's localhost with the tokens.
@@ -22,7 +23,7 @@ export async function GET(request: NextRequest) {
     request.cookies.get(CLI_OAUTH_FLOW_COOKIE)?.value
   )
 
-  if (!flow) {
+  if (!flow || !isLoopbackUrl(flow.next)) {
     return finalize(
       new NextResponse('Invalid or expired flow state', { status: 400 }),
       origin

--- a/src/app/api/auth/oauth/cli-callback/route.ts
+++ b/src/app/api/auth/oauth/cli-callback/route.ts
@@ -69,7 +69,7 @@ export async function GET(request: NextRequest) {
       refreshToken: tokens.refreshToken ?? '',
       tokenEndpoint: tokenEndpoint,
       revokeEndpoint: revokeEndpoint,
-      cliClientId: env.clientId,
+      clientId: env.clientId,
     }),
     origin
   )

--- a/src/app/api/auth/oauth/cli-callback/route.ts
+++ b/src/app/api/auth/oauth/cli-callback/route.ts
@@ -39,7 +39,17 @@ export async function GET(request: NextRequest) {
     )
   }
 
-  const env = readCliOAuthEnv()
+  let env: ReturnType<typeof readCliOAuthEnv>
+  try {
+    env = readCliOAuthEnv()
+  } catch (error) {
+    return finalize(
+      redirectWithParams(flow.next, {
+        error: `OAuth configuration error: ${error instanceof Error ? error.message : String(error)}`,
+      }),
+      origin
+    )
+  }
   const redirectUri = `${origin}${CLI_OAUTH_CALLBACK_PATH}`
 
   let tokens: Awaited<ReturnType<typeof exchangeCliCallback>>

--- a/src/app/api/auth/oauth/cli-start/route.ts
+++ b/src/app/api/auth/oauth/cli-start/route.ts
@@ -1,0 +1,39 @@
+import { type NextRequest, NextResponse } from 'next/server'
+import {
+  buildCliAuthorizationRequest,
+  CLI_OAUTH_CALLBACK_PATH,
+  CLI_OAUTH_FLOW_COOKIE,
+  cliFlowCookieOptions,
+  sealCliFlowState,
+} from '@/core/server/auth/ory/cli-oauth'
+import { isLoopbackUrl } from '@/core/shared/schemas/url'
+
+// Initiates the CLI OAuth flow with the public client. The browser is
+// redirected to Hydra; if a Kratos session is active, Hydra issues an
+// authorization code immediately (SSO, no login prompt).
+export async function GET(request: NextRequest) {
+  const next = request.nextUrl.searchParams.get('next')
+
+  if (!next || !isLoopbackUrl(next)) {
+    return new NextResponse('Invalid redirect URL', { status: 400 })
+  }
+
+  const redirectUri = `${request.nextUrl.origin}${CLI_OAUTH_CALLBACK_PATH}`
+
+  const authorization = await buildCliAuthorizationRequest(redirectUri)
+
+  const sealedFlow = await sealCliFlowState({
+    state: authorization.state,
+    codeVerifier: authorization.codeVerifier,
+    next,
+  })
+
+  const response = NextResponse.redirect(authorization.url)
+  response.cookies.set(
+    CLI_OAUTH_FLOW_COOKIE,
+    sealedFlow,
+    cliFlowCookieOptions()
+  )
+
+  return response
+}

--- a/src/app/api/auth/oauth/cli-start/route.ts
+++ b/src/app/api/auth/oauth/cli-start/route.ts
@@ -22,8 +22,14 @@ export async function GET(request: NextRequest) {
   const redirectUri = `${request.nextUrl.origin}${CLI_OAUTH_CALLBACK_PATH}`
 
   let authorization: CliAuthorizationRequest
+  let sealedFlow: string
   try {
     authorization = await buildCliAuthorizationRequest(redirectUri)
+    sealedFlow = await sealCliFlowState({
+      state: authorization.state,
+      codeVerifier: authorization.codeVerifier,
+      next,
+    })
   } catch (error) {
     const errorUrl = new URL(next)
     errorUrl.searchParams.set(
@@ -32,12 +38,6 @@ export async function GET(request: NextRequest) {
     )
     return NextResponse.redirect(errorUrl)
   }
-
-  const sealedFlow = await sealCliFlowState({
-    state: authorization.state,
-    codeVerifier: authorization.codeVerifier,
-    next,
-  })
 
   const response = NextResponse.redirect(authorization.url)
   response.cookies.set(

--- a/src/app/api/auth/oauth/cli-start/route.ts
+++ b/src/app/api/auth/oauth/cli-start/route.ts
@@ -3,6 +3,7 @@ import {
   buildCliAuthorizationRequest,
   CLI_OAUTH_CALLBACK_PATH,
   CLI_OAUTH_FLOW_COOKIE,
+  type CliAuthorizationRequest,
   cliFlowCookieOptions,
   sealCliFlowState,
 } from '@/core/server/auth/ory/cli-oauth'
@@ -20,7 +21,16 @@ export async function GET(request: NextRequest) {
 
   const redirectUri = `${request.nextUrl.origin}${CLI_OAUTH_CALLBACK_PATH}`
 
-  const authorization = await buildCliAuthorizationRequest(redirectUri)
+  let authorization: CliAuthorizationRequest
+  try {
+    authorization = await buildCliAuthorizationRequest(redirectUri)
+  } catch (error) {
+    return NextResponse.redirect(
+      `${next}?${new URLSearchParams({
+        error: `Failed to start OAuth flow: ${error instanceof Error ? error.message : String(error)}`,
+      }).toString()}`
+    )
+  }
 
   const sealedFlow = await sealCliFlowState({
     state: authorization.state,

--- a/src/app/api/auth/oauth/cli-start/route.ts
+++ b/src/app/api/auth/oauth/cli-start/route.ts
@@ -25,11 +25,12 @@ export async function GET(request: NextRequest) {
   try {
     authorization = await buildCliAuthorizationRequest(redirectUri)
   } catch (error) {
-    return NextResponse.redirect(
-      `${next}?${new URLSearchParams({
-        error: `Failed to start OAuth flow: ${error instanceof Error ? error.message : String(error)}`,
-      }).toString()}`
+    const errorUrl = new URL(next)
+    errorUrl.searchParams.set(
+      'error',
+      `Failed to start OAuth flow: ${error instanceof Error ? error.message : String(error)}`
     )
+    return NextResponse.redirect(errorUrl)
   }
 
   const sealedFlow = await sealCliFlowState({

--- a/src/app/consent/route.ts
+++ b/src/app/consent/route.ts
@@ -29,11 +29,16 @@ export async function GET(request: NextRequest) {
     const consent = await oauth2.getOAuth2ConsentRequest({ consentChallenge })
 
     const { clientId } = readOryOAuthEnv()
-    if (consent.client?.client_id !== clientId) {
+    const cliClientId = process.env.ORY_OAUTH2_CLI_CLIENT_ID
+    const allowedClientIds = new Set(
+      [clientId, cliClientId].filter((id): id is string => Boolean(id))
+    )
+    const requestClientId = consent.client?.client_id
+    if (!requestClientId || !allowedClientIds.has(requestClientId)) {
       l.warn(
         {
           key: 'oauth_consent:unexpected_client',
-          clientId: consent.client?.client_id,
+          clientId: requestClientId,
         },
         'refusing to auto-consent for unexpected OAuth client'
       )

--- a/src/core/modules/feature-flags/definitions.ts
+++ b/src/core/modules/feature-flags/definitions.ts
@@ -15,6 +15,14 @@ export const FEATURE_FLAGS = {
     description: 'Enables dashboard admin-only surfaces.',
     exposure: 'server',
   },
+  blockLegacyCliAuth: {
+    kind: 'boolean',
+    key: 'block_legacy_cli_auth',
+    defaultValue: false,
+    description:
+      'Blocks the legacy e2b access token CLI auth flow. When enabled, old CLI versions see an upgrade prompt instead.',
+    exposure: 'server',
+  },
 } as const satisfies Record<string, FeatureFlagDefinition>
 
 export type FeatureFlagId = keyof typeof FEATURE_FLAGS

--- a/src/core/modules/feature-flags/definitions.ts
+++ b/src/core/modules/feature-flags/definitions.ts
@@ -23,6 +23,14 @@ export const FEATURE_FLAGS = {
       'Blocks the legacy e2b access token CLI auth flow. When enabled, old CLI versions see an upgrade prompt instead.',
     exposure: 'server',
   },
+  disableE2BAccessTokenProvisioning: {
+    kind: 'boolean',
+    key: 'disable_e2b_access_token_provisioning',
+    defaultValue: false,
+    description:
+      'Disables provisioning of e2b access tokens via generateE2BUserAccessToken. When enabled, the legacy CLI flow shows an upgrade prompt and the createAccessToken tRPC mutation returns an error.',
+    exposure: 'server',
+  },
 } as const satisfies Record<string, FeatureFlagDefinition>
 
 export type FeatureFlagId = keyof typeof FEATURE_FLAGS

--- a/src/core/modules/feature-flags/definitions.ts
+++ b/src/core/modules/feature-flags/definitions.ts
@@ -15,14 +15,6 @@ export const FEATURE_FLAGS = {
     description: 'Enables dashboard admin-only surfaces.',
     exposure: 'server',
   },
-  blockLegacyCliAuth: {
-    kind: 'boolean',
-    key: 'block_legacy_cli_auth',
-    defaultValue: false,
-    description:
-      'Blocks the legacy e2b access token CLI auth flow. When enabled, old CLI versions see an upgrade prompt instead.',
-    exposure: 'server',
-  },
   disableE2BAccessTokenProvisioning: {
     kind: 'boolean',
     key: 'disable_e2b_access_token_provisioning',

--- a/src/core/server/api/routers/user.ts
+++ b/src/core/server/api/routers/user.ts
@@ -1,5 +1,6 @@
 import { TRPCError } from '@trpc/server'
 import { z } from 'zod'
+import { featureFlags } from '@/core/modules/feature-flags/feature-flags.server'
 import {
   type AuthUser,
   getUserProfile,
@@ -10,7 +11,6 @@ import { createTRPCRouter } from '@/core/server/trpc/init'
 import { protectedProcedure } from '@/core/server/trpc/procedures'
 import { l } from '@/core/shared/clients/logger/logger'
 import { generateE2BUserAccessToken } from '@/lib/utils/server'
-import { featureFlags } from '@/core/modules/feature-flags/feature-flags.server'
 
 // How long the live identity-provider profile lookup is allowed to take before
 // we fall back to the cheap session user. Keeps a slow Ory admin API out of the

--- a/src/core/server/api/routers/user.ts
+++ b/src/core/server/api/routers/user.ts
@@ -10,6 +10,7 @@ import { createTRPCRouter } from '@/core/server/trpc/init'
 import { protectedProcedure } from '@/core/server/trpc/procedures'
 import { l } from '@/core/shared/clients/logger/logger'
 import { generateE2BUserAccessToken } from '@/lib/utils/server'
+import { featureFlags } from '@/core/modules/feature-flags/feature-flags.server'
 
 // How long the live identity-provider profile lookup is allowed to take before
 // we fall back to the cheap session user. Keeps a slow Ory admin API out of the
@@ -145,6 +146,23 @@ export const userRouter = createTRPCRouter({
 
   // Creates (POSTs) a fresh E2B access token — non-idempotent, fired on demand.
   createAccessToken: protectedProcedure.mutation(async ({ ctx }) => {
+    const provisioningDisabled = await featureFlags.isEnabled(
+      'disableE2BAccessTokenProvisioning',
+      {
+        user: {
+          id: ctx.user.id,
+          email: ctx.user.email ?? undefined,
+        },
+      }
+    )
+
+    if (provisioningDisabled) {
+      throw new TRPCError({
+        code: 'PRECONDITION_FAILED',
+        message: 'E2B access token provisioning is disabled',
+      })
+    }
+
     try {
       return await generateE2BUserAccessToken(ctx.session.access_token)
     } catch (error) {

--- a/src/core/server/auth/ory/cli-oauth.ts
+++ b/src/core/server/auth/ory/cli-oauth.ts
@@ -1,0 +1,208 @@
+import 'server-only'
+
+import { EncryptJWT, jwtDecrypt } from 'jose'
+import * as oauth from 'oauth4webapi'
+import { isLoopbackUrl } from '@/core/shared/schemas/url'
+import { CONTENT_ENCRYPTION, deriveKey, KEY_ALGORITHM } from './cookie-crypto'
+
+// Public OAuth2 client for CLI token issuance. Mirrors oauth-client.ts but
+// uses oauth.None() (no client secret) instead of ClientSecretBasic. The CLI
+// receives Hydra JWTs via this flow and refreshes them directly with Ory.
+
+const OAUTH_SCOPE = 'openid offline_access email profile'
+
+export const CLI_OAUTH_FLOW_COOKIE = 'e2b_cli_oauth_flow'
+export const CLI_OAUTH_CALLBACK_PATH = '/api/auth/oauth/cli-callback'
+
+const FLOW_COOKIE_MAX_AGE_SECONDS = 60 * 5
+
+type CliOAuthEnv = {
+  issuer: URL
+  clientId: string
+  audience?: string
+  insecure: boolean
+}
+
+export type CliAuthorizationRequest = {
+  url: string
+  state: string
+  codeVerifier: string
+}
+
+export type CliTokenExchange = {
+  accessToken: string
+  refreshToken?: string
+}
+
+export type CliFlowState = {
+  state: string
+  codeVerifier: string
+  next: string
+}
+
+export function readCliOAuthEnv(): CliOAuthEnv {
+  const issuerValue =
+    process.env.ORY_HYDRA_PUBLIC_URL ?? process.env.ORY_SDK_URL
+  const clientId = process.env.ORY_OAUTH2_CLI_CLIENT_ID
+
+  if (!issuerValue || !clientId) {
+    throw new Error(
+      'CLI OAuth client is misconfigured (need ORY_HYDRA_PUBLIC_URL or ORY_SDK_URL, ORY_OAUTH2_CLI_CLIENT_ID)'
+    )
+  }
+
+  const issuer = new URL(issuerValue)
+  return {
+    issuer,
+    clientId,
+    audience: process.env.ORY_OAUTH2_AUDIENCE,
+    insecure: issuer.protocol === 'http:' && isLoopbackUrl(issuer.href),
+  }
+}
+
+let cachedAs: {
+  issuer: string
+  as: Promise<oauth.AuthorizationServer>
+} | null = null
+
+function discoverAuthorizationServer(
+  env: CliOAuthEnv
+): Promise<oauth.AuthorizationServer> {
+  if (cachedAs?.issuer === env.issuer.href) return cachedAs.as
+
+  const discovery = oauth
+    .discoveryRequest(env.issuer, {
+      algorithm: 'oidc',
+      ...(env.insecure ? { [oauth.allowInsecureRequests]: true } : {}),
+    })
+    .then((response) => oauth.processDiscoveryResponse(env.issuer, response))
+
+  discovery.catch(() => {
+    if (cachedAs?.as === discovery) cachedAs = null
+  })
+
+  cachedAs = { issuer: env.issuer.href, as: discovery }
+  return discovery
+}
+
+function cliClient(env: CliOAuthEnv): oauth.Client {
+  return { client_id: env.clientId }
+}
+
+export async function buildCliAuthorizationRequest(
+  redirectUri: string
+): Promise<CliAuthorizationRequest> {
+  const env = readCliOAuthEnv()
+  const as = await discoverAuthorizationServer(env)
+
+  if (!as.authorization_endpoint) {
+    throw new Error('Ory discovery metadata is missing authorization_endpoint')
+  }
+
+  const codeVerifier = oauth.generateRandomCodeVerifier()
+  const codeChallenge = await oauth.calculatePKCECodeChallenge(codeVerifier)
+  const state = oauth.generateRandomState()
+
+  const url = new URL(as.authorization_endpoint)
+  url.searchParams.set('client_id', env.clientId)
+  url.searchParams.set('redirect_uri', redirectUri)
+  url.searchParams.set('response_type', 'code')
+  url.searchParams.set('scope', OAUTH_SCOPE)
+  url.searchParams.set('code_challenge', codeChallenge)
+  url.searchParams.set('code_challenge_method', 'S256')
+  url.searchParams.set('state', state)
+  if (env.audience) url.searchParams.set('audience', env.audience)
+
+  return { url: url.toString(), state, codeVerifier }
+}
+
+export async function exchangeCliCallback(params: {
+  currentUrl: URL
+  expectedState: string
+  codeVerifier: string
+  redirectUri: string
+}): Promise<CliTokenExchange> {
+  const env = readCliOAuthEnv()
+  const as = await discoverAuthorizationServer(env)
+  const client = cliClient(env)
+  // Public client: no client secret.
+  const clientAuth = oauth.None()
+
+  const callbackParams = oauth.validateAuthResponse(
+    as,
+    client,
+    params.currentUrl,
+    params.expectedState
+  )
+
+  const response = await oauth.authorizationCodeGrantRequest(
+    as,
+    client,
+    clientAuth,
+    callbackParams,
+    params.redirectUri,
+    params.codeVerifier,
+    env.insecure ? { [oauth.allowInsecureRequests]: true } : undefined
+  )
+
+  const result = await oauth.processAuthorizationCodeResponse(
+    as,
+    client,
+    response,
+    // CLI flow does not use nonce (no id_token verification needed).
+    { expectedNonce: undefined, requireIdToken: false }
+  )
+
+  return {
+    accessToken: result.access_token,
+    refreshToken: result.refresh_token,
+  }
+}
+
+export async function sealCliFlowState(flow: CliFlowState): Promise<string> {
+  return new EncryptJWT({
+    state: flow.state,
+    codeVerifier: flow.codeVerifier,
+    next: flow.next,
+  })
+    .setProtectedHeader({ alg: KEY_ALGORITHM, enc: CONTENT_ENCRYPTION })
+    .setIssuedAt()
+    .encrypt(await deriveKey())
+}
+
+export async function openCliFlowState(
+  value: string | undefined | null
+): Promise<CliFlowState | null> {
+  if (!value) return null
+
+  try {
+    const { payload } = await jwtDecrypt(value, await deriveKey())
+    const { state, codeVerifier, next } = payload
+    if (
+      typeof state !== 'string' ||
+      typeof codeVerifier !== 'string' ||
+      typeof next !== 'string'
+    ) {
+      return null
+    }
+
+    return { state, codeVerifier, next }
+  } catch {
+    return null
+  }
+}
+
+export function cliFlowCookieOptions() {
+  return {
+    httpOnly: true as const,
+    sameSite: 'lax' as const,
+    path: '/' as const,
+    secure: process.env.NODE_ENV === 'production',
+    maxAge: FLOW_COOKIE_MAX_AGE_SECONDS,
+  }
+}
+
+export function buildTokenEndpoint(issuer: string): string {
+  const base = issuer.replace(/\/$/, '')
+  return `${base}/oauth2/token`
+}

--- a/src/core/server/auth/ory/cli-oauth.ts
+++ b/src/core/server/auth/ory/cli-oauth.ts
@@ -206,3 +206,8 @@ export function buildTokenEndpoint(issuer: string): string {
   const base = issuer.replace(/\/$/, '')
   return `${base}/oauth2/token`
 }
+
+export function buildRevokeEndpoint(issuer: string): string {
+  const base = issuer.replace(/\/$/, '')
+  return `${base}/oauth2/revoke`
+}

--- a/src/lib/env.ts
+++ b/src/lib/env.ts
@@ -19,6 +19,7 @@ export const serverSchema = z.object({
   ORY_HYDRA_PUBLIC_URL: z.url().optional(),
   ORY_OAUTH2_CLIENT_ID: z.string().min(1).optional(),
   ORY_OAUTH2_CLIENT_SECRET: z.string().min(1).optional(),
+  ORY_OAUTH2_CLI_CLIENT_ID: z.string().min(1).optional(),
   ORY_OAUTH2_AUDIENCE: z.string().min(1).optional(),
   ORY_PROJECT_API_TOKEN: z.string().min(1).optional(),
   ORY_KRATOS_ADMIN_URL: z.url().optional(),
@@ -91,6 +92,7 @@ const oryRequiredEnvVars = [
   'ORY_SDK_URL',
   'ORY_OAUTH2_CLIENT_ID',
   'ORY_OAUTH2_CLIENT_SECRET',
+  'ORY_OAUTH2_CLI_CLIENT_ID',
   'ORY_OAUTH2_AUDIENCE',
   'DASHBOARD_API_ADMIN_TOKEN',
 ] as const satisfies readonly (keyof MergedEnv)[]

--- a/tests/setup.ts
+++ b/tests/setup.ts
@@ -9,6 +9,7 @@ process.env.E2B_SESSION_SECRET ??= 'test-session-secret'
 process.env.ORY_SDK_URL ??= 'https://test-ory.projects.oryapis.com'
 process.env.ORY_OAUTH2_CLIENT_ID ??= 'test-ory-client-id'
 process.env.ORY_OAUTH2_CLIENT_SECRET ??= 'test-ory-client-secret'
+process.env.ORY_OAUTH2_CLI_CLIENT_ID ??= 'test-ory-cli-client-id'
 process.env.ORY_OAUTH2_AUDIENCE ??= 'https://api.e2b-test.dev'
 process.env.ORY_PROJECT_API_TOKEN ??= 'test-ory-project-api-token'
 

--- a/tests/unit/feature-flags.test.ts
+++ b/tests/unit/feature-flags.test.ts
@@ -66,7 +66,7 @@ describe('createFeatureFlagService', () => {
     expect(provider.evaluate).toHaveBeenCalledWith(context, [
       FEATURE_FLAGS.agentsEnabled,
       FEATURE_FLAGS.isAdmin,
-      FEATURE_FLAGS.blockLegacyCliAuth,
+      FEATURE_FLAGS.disableE2BAccessTokenProvisioning,
     ])
     expect(result).toEqual([
       {
@@ -86,11 +86,11 @@ describe('createFeatureFlagService', () => {
         value: true,
       },
       {
-        id: 'blockLegacyCliAuth',
-        key: 'block_legacy_cli_auth',
+        id: 'disableE2BAccessTokenProvisioning',
+        key: 'disable_e2b_access_token_provisioning',
         kind: 'boolean',
         description:
-          'Blocks the legacy e2b access token CLI auth flow. When enabled, old CLI versions see an upgrade prompt instead.',
+          'Disables provisioning of e2b access tokens via generateE2BUserAccessToken. When enabled, the legacy CLI flow shows an upgrade prompt and the createAccessToken tRPC mutation returns an error.',
         defaultValue: false,
         value: true,
       },

--- a/tests/unit/feature-flags.test.ts
+++ b/tests/unit/feature-flags.test.ts
@@ -66,6 +66,7 @@ describe('createFeatureFlagService', () => {
     expect(provider.evaluate).toHaveBeenCalledWith(context, [
       FEATURE_FLAGS.agentsEnabled,
       FEATURE_FLAGS.isAdmin,
+      FEATURE_FLAGS.blockLegacyCliAuth,
     ])
     expect(result).toEqual([
       {
@@ -81,6 +82,15 @@ describe('createFeatureFlagService', () => {
         key: 'is_admin',
         kind: 'boolean',
         description: 'Enables dashboard admin-only surfaces.',
+        defaultValue: false,
+        value: true,
+      },
+      {
+        id: 'blockLegacyCliAuth',
+        key: 'block_legacy_cli_auth',
+        kind: 'boolean',
+        description:
+          'Blocks the legacy e2b access token CLI auth flow. When enabled, old CLI versions see an upgrade prompt instead.',
         defaultValue: false,
         value: true,
       },


### PR DESCRIPTION
## Summary

Adds a public OAuth2 client flow for CLI token issuance. CLI versions >= 2.12.2 use PKCE-based OAuth with Hydra's public client instead of the legacy e2b access token flow. The dashboard acts as consent provider for both the dashboard and CLI OAuth clients.

Paired with: E2B CLI PR replacing access token auth with Hydra OAuth flow