### PR TITLE
feat: 'data retention is over' message across sandbox tabs

### DIFF
--- a/spec/openapi.dashboard-api.yaml
+++ b/spec/openapi.dashboard-api.yaml
@@ -565,6 +565,7 @@ components:
         - cpuCount
         - memoryMB
         - diskSizeMB
+        - retentionExpired
       properties:
         templateID:
           type: string
@@ -594,6 +595,9 @@ components:
           $ref: "#/components/schemas/MemoryMB"
         diskSizeMB:
           $ref: "#/components/schemas/DiskSizeMB"
+        retentionExpired:
+          type: boolean
+          description: Whether the sandbox ended more than the retention window ago, so its monitoring, events, and logs data is no longer available
 
     HealthResponse:
       type: object

--- a/src/core/modules/sandboxes/models.ts
+++ b/src/core/modules/sandboxes/models.ts
@@ -20,6 +20,9 @@ interface SandboxDetailsBaseModel {
   cpuCount: number
   memoryMB: number
   diskSizeMB: number
+  // True when the sandbox ended more than the retention window ago, so its
+  // monitoring, events, and logs data is no longer available.
+  retentionExpired: boolean
   lifecycle?: SandboxLifecycleModel
 }
 
@@ -169,6 +172,8 @@ export function mapInfraSandboxDetailsToModel(
     diskSizeMB: sandbox.diskSizeMB,
     metadata: sandbox.metadata,
     state: sandbox.state,
+    // Infra only serves live sandboxes, whose data is never past retention.
+    retentionExpired: false,
   }
 }
 
@@ -189,5 +194,6 @@ export function mapApiSandboxRecordToModel(
     memoryMB: sandbox.memoryMB,
     diskSizeMB: sandbox.diskSizeMB,
     state: 'killed',
+    retentionExpired: sandbox.retentionExpired,
   }
 }

--- a/src/core/server/api/routers/sandbox.ts
+++ b/src/core/server/api/routers/sandbox.ts
@@ -20,6 +20,17 @@ import { SandboxIdSchema } from '@/core/shared/schemas/api'
 import { SANDBOX_MONITORING_METRICS_RETENTION_MS } from '@/features/dashboard/sandbox/monitoring/utils/constants'
 import { TERMINAL_SANDBOX_TIMEOUT_MS } from '@/features/dashboard/terminal/constants'
 
+function isPastRetention(timestamp: string | null): boolean {
+  if (!timestamp) {
+    return false
+  }
+  const timestampMs = new Date(timestamp).getTime()
+  if (Number.isNaN(timestampMs)) {
+    return false
+  }
+  return Date.now() - timestampMs > SANDBOX_MONITORING_METRICS_RETENTION_MS
+}
+
 const sandboxRepositoryProcedure = protectedTeamProcedure.use(
   withTeamAuthedRequestRepository(
     createSandboxesRepository,
@@ -67,11 +78,21 @@ export const sandboxRouter = createTRPCRouter({
           ? (mappedDetails.stoppedAt ?? mappedDetails.endAt)
           : null
 
+      const pausedAt = derivedLifecycle.pausedAt ?? fallbackPausedAt
+
+      // A paused sandbox keeps no fresh data, so once it has been paused longer
+      // than the retention window its monitoring/events/logs are gone too. The
+      // killed case is already flagged by the backend (mappedDetails).
+      const retentionExpired =
+        mappedDetails.retentionExpired ||
+        (mappedDetails.state === 'paused' && isPastRetention(pausedAt))
+
       return {
         ...mappedDetails,
+        retentionExpired,
         lifecycle: {
           createdAt: derivedLifecycle.createdAt ?? mappedDetails.startedAt,
-          pausedAt: derivedLifecycle.pausedAt ?? fallbackPausedAt,
+          pausedAt,
           endedAt: derivedLifecycle.endedAt ?? fallbackEndedAt,
           events: derivedLifecycle.events,
         },

--- a/src/core/shared/contracts/dashboard-api.types.ts
+++ b/src/core/shared/contracts/dashboard-api.types.ts
@@ -1280,6 +1280,8 @@ export interface components {
       cpuCount: components['schemas']['CPUCount']
       memoryMB: components['schemas']['MemoryMB']
       diskSizeMB: components['schemas']['DiskSizeMB']
+      /** @description Whether the sandbox ended more than the retention window ago, so its monitoring, events, and logs data is no longer available */
+      retentionExpired: boolean
     }
     HealthResponse: {
       /** @description Human-readable health check result. */

--- a/src/features/dashboard/sandbox/common/data-retention-expired.tsx
+++ b/src/features/dashboard/sandbox/common/data-retention-expired.tsx
@@ -1,0 +1,17 @@
+import { LOG_RETENTION_MS } from '@/configs/logs'
+import DashboardEmptyFrame from '@/features/dashboard/common/empty-frame'
+
+const RETENTION_DAYS = LOG_RETENTION_MS / 24 / 60 / 60 / 1000
+
+export function DataRetentionExpired() {
+  return (
+    <DashboardEmptyFrame
+      // min-w-0 lets the frame shrink inside flex tab containers; without it the
+      // wide ASCII background forces min-content width and pushes the card off-screen.
+      className="min-w-0"
+      title="Data retention is over"
+      description={`This sandbox's monitoring, events, and logs data has exceeded the ${RETENTION_DAYS}-day retention limit and is no longer available.`}
+      descriptionPlacement="content"
+    />
+  )
+}

--- a/src/features/dashboard/sandbox/events/view.tsx
+++ b/src/features/dashboard/sandbox/events/view.tsx
@@ -1,6 +1,7 @@
 'use client'
 
 import { useMemo, useState } from 'react'
+import { DataRetentionExpired } from '@/features/dashboard/sandbox/common/data-retention-expired'
 import { useSandboxContext } from '../context'
 import { EventTypeFilter } from './event-type-filter'
 import { SandboxEventsTable } from './table'
@@ -9,7 +10,8 @@ import { useSandboxEventFilters } from './use-sandbox-event-filters'
 export const SandboxEventsView = () => {
   'use no memo'
 
-  const { sandboxLifecycle, isSandboxInfoLoading } = useSandboxContext()
+  const { sandboxInfo, sandboxLifecycle, isSandboxInfoLoading } =
+    useSandboxContext()
   const { order, orderAsc, setOrder, setTypes, types } =
     useSandboxEventFilters()
   const [scrollContainer, setScrollContainer] = useState<HTMLDivElement | null>(
@@ -31,18 +33,29 @@ export const SandboxEventsView = () => {
   }, [orderAsc, sandboxLifecycle?.events, types])
 
   return (
-    <div className="flex min-h-0 flex-1 flex-col gap-3 md:gap-6 overflow-hidden p-3 md:p-6">
-      <EventTypeFilter types={types} onTypesChange={setTypes} />
-      <div ref={setScrollContainer} className="min-h-0 flex-1 overflow-auto">
-        <SandboxEventsTable
-          events={events}
-          isLoading={isSandboxInfoLoading && !sandboxLifecycle}
-          scrollContainer={scrollContainer}
-          isTimestampDescending={order === 'desc'}
-          onToggleTimestampSort={() =>
-            setOrder(order === 'desc' ? 'asc' : 'desc')
-          }
-        />
+    <div className="flex min-h-0 flex-1 flex-col overflow-hidden p-3 md:p-6">
+      <div className="flex min-h-0 flex-1 flex-col gap-3 md:gap-6 overflow-hidden border bg-bg">
+        {sandboxInfo?.retentionExpired ? (
+          <DataRetentionExpired />
+        ) : (
+          <>
+            <EventTypeFilter types={types} onTypesChange={setTypes} />
+            <div
+              ref={setScrollContainer}
+              className="min-h-0 flex-1 overflow-auto"
+            >
+              <SandboxEventsTable
+                events={events}
+                isLoading={isSandboxInfoLoading && !sandboxLifecycle}
+                scrollContainer={scrollContainer}
+                isTimestampDescending={order === 'desc'}
+                onToggleTimestampSort={() =>
+                  setOrder(order === 'desc' ? 'asc' : 'desc')
+                }
+              />
+            </div>
+          </>
+        )}
       </div>
     </div>
   )

--- a/src/features/dashboard/sandbox/logs/logs.tsx
+++ b/src/features/dashboard/sandbox/logs/logs.tsx
@@ -12,7 +12,6 @@ import {
   useRef,
   useState,
 } from 'react'
-import { LOG_RETENTION_MS } from '@/configs/logs'
 import type { SandboxLogModel } from '@/core/modules/sandboxes/models'
 import {
   LOG_LEVEL_LEFT_BORDER_CLASS,
@@ -28,6 +27,7 @@ import {
   VirtualizedTableLoaderBody,
   VirtualizedTableRow,
 } from '@/features/dashboard/common/virtualized-table-ui'
+import { DataRetentionExpired } from '@/features/dashboard/sandbox/common/data-retention-expired'
 import { cn } from '@/lib/utils'
 import { DebouncedInput } from '@/ui/primitives/input'
 import { Loader } from '@/ui/primitives/loader'
@@ -44,28 +44,21 @@ const ROW_HEIGHT_PX = 26
 const LIVE_STATUS_ROW_HEIGHT_PX = ROW_HEIGHT_PX + 16
 const VIRTUAL_OVERSCAN = 16
 const SCROLL_LOAD_THRESHOLD_PX = 200
-const LOG_RETENTION_DAYS = LOG_RETENTION_MS / 24 / 60 / 60 / 1000
 
 interface LogsProps {
   teamSlug: string
   sandboxId: string
 }
 
-function checkIfSandboxStillHasLogs(startedAtIso: string) {
-  const startedAtUnix = new Date(startedAtIso).getTime()
-
-  if (Number.isNaN(startedAtUnix)) {
-    return true
-  }
-
-  return Date.now() - startedAtUnix < LOG_RETENTION_MS
-}
-
 export default function SandboxLogs({ teamSlug, sandboxId }: LogsProps) {
   'use no memo'
 
-  const { sandboxInfo, sandboxLifecycle, isRunning } = useSandboxContext()
+  const { sandboxInfo, isRunning } = useSandboxContext()
   const { level, setLevel, search, setSearch } = useLogFilters()
+
+  if (sandboxInfo?.retentionExpired) {
+    return <DataRetentionExpired />
+  }
 
   if (!sandboxInfo) {
     return (
@@ -90,16 +83,11 @@ export default function SandboxLogs({ teamSlug, sandboxId }: LogsProps) {
     )
   }
 
-  const hasRetainedLogs = checkIfSandboxStillHasLogs(
-    sandboxLifecycle?.createdAt ?? sandboxInfo.startedAt
-  )
-
   return (
     <LogsContent
       teamSlug={teamSlug}
       sandboxId={sandboxId}
       isRunning={isRunning}
-      hasRetainedLogs={hasRetainedLogs}
       level={level}
       search={search}
       setLevel={setLevel}
@@ -112,7 +100,6 @@ interface LogsContentProps {
   teamSlug: string
   sandboxId: string
   isRunning: boolean
-  hasRetainedLogs: boolean
   level: SandboxLogLevelFilter | null
   search: string
   setLevel: (level: SandboxLogLevelFilter | null) => void
@@ -123,7 +110,6 @@ function LogsContent({
   teamSlug,
   sandboxId,
   isRunning,
-  hasRetainedLogs,
   level,
   search,
   setLevel,
@@ -207,12 +193,7 @@ function LogsContent({
           />
 
           {showLoader && <VirtualizedTableLoaderBody />}
-          {showEmpty && (
-            <EmptyBody
-              hasRetainedLogs={hasRetainedLogs}
-              errorMessage={initialLoadError}
-            />
-          )}
+          {showEmpty && <EmptyBody errorMessage={initialLoadError} />}
           {hasLogs && scrollContainerElement && (
             <VirtualizedLogsBody
               logs={renderedLogs}
@@ -266,16 +247,13 @@ function useFilterRefetchTracking(
 }
 
 interface EmptyBodyProps {
-  hasRetainedLogs: boolean
   errorMessage: string | null
 }
 
-function EmptyBody({ hasRetainedLogs, errorMessage }: EmptyBodyProps) {
+function EmptyBody({ errorMessage }: EmptyBodyProps) {
   const description = errorMessage
     ? errorMessage
-    : !hasRetainedLogs
-      ? `This sandbox has exceeded the ${LOG_RETENTION_DAYS} day retention limit.`
-      : 'Sandbox logs will appear here once available.'
+    : 'Sandbox logs will appear here once available.'
 
   return <LogsEmptyBody description={description} />
 }

--- a/src/features/dashboard/sandbox/logs/view.tsx
+++ b/src/features/dashboard/sandbox/logs/view.tsx
@@ -12,8 +12,10 @@ export default function SandboxLogsView({
   sandboxId,
 }: SandboxLogsViewProps) {
   return (
-    <div className="flex min-h-0 flex-1 flex-col gap-4 overflow-hidden p-3 md:p-6">
-      <SandboxLogs teamSlug={teamSlug} sandboxId={sandboxId} />
+    <div className="flex min-h-0 flex-1 flex-col overflow-hidden p-3 md:p-6">
+      <div className="flex min-h-0 flex-1 flex-col overflow-hidden border bg-bg">
+        <SandboxLogs teamSlug={teamSlug} sandboxId={sandboxId} />
+      </div>
     </div>
   )
 }

--- a/src/features/dashboard/sandbox/monitoring/components/monitoring-view.tsx
+++ b/src/features/dashboard/sandbox/monitoring/components/monitoring-view.tsx
@@ -1,6 +1,7 @@
 'use client'
 
 import LoadingLayout from '@/features/dashboard/loading-layout'
+import { DataRetentionExpired } from '@/features/dashboard/sandbox/common/data-retention-expired'
 import { useSandboxContext } from '@/features/dashboard/sandbox/context'
 import SandboxMetricsCharts from './monitoring-charts'
 
@@ -18,8 +19,14 @@ export default function SandboxMonitoringView({
   }
 
   return (
-    <div className="flex min-h-0 flex-1 flex-col overflow-hidden">
-      <SandboxMetricsCharts sandboxId={sandboxId} />
+    <div className="flex min-h-0 flex-1 flex-col overflow-hidden p-3 md:p-6">
+      <div className="flex min-h-0 flex-1 flex-col overflow-hidden border bg-bg">
+        {sandboxInfo?.retentionExpired ? (
+          <DataRetentionExpired />
+        ) : (
+          <SandboxMetricsCharts sandboxId={sandboxId} />
+        )}
+      </div>
     </div>
   )
 }


### PR DESCRIPTION
## What
Shows a single, consistent **"Data retention is over"** message on a sandbox's **monitoring / events / logs** tabs once that data has aged past its 7-day TTL — replacing empty views and the old ad-hoc, client-side logs check.

## Changes
- **`models.ts`**: add \`retentionExpired\` to the sandbox details model; map it from the backend record (killed) and default \`false\` for live infra detail.
- **`common/data-retention-expired.tsx`**: new shared message component.
- **monitoring / events / logs views**: render the shared component when \`retentionExpired\` is set. Removes the old client-side \`checkIfSandboxStillHasLogs\` / \`LOG_RETENTION_MS\` logic from the logs view.
- **`sandbox.ts` (`details` resolver)**: also flag **paused** sandboxes whose last pause is older than 7 days (the backend already exposes the pause time via \`endAt\`/lifecycle \`pausedAt\`). Resumed/running sandboxes clear the flag automatically; killed sandboxes use the backend flag.
- Spec sync (\`openapi.dashboard-api.yaml\`) + regenerated contract types.
<img width="3218" height="2178" alt="CleanShot 2026-07-01 at 14 53 43@2x" src="https://github.com/user-attachments/assets/18f514c8-f817-46e8-992d-02cb6a1c08b1" />

## Matrix
| State | Flagged? |
|---|---|
| killed/stopped ended >7d ago | ✅ (backend) |
| paused >7d ago | ✅ (resolver) |
| running (even if old) | ❌ fresh data |
| recently stopped/paused (<7d) | ❌ data still present |

## Companion
- **infra** PR (e2b-dev/infra#3102): adds \`retentionExpired\` to \`SandboxRecord\` and relaxes the record retention filter.
