### PR TITLE
feat: disable new access token creation after July 1

### DIFF
--- a/src/configs/urls.ts
+++ b/src/configs/urls.ts
@@ -100,6 +100,8 @@ export const HELP_URLS = {
   BUILD_TEMPLATE:
     'https://e2b.dev/docs/sandbox-template#4-build-your-sandbox-template',
   START_COMMAND: 'https://e2b.dev/docs/sandbox-template/start-cmd',
+  ACCESS_TOKEN_DEPRECATION:
+    'https://e2b.dev/docs/migration/access-token-deprecation',
 }
 
 export const BASE_URL = process.env.VERCEL_ENV

--- a/src/features/dashboard/account/access-token-settings.tsx
+++ b/src/features/dashboard/account/access-token-settings.tsx
@@ -1,6 +1,10 @@
 'use client'
 
+import Link from 'next/link'
+import { HELP_URLS, PROTECTED_URLS } from '@/configs/urls'
+import { useFeatureFlag } from '@/core/modules/feature-flags/feature-flags.client'
 import { cn } from '@/lib/utils'
+import { Badge } from '@/ui/primitives/badge'
 import {
   Card,
   CardContent,
@@ -9,6 +13,7 @@ import {
   CardHeader,
   CardTitle,
 } from '@/ui/primitives/card'
+import { ChevronRightIcon, KeyIcon } from '@/ui/primitives/icons'
 import { useDashboard } from '../context'
 import UserAccessToken from './user-access-token'
 
@@ -17,26 +22,67 @@ interface AccessTokenSettingsProps {
 }
 
 export function AccessTokenSettings({ className }: AccessTokenSettingsProps) {
-  const { user } = useDashboard()
+  const { user, team } = useDashboard()
+  const provisioningDisabled = useFeatureFlag(
+    'disableE2BAccessTokenProvisioning'
+  )
 
   if (!user) return null
 
   return (
     <Card className={cn('overflow-hidden border-b md:border', className)}>
       <CardHeader>
-        <CardTitle>Access Token</CardTitle>
+        <CardTitle className="flex items-center gap-2">
+          Access Token
+          {provisioningDisabled && <Badge>Deprecated</Badge>}
+        </CardTitle>
         <CardDescription>Manage your personal access token.</CardDescription>
       </CardHeader>
 
-      <CardContent>
-        <UserAccessToken className="max-w-lg" />
+      <CardContent className="flex flex-col gap-3">
+        <UserAccessToken className="max-w-lg" disabled={provisioningDisabled} />
+
+        {provisioningDisabled && (
+          <p className="text-fg-tertiary max-w-lg leading-relaxed">
+            Access tokens are deprecated and will stop working on August 1,
+            2026.
+            <br />
+            Use an API key instead.{' '}
+            <a
+              href={HELP_URLS.ACCESS_TOKEN_DEPRECATION}
+              target="_blank"
+              rel="noopener"
+              className="text-fg underline underline-offset-2 hover:opacity-80"
+            >
+              Learn more
+            </a>
+            .
+          </p>
+        )}
       </CardContent>
 
-      <CardFooter className="bg-bg-1 justify-between gap-6">
-        <p className="text-fg-tertiary ">
-          Keep it safe, as it can be used to authenticate with E2B services.
-        </p>
-      </CardFooter>
+      {provisioningDisabled ? (
+        <CardFooter className="bg-bg-1 p-0">
+          <Link
+            href={PROTECTED_URLS.KEYS(team.slug)}
+            className="group hover:bg-bg-hover flex w-full items-center justify-between gap-3 px-6 py-4 transition-colors"
+          >
+            <span className="flex items-center gap-2">
+              <KeyIcon className="text-icon-tertiary size-4" />
+              <span className="prose-body-highlight text-fg">
+                Use API keys instead
+              </span>
+            </span>
+            <ChevronRightIcon className="text-icon-tertiary size-4 transition-transform group-hover:translate-x-0.5" />
+          </Link>
+        </CardFooter>
+      ) : (
+        <CardFooter className="bg-bg-1 justify-between gap-6">
+          <p className="text-fg-tertiary">
+            Keep it safe, as it can be used to authenticate with E2B services.
+          </p>
+        </CardFooter>
+      )}
     </Card>
   )
 }

--- a/src/features/dashboard/account/user-access-token.tsx
+++ b/src/features/dashboard/account/user-access-token.tsx
@@ -12,9 +12,13 @@ import { Loader } from '@/ui/primitives/loader'
 
 interface UserAccessTokenProps {
   className?: string
+  disabled?: boolean
 }
 
-export default function UserAccessToken({ className }: UserAccessTokenProps) {
+export default function UserAccessToken({
+  className,
+  disabled,
+}: UserAccessTokenProps) {
   const { toast } = useToast()
   const trpc = useTRPC()
   const [token, setToken] = useState<string>()
@@ -41,6 +45,7 @@ export default function UserAccessToken({ className }: UserAccessTokenProps) {
           type={isVisible ? 'text' : 'password'}
           value={token ?? '••••••••••••••••'}
           readOnly
+          disabled={disabled}
           className="bg-bg-1 font-mono"
         />
         <IconButton
@@ -54,7 +59,7 @@ export default function UserAccessToken({ className }: UserAccessTokenProps) {
               fetchToken()
             }
           }}
-          disabled={isPending}
+          disabled={isPending || disabled}
         >
           {isPending ? (
             <Loader variant="square" size="lg" />


### PR DESCRIPTION
Users should no longer be able to request or generate new access tokens after July 1.

Learn more navigates to: https://e2b.dev/docs/migration/access-token-deprecation
Use api key instead navigates to: `/dashboard/(team)/keys`


| Before | After |
|--------|--------|
| <img width="972" height="266" alt="Screenshot 2026-06-25 at 15 41 41" src="https://github.com/user-attachments/assets/15196491-95c6-4f09-844b-931b8883de23" /> | <img width="983" height="314" alt="Screenshot 2026-06-25 at 15 32 44 (1)" src="https://github.com/user-attachments/assets/f98f2d7d-26bd-4e62-91ad-9b940b030c3f" /> |

