### PR TITLE
fix: shrink E2B template badge to match Figma

### DIFF
--- a/src/ui/brand.tsx
+++ b/src/ui/brand.tsx
@@ -58,9 +58,9 @@ export const E2BLogoSmall = ({
 )
 
 export const E2BBadge = ({ className, ...props }: BadgeProps) => (
-  <Badge className={cn('gap-1', className)} variant="default" {...props}>
-    <span className="inline-flex items-center">
-      <E2BLogoSmall className="h-[8px] w-auto" />
+  <Badge className={cn('h-4', className)} variant="default" {...props}>
+    <span className="inline-flex h-[8px] w-[25px] items-center justify-center">
+      <E2BLogoSmall className="h-[7px] w-auto" />
     </span>
   </Badge>
 )


### PR DESCRIPTION
Shrinks the E2B badge used in the templates list to match the Figma spec.

| Before | After |
| ------- | ------- |
| <img width="608" height="274" alt="CleanShot 2026-06-25 at 16 58 37@2x" src="https://github.com/user-attachments/assets/22c4264f-ab3d-47d4-a58f-83837809d63e" /> | <img width="614" height="278" alt="CleanShot 2026-06-25 at 16 58 26@2x" src="https://github.com/user-attachments/assets/d740f660-0d33-49a0-84cd-f9951a75c580" /> |

closes EN-1148
  

🤖 Generated with [Claude Code](https://claude.com/claude-code)