### PR TITLE
feat(sandboxes): server-side ordering and state filter for sandbox list

### DIFF
--- a/spec/openapi.infra.yaml
+++ b/spec/openapi.infra.yaml
@@ -2172,6 +2172,14 @@ paths:
               $ref: "#/components/schemas/SandboxState"
           style: form
           explode: false
+        - name: order
+          in: query
+          description: Sort direction by sandbox start time. Defaults to desc (newest first).
+          required: false
+          schema:
+            type: string
+            enum: [asc, desc]
+            default: desc
         - $ref: "#/components/parameters/paginationNextToken"
         - $ref: "#/components/parameters/paginationLimit"
       responses:

--- a/src/app/dashboard/[teamSlug]/sandboxes/(tabs)/list2/page.tsx
+++ b/src/app/dashboard/[teamSlug]/sandboxes/(tabs)/list2/page.tsx
@@ -21,6 +21,7 @@ export default async function NewSandboxesListPage({
     trpc.sandboxes.listSandboxesPaginated.infiniteQueryOptions({
       teamSlug,
       limit: 50,
+      order: 'desc',
     })
   )
 

--- a/src/core/modules/sandboxes/repository.server.ts
+++ b/src/core/modules/sandboxes/repository.server.ts
@@ -41,6 +41,7 @@ export interface ListSandboxesOptions {
   cursor?: string
   limit: number
   states?: SandboxState[]
+  order?: 'asc' | 'desc'
 }
 
 export interface ListSandboxesResult {
@@ -409,6 +410,7 @@ export function createSandboxesRepository(
             state: options.states ?? DEFAULT_SANDBOX_STATES,
             nextToken: options.cursor,
             limit: options.limit,
+            order: options.order,
           },
         },
         headers: {

--- a/src/core/server/api/routers/sandboxes.ts
+++ b/src/core/server/api/routers/sandboxes.ts
@@ -56,6 +56,7 @@ export const sandboxesRouter = createTRPCRouter({
         cursor: z.string().optional(),
         limit: z.number().int().min(1).max(100).default(50),
         states: z.array(z.enum(['running', 'paused'])).optional(),
+        order: z.enum(['asc', 'desc']).optional(),
       })
     )
     .query(async ({ ctx, input }) => {
@@ -77,6 +78,7 @@ export const sandboxesRouter = createTRPCRouter({
           cursor: input.cursor,
           limit: input.limit,
           states: input.states,
+          order: input.order,
         })
       if (!sandboxesResult.ok) {
         throwTRPCErrorFromRepoError(sandboxesResult.error)

--- a/src/core/shared/contracts/infra-api.types.ts
+++ b/src/core/shared/contracts/infra-api.types.ts
@@ -255,6 +255,8 @@ export interface paths {
           metadata?: string
           /** @description Filter sandboxes by one or more states */
           state?: components['schemas']['SandboxState'][]
+          /** @description Sort direction by sandbox start time. Defaults to desc (newest first). */
+          order?: 'asc' | 'desc'
           /** @description Cursor to start the list from */
           nextToken?: components['parameters']['paginationNextToken']
           /** @description Maximum number of items to return per page */

--- a/src/features/dashboard/sandboxes/list/stores/table-store.ts
+++ b/src/features/dashboard/sandboxes/list/stores/table-store.ts
@@ -3,6 +3,7 @@
 import type { OnChangeFn, SortingState } from '@tanstack/react-table'
 import { create } from 'zustand'
 import { createJSONStorage, persist } from 'zustand/middleware'
+import type { SandboxState } from '@/core/modules/sandboxes/models'
 import { areStringArraysEqual } from '@/lib/utils/array'
 import { createHashStorage } from '@/lib/utils/store'
 import { trackSandboxListInteraction } from '../tracking'
@@ -19,6 +20,9 @@ type SandboxListPollingInterval =
   (typeof sandboxListPollingIntervals)[number]['value']
 
 export type SandboxStartedAtFilter = '1h ago' | '6h ago' | '12h ago' | undefined
+
+// Both states selected = no active state filter (server defaults to both).
+export const sandboxListAllStates: SandboxState[] = ['running', 'paused']
 
 export const sandboxListDefaultSorting: SortingState = [
   { id: 'startedAt', desc: true },
@@ -44,6 +48,7 @@ interface SandboxListTableState {
   globalFilter: string
 
   // Filter state
+  stateFilter: SandboxState[]
   startedAtFilter: SandboxStartedAtFilter
   templateFilters: string[]
   cpuCount: number | undefined
@@ -56,6 +61,7 @@ interface SandboxListTableActions {
   setGlobalFilter: OnChangeFn<string>
 
   // Filter actions
+  setStateFilter: (states: SandboxState[]) => void
   setStartedAtFilter: (filter: SandboxStartedAtFilter) => void
   setTemplateFilters: (filters: string[]) => void
   setCpuCount: (count: number | undefined) => void
@@ -77,6 +83,7 @@ const initialState: SandboxListTableState = {
   globalFilter: '',
 
   // Filter state
+  stateFilter: sandboxListAllStates,
   startedAtFilter: undefined,
   templateFilters: [],
   cpuCount: undefined,
@@ -147,6 +154,29 @@ export const useSandboxListTableStore = create<SandboxListTableStore>()(
       },
 
       // Filter actions
+      setStateFilter: (stateFilter) => {
+        let didChangeStateFilter = false
+
+        set((state) => {
+          if (areStringArraysEqual(state.stateFilter, stateFilter)) {
+            return state
+          }
+
+          didChangeStateFilter = true
+
+          return { stateFilter }
+        })
+
+        if (!didChangeStateFilter) {
+          return
+        }
+
+        trackSandboxListInteraction('filtered', {
+          type: 'state',
+          value: stateFilter.join(','),
+        })
+      },
+
       setStartedAtFilter: (startedAtFilter) => {
         let didChangeStartedAtFilter = false
 
@@ -244,6 +274,10 @@ export const useSandboxListTableStore = create<SandboxListTableStore>()(
 
         set((state) => {
           const hasFilterChanges =
+            !areStringArraysEqual(
+              state.stateFilter,
+              initialState.stateFilter
+            ) ||
             state.startedAtFilter !== initialState.startedAtFilter ||
             state.templateFilters.length > 0 ||
             state.cpuCount !== initialState.cpuCount ||
@@ -257,6 +291,7 @@ export const useSandboxListTableStore = create<SandboxListTableStore>()(
           didResetFilters = true
 
           return {
+            stateFilter: initialState.stateFilter,
             startedAtFilter: initialState.startedAtFilter,
             templateFilters: initialState.templateFilters,
             cpuCount: initialState.cpuCount,

--- a/src/features/dashboard/sandboxes/list/table-body.tsx
+++ b/src/features/dashboard/sandboxes/list/table-body.tsx
@@ -37,6 +37,7 @@ export const SandboxesTableBody = ({
   )
   const hasFilter = useSandboxListTableStore((state) => {
     return (
+      state.stateFilter.length < 2 ||
       state.startedAtFilter !== undefined ||
       state.templateFilters.length > 0 ||
       state.cpuCount !== undefined ||

--- a/src/features/dashboard/sandboxes/list/table-cells.tsx
+++ b/src/features/dashboard/sandboxes/list/table-cells.tsx
@@ -4,6 +4,7 @@ import type { CellContext } from '@tanstack/react-table'
 import Link from 'next/link'
 import { useMemo } from 'react'
 import { PROTECTED_URLS } from '@/configs/urls'
+import type { SandboxState } from '@/core/modules/sandboxes/models'
 import ResourceUsage from '@/features/dashboard/common/resource-usage'
 import { formatLocalLogStyleTimestamp } from '@/lib/utils/formatting'
 import { JsonPopover } from '@/ui/json-popover'
@@ -144,9 +145,7 @@ export const DiskUsageCell = ({
   </div>
 )
 
-export function StateCell({ row }: CellContext<SandboxListRow, unknown>) {
-  const state = row.original.state
-
+export function StateBadge({ state }: { state: SandboxState }) {
   if (state === 'paused') {
     return (
       <Badge variant="warning" className="uppercase">
@@ -162,6 +161,10 @@ export function StateCell({ row }: CellContext<SandboxListRow, unknown>) {
       Running
     </Badge>
   )
+}
+
+export function StateCell({ row }: CellContext<SandboxListRow, unknown>) {
+  return <StateBadge state={row.original.state} />
 }
 
 export function IdCell({ getValue }: CellContext<SandboxListRow, unknown>) {

--- a/src/features/dashboard/sandboxes/list/table-filters.tsx
+++ b/src/features/dashboard/sandboxes/list/table-filters.tsx
@@ -1,14 +1,19 @@
 import * as React from 'react'
 import { memo, useCallback } from 'react'
 import { useDebounceValue } from 'usehooks-ts'
+import type { SandboxState } from '@/core/modules/sandboxes/models'
 import type { SandboxStartedAtFilter } from '@/features/dashboard/sandboxes/list/stores/table-store'
-import { useSandboxListTableStore } from '@/features/dashboard/sandboxes/list/stores/table-store'
+import {
+  sandboxListAllStates,
+  useSandboxListTableStore,
+} from '@/features/dashboard/sandboxes/list/stores/table-store'
 import { cn } from '@/lib/utils'
 import { formatCPUCores, formatMemory } from '@/lib/utils/formatting'
 import { NumberInput } from '@/ui/number-input'
 import { Button } from '@/ui/primitives/button'
 import {
   DropdownMenu,
+  DropdownMenuCheckboxItem,
   DropdownMenuContent,
   DropdownMenuGroup,
   DropdownMenuItem,
@@ -24,8 +29,43 @@ import { Input } from '@/ui/primitives/input'
 import { Label } from '@/ui/primitives/label'
 import { Separator } from '@/ui/primitives/separator'
 import { TableFilterButton } from '@/ui/table-filter-button'
+import { StateBadge } from './table-cells'
 
 // Components
+const StateFilter = memo(function StateFilter() {
+  const stateFilter = useSandboxListTableStore((state) => state.stateFilter)
+  const setStateFilter = useSandboxListTableStore(
+    (state) => state.setStateFilter
+  )
+
+  const handleToggle = useCallback(
+    (value: SandboxState) => {
+      const next = stateFilter.includes(value)
+        ? stateFilter.filter((s) => s !== value)
+        : [...stateFilter, value]
+
+      // Always keep at least one state selected; emptying resets to both.
+      setStateFilter(next.length === 0 ? sandboxListAllStates : next)
+    },
+    [stateFilter, setStateFilter]
+  )
+
+  return (
+    <div>
+      {sandboxListAllStates.map((state) => (
+        <DropdownMenuCheckboxItem
+          key={state}
+          checked={stateFilter.includes(state)}
+          onCheckedChange={() => handleToggle(state)}
+          onSelect={(e) => e.preventDefault()}
+        >
+          <StateBadge state={state} />
+        </DropdownMenuCheckboxItem>
+      ))}
+    </div>
+  )
+})
+
 const RunningSinceFilter = memo(function RunningSinceFilter() {
   const startedAtFilter = useSandboxListTableStore(
     (state) => state.startedAtFilter
@@ -271,6 +311,7 @@ const SandboxesTableFilters = memo(function SandboxesTableFilters({
   className,
   ...props
 }: SandboxesTableFiltersProps) {
+  const stateFilter = useSandboxListTableStore((state) => state.stateFilter)
   const startedAtFilter = useSandboxListTableStore(
     (state) => state.startedAtFilter
   )
@@ -279,6 +320,9 @@ const SandboxesTableFilters = memo(function SandboxesTableFilters({
   )
   const cpuCount = useSandboxListTableStore((state) => state.cpuCount)
   const memoryMB = useSandboxListTableStore((state) => state.memoryMB)
+  const setStateFilter = useSandboxListTableStore(
+    (state) => state.setStateFilter
+  )
   const setStartedAtFilter = useSandboxListTableStore(
     (state) => state.setStartedAtFilter
   )
@@ -310,6 +354,14 @@ const SandboxesTableFilters = memo(function SandboxesTableFilters({
           <DropdownMenuGroup>
             <DropdownMenuLabel>Filters</DropdownMenuLabel>
             <DropdownMenuSub>
+              <DropdownMenuSubTrigger>State</DropdownMenuSubTrigger>
+              <DropdownMenuPortal>
+                <DropdownMenuSubContent>
+                  <StateFilter />
+                </DropdownMenuSubContent>
+              </DropdownMenuPortal>
+            </DropdownMenuSub>
+            <DropdownMenuSub>
               <DropdownMenuSubTrigger>Started</DropdownMenuSubTrigger>
               <DropdownMenuPortal>
                 <DropdownMenuSubContent>
@@ -337,6 +389,15 @@ const SandboxesTableFilters = memo(function SandboxesTableFilters({
         </DropdownMenuContent>
       </DropdownMenu>
 
+      {stateFilter.length < sandboxListAllStates.length && (
+        <TableFilterButton
+          label="State"
+          value={stateFilter
+            .map((state) => state.replace(/^./, (c) => c.toUpperCase()))
+            .join(', ')}
+          onClick={() => setStateFilter(sandboxListAllStates)}
+        />
+      )}
       {startedAtFilter && (
         <TableFilterButton
           label="Started"

--- a/src/features/dashboard/sandboxes/list/table.tsx
+++ b/src/features/dashboard/sandboxes/list/table.tsx
@@ -34,7 +34,10 @@ import {
 import { SIDEBAR_TRANSITION_CLASSNAMES } from '@/ui/primitives/sidebar'
 import { SandboxesHeader } from './header'
 import type { SandboxStartedAtFilter } from './stores/table-store'
-import { getSandboxListEffectiveSorting } from './stores/table-store'
+import {
+  getSandboxListEffectiveSorting,
+  sandboxListAllStates,
+} from './stores/table-store'
 import { SandboxesTableBody } from './table-body'
 import type { SandboxListRow } from './table-config'
 import {
@@ -97,6 +100,9 @@ interface SandboxesTableViewProps {
   hasNextPage?: boolean
   isFetchingNextPage?: boolean
   fetchNextPage?: () => void
+  // When true the rows arrive already sorted from the server, so the table only
+  // reflects the sort indicator instead of re-sorting client-side.
+  manualSorting?: boolean
 }
 
 function SandboxesTableView({
@@ -107,6 +113,7 @@ function SandboxesTableView({
   hasNextPage,
   isFetchingNextPage,
   fetchNextPage,
+  manualSorting = false,
 }: SandboxesTableViewProps) {
   'use no memo'
 
@@ -122,6 +129,7 @@ function SandboxesTableView({
   )
 
   const {
+    stateFilter,
     startedAtFilter,
     templateFilters,
     cpuCount,
@@ -158,6 +166,7 @@ function SandboxesTableView({
     getFilteredRowModel: getFilteredRowModel(),
     getSortedRowModel: getSortedRowModel(),
     enableSorting: true,
+    manualSorting,
     enableMultiSort: false,
     enableSortingRemoval: false,
     columnResizeMode: 'onChange',
@@ -171,8 +180,14 @@ function SandboxesTableView({
 
   const columnSizeVars = useColumnSizeVars(table)
   const scrollResetKey = useMemo(
-    () => JSON.stringify({ activeSorting, globalFilter, columnFilters }),
-    [activeSorting, globalFilter, columnFilters]
+    () =>
+      JSON.stringify({
+        activeSorting,
+        globalFilter,
+        columnFilters,
+        stateFilter,
+      }),
+    [activeSorting, globalFilter, columnFilters, stateFilter]
   )
 
   useEffect(() => {
@@ -256,6 +271,18 @@ export function NewSandboxesTable() {
   const pollingInterval = useSandboxListTableStore(
     (state) => state.pollingInterval
   )
+  const sorting = useSandboxListTableStore((state) => state.sorting)
+  const stateFilter = useSandboxListTableStore((state) => state.stateFilter)
+
+  // The only sortable column is startedAt; map its direction to the server order
+  // so sorting happens across the whole dataset, not just the loaded pages.
+  const order: 'asc' | 'desc' =
+    getSandboxListEffectiveSorting(sorting)[0]?.desc === false ? 'asc' : 'desc'
+
+  // Both states selected means no filter — omit it so the server default (both)
+  // applies and the query key matches the SSR prefetch.
+  const states =
+    stateFilter.length === sandboxListAllStates.length ? undefined : stateFilter
 
   const {
     data,
@@ -266,7 +293,7 @@ export function NewSandboxesTable() {
     isFetchingNextPage,
   } = useSuspenseInfiniteQuery(
     trpc.sandboxes.listSandboxesPaginated.infiniteQueryOptions(
-      { teamSlug, limit: SANDBOXES_PAGE_SIZE },
+      { teamSlug, limit: SANDBOXES_PAGE_SIZE, order, states },
       {
         getNextPageParam: (lastPage) => lastPage.nextCursor ?? undefined,
         initialCursor: undefined,
@@ -292,6 +319,7 @@ export function NewSandboxesTable() {
       hasNextPage={hasNextPage}
       isFetchingNextPage={isFetchingNextPage}
       fetchNextPage={fetchNextPage}
+      manualSorting
     />
   )
 }


### PR DESCRIPTION
## What

Moves the new sandbox list (list2) ordering to the server and adds a **running/paused state filter**, both pushed to `GET /v2/sandboxes` so they apply across the **whole dataset**, not just the pages already loaded into the infinite-scroll list.

## Changes
- **Ordering (server-side):** derive an `order` (`asc`/`desc`) from the *Started At* sort header and pass it into `listSandboxesPaginated`. The table now uses `manualSorting` and refetches from page 1 on toggle. Default `desc` matches the SSR prefetch key.
- **State filter:** new **State** entry in the Filters dropdown with *Running*/*Paused* multi-select, rendered with the existing status `Badge`s to match the [Figma design](https://www.figma.com/design/PgyPoTwMj8KkqOgUbJ18OL/Dashboard-2.0?node-id=1940-120261&m=dev). Both selected = no filter (server default); selecting one sends `state=...`. Always keeps at least one selected.
- Threaded `order`/`states` through the tRPC router and sandboxes repository; included state in the empty-state and scroll-reset logic; regenerated infra types for the new `order` param.

## Notes
- Requires the backend `order` param — companion PR: **e2b-dev/infra#3107**.
- `tsc` and `biome` clean on changed files.

## Test
Open list2 → toggle *Started At* (watch Network: `order=asc|desc`), and **Filters → State** → Running/Paused (`state=...`). Verify ordering/filtering hold beyond the first 50 rows.