### PR TITLE
fix: templates list and builds are missing separators

### DIFF
--- a/src/features/dashboard/templates/builds/table-body.tsx
+++ b/src/features/dashboard/templates/builds/table-body.tsx
@@ -52,7 +52,7 @@ export function BuildsTableBody({
             key={row.id}
             className={cn(
               'group/row relative h-10 min-w-full cursor-pointer -mx-2 px-2 hover:bg-bg-1 border-b-0 transition-none w-[calc(100%+16px)]',
-              'border-stroke/80 hover:z-20 focus-within:z-10',
+              'hover:z-20 focus-within:z-10',
               { 'bg-bg-1 animate-pulse': isBuilding }
             )}
             onClick={() => onRowClick(row.original)}
@@ -69,6 +69,13 @@ export function BuildsTableBody({
                 {flexRender(cell.column.columnDef.cell, cell.getContext())}
               </DataTableCell>
             ))}
+            <div
+              aria-hidden
+              className={cn(
+                'pointer-events-none absolute inset-x-2 bottom-0 border-b border-stroke/80',
+                'group-hover/row:hidden group-focus-visible/row:hidden'
+              )}
+            />
             <RowHoverFrame />
           </DataTableRow>
         )

--- a/src/features/dashboard/templates/list/table-body.tsx
+++ b/src/features/dashboard/templates/list/table-body.tsx
@@ -139,7 +139,7 @@ export function TemplatesTableBody({
               isSelected={row.getIsSelected()}
               className={cn(
                 'group/row relative h-8 min-w-full -mx-2 px-2 hover:bg-bg-1 border-b-0 transition-none w-[calc(100%+16px)]',
-                'border-stroke/80 hover:z-20 focus-within:z-10',
+                'hover:z-20 focus-within:z-10',
                 'has-[button[aria-haspopup=menu][data-state=open]]:z-10'
               )}
             >
@@ -165,6 +165,14 @@ export function TemplatesTableBody({
                   {flexRender(cell.column.columnDef.cell, cell.getContext())}
                 </DataTableCell>
               ))}
+              <div
+                aria-hidden
+                className={cn(
+                  'pointer-events-none absolute inset-x-2 bottom-0 border-b border-stroke/80',
+                  'group-hover/row:hidden group-focus-visible/row:hidden',
+                  'group-has-[button[aria-haspopup=menu][data-state=open]]/row:hidden'
+                )}
+              />
               <RowHoverFrame
                 className={cn(
                   'group-has-[button[aria-haspopup=menu][data-state=open]]/row:border-stroke',


### PR DESCRIPTION
Fix: templates list and builds are missing separators

| Templates list | Template builds |
|--------|--------|
| <img width="1083" height="348" alt="templates-list" src="https://github.com/user-attachments/assets/d08b9bf7-654a-42f6-9350-495c0275a3b5" /> | <img width="1266" height="260" alt="templates-builds" src="https://github.com/user-attachments/assets/a5979d3f-d6bb-4ac9-8b00-48d5ef10df59" /> | 