### PR TITLE
feat: skip bootstrap call when Kratos identity already has external_id

### DIFF
--- a/src/app/api/auth/oauth/callback/ory/route.ts
+++ b/src/app/api/auth/oauth/callback/ory/route.ts
@@ -10,13 +10,13 @@ import {
   openOryFlowState,
 } from '@/core/server/auth/ory/oauth-flow'
 import { resolveOryRedirectUri } from '@/core/server/auth/ory/oauth-relay'
+import { readKratosExternalId } from '@/core/server/auth/ory/session'
 import {
   E2B_SESSION_COOKIE,
   ORY_SIGNUP_METADATA_COOKIE,
   sealSessionCookie,
   sessionCookieOptions,
 } from '@/core/server/auth/ory/session-cookie'
-import { readKratosExternalId } from '@/core/server/auth/ory/session'
 import {
   buildOryLogoutUrl,
   ORY_POST_LOGOUT_PATH,
@@ -89,7 +89,9 @@ export async function GET(request: NextRequest) {
         ? await buildOryLogoutUrl({ idToken: tokens.idToken, origin })
         : null
       return finalize(
-        NextResponse.redirect(logoutUrl ?? new URL(ORY_POST_LOGOUT_PATH, origin))
+        NextResponse.redirect(
+          logoutUrl ?? new URL(ORY_POST_LOGOUT_PATH, origin)
+        )
       )
     }
   }

--- a/src/app/api/auth/oauth/callback/ory/route.ts
+++ b/src/app/api/auth/oauth/callback/ory/route.ts
@@ -16,6 +16,7 @@ import {
   sealSessionCookie,
   sessionCookieOptions,
 } from '@/core/server/auth/ory/session-cookie'
+import { readKratosExternalId } from '@/core/server/auth/ory/session'
 import {
   buildOryLogoutUrl,
   ORY_POST_LOGOUT_PATH,
@@ -64,25 +65,33 @@ export async function GET(request: NextRequest) {
     return finalize(NextResponse.redirect(new URL(ORY_RECOVER_PATH, origin)))
   }
 
-  const bootstrapped = await ensureOryUserBootstrapped({
-    accessToken: tokens.accessToken,
-    idToken: tokens.idToken,
-    provider: 'ory',
-  })
+  // Bootstrap links the Kratos identity to its dashboard user and backfills
+  // external_id. Once that's set the user is fully provisioned, so skip the admin
+  // call on repeat logins. A null read (e.g. session cookie not yet visible) falls
+  // through to bootstrap — identical to the prior unconditional behavior.
+  const alreadyProvisioned = await readKratosExternalId()
 
-  if (!bootstrapped) {
-    l.error(
-      { key: 'oauth_callback:bootstrap_failed' },
-      'dashboard bootstrap failed; ending the Ory session without a dashboard cookie'
-    )
-    // Don't strand the user with a half-provisioned login: end the Ory + Kratos
-    // session via RP-logout (falling back to home if no id_token is available).
-    const logoutUrl = tokens.idToken
-      ? await buildOryLogoutUrl({ idToken: tokens.idToken, origin })
-      : null
-    return finalize(
-      NextResponse.redirect(logoutUrl ?? new URL(ORY_POST_LOGOUT_PATH, origin))
-    )
+  if (!alreadyProvisioned) {
+    const bootstrapped = await ensureOryUserBootstrapped({
+      accessToken: tokens.accessToken,
+      idToken: tokens.idToken,
+      provider: 'ory',
+    })
+
+    if (!bootstrapped) {
+      l.error(
+        { key: 'oauth_callback:bootstrap_failed' },
+        'dashboard bootstrap failed; ending the Ory session without a dashboard cookie'
+      )
+      // Don't strand the user with a half-provisioned login: end the Ory + Kratos
+      // session via RP-logout (falling back to home if no id_token is available).
+      const logoutUrl = tokens.idToken
+        ? await buildOryLogoutUrl({ idToken: tokens.idToken, origin })
+        : null
+      return finalize(
+        NextResponse.redirect(logoutUrl ?? new URL(ORY_POST_LOGOUT_PATH, origin))
+      )
+    }
   }
 
   const sealed = await sealSessionCookie({

--- a/src/core/server/auth/ory/session.ts
+++ b/src/core/server/auth/ory/session.ts
@@ -72,6 +72,15 @@ export async function getAuthContext(): Promise<AuthContext | null> {
   }
 }
 
+// external_id is set by bootstrap and lives only on the Kratos identity (never in
+// the token claims). A non-null value means the user is already provisioned, so
+// the OAuth callback can skip the bootstrap admin call. Reuses the request-cached
+// session read — no extra whoami round trip.
+export async function readKratosExternalId(): Promise<string | null> {
+  const kratos = await readKratosSession()
+  return kratos?.active ? (kratos.identity?.external_id ?? null) : null
+}
+
 export async function getUserProfile(): Promise<AuthUser | null> {
   const identityId = (await readKratosSession())?.identity?.id
   if (!identityId) return null

--- a/tests/integration/auth-ory-callback.test.ts
+++ b/tests/integration/auth-ory-callback.test.ts
@@ -12,6 +12,7 @@ import {
 
 const exchangeMock = vi.hoisted(() => vi.fn())
 const bootstrapMock = vi.hoisted(() => vi.fn())
+const readExternalIdMock = vi.hoisted(() => vi.fn())
 
 vi.mock('@/core/server/auth/ory/oauth-client', () => ({
   exchangeOryCallback: exchangeMock,
@@ -19,6 +20,10 @@ vi.mock('@/core/server/auth/ory/oauth-client', () => ({
 
 vi.mock('@/core/server/auth/ory/dashboard-bootstrap', () => ({
   ensureOryUserBootstrapped: bootstrapMock,
+}))
+
+vi.mock('@/core/server/auth/ory/session', () => ({
+  readKratosExternalId: readExternalIdMock,
 }))
 
 vi.mock('@/core/shared/clients/logger/logger', () => ({
@@ -64,6 +69,8 @@ describe('Ory OAuth callback', () => {
     vi.stubEnv('ORY_HYDRA_PUBLIC_URL', 'https://ory.example.com')
     exchangeMock.mockReset().mockResolvedValue(tokens)
     bootstrapMock.mockReset().mockResolvedValue(true)
+    // Default to an unprovisioned identity so bootstrap runs as before.
+    readExternalIdMock.mockReset().mockResolvedValue(null)
   })
 
   afterEach(() => {
@@ -114,6 +121,26 @@ describe('Ory OAuth callback', () => {
       'https://app.e2b.dev/api/auth/oauth/recover'
     )
     expect(response.cookies.get(E2B_SESSION_COOKIE)?.value).toBeUndefined()
+  })
+
+  it('bootstraps when the identity has no external_id yet', async () => {
+    await GET(await callbackRequest())
+
+    expect(bootstrapMock).toHaveBeenCalledOnce()
+  })
+
+  it('skips bootstrap when the identity already has an external_id', async () => {
+    readExternalIdMock.mockResolvedValueOnce('user-ext-123')
+
+    const response = await GET(await callbackRequest({ returnTo: '/dashboard' }))
+
+    expect(bootstrapMock).not.toHaveBeenCalled()
+    // The session is still sealed and the user lands on their destination.
+    const sealed = response.cookies.get(E2B_SESSION_COOKIE)?.value
+    expect(await openSessionCookie(sealed)).toEqual(tokens)
+    expect(response.headers.get('location')).toBe(
+      'https://app.e2b.dev/dashboard'
+    )
   })
 
   it('RP-logs-out (no dashboard cookie) when bootstrap fails', async () => {

--- a/tests/integration/auth-ory-callback.test.ts
+++ b/tests/integration/auth-ory-callback.test.ts
@@ -132,7 +132,9 @@ describe('Ory OAuth callback', () => {
   it('skips bootstrap when the identity already has an external_id', async () => {
     readExternalIdMock.mockResolvedValueOnce('user-ext-123')
 
-    const response = await GET(await callbackRequest({ returnTo: '/dashboard' }))
+    const response = await GET(
+      await callbackRequest({ returnTo: '/dashboard' })
+    )
 
     expect(bootstrapMock).not.toHaveBeenCalled()
     // The session is still sealed and the user lands on their destination.


### PR DESCRIPTION
The OAuth callback bootstrapped the dashboard user on every login. Once `external_id` is set the user is fully provisioned, so gate the admin bootstrap call on a request-cached whoami read and skip it on repeat logins. A null read falls through to bootstrap, preserving prior behavior.