### PR TITLE
fix: allow user access recovery flow without being fully provisioned

### DIFF
--- a/src/app/settings/page.tsx
+++ b/src/app/settings/page.tsx
@@ -1,16 +1,17 @@
 import { getSettingsFlow, type OryPageParams } from '@ory/nextjs/app'
 import oryConfig from '@/configs/ory'
-import { getUserProfile } from '@/core/server/auth'
+import { getSettingsProfile } from '@/core/server/auth'
 import { getOryConfigForRequest } from '@/core/server/auth/ory/request-config'
 import { SettingsCards } from './settings-cards'
 
 export const dynamic = 'force-dynamic'
 
 // Ory-driven settings page, intentionally separate from /dashboard/account.
-// It needs only a Kratos session (getSettingsFlow + getUserProfile read the
+// It needs only a Kratos session (getSettingsFlow + getSettingsProfile read the
 // session/identity, not e2b_session) — so the post-recovery password reset works
-// before any Hydra token exists. Name/e-mail are shown read-only for reference;
-// editing the account profile stays on the gated /dashboard/account page.
+// before any Hydra token exists, even for an identity not yet bootstrapped (no
+// external_id). Name/e-mail are shown read-only for reference; editing the
+// account profile stays on the gated /dashboard/account page.
 export default async function SettingsPage(props: OryPageParams) {
   const flow = await getSettingsFlow(oryConfig, props.searchParams)
 
@@ -19,17 +20,17 @@ export default async function SettingsPage(props: OryPageParams) {
     return null
   }
 
-  const [config, user] = await Promise.all([
+  const [config, profile] = await Promise.all([
     getOryConfigForRequest(),
-    getUserProfile(),
+    getSettingsProfile(),
   ])
 
   return (
     <SettingsCards
       flow={flow}
       config={config}
-      name={user?.name ?? null}
-      email={user?.email ?? null}
+      name={profile?.name ?? null}
+      email={profile?.email ?? null}
     />
   )
 }

--- a/src/core/server/auth/index.ts
+++ b/src/core/server/auth/index.ts
@@ -3,6 +3,7 @@ import 'server-only'
 export type { AuthUser } from '@/core/modules/auth/models'
 export {
   getAuthContext,
+  getSettingsProfile,
   getUserProfile,
   handleCredentialChangeSuccess,
   revokeCurrentSession,

--- a/src/core/server/auth/ory/identity.ts
+++ b/src/core/server/auth/ory/identity.ts
@@ -88,6 +88,23 @@ export function fromKratosSessionIdentity(identity: {
   }
 }
 
+// Display-only traits (name/email) from a Kratos session identity, without
+// requiring external_id — for the pre-provisioning /settings page, where a
+// recovery session's identity may not be bootstrapped yet.
+export function readIdentityDisplayProfile(identity: {
+  id: string
+  traits?: unknown
+}): Pick<AuthUser, 'name' | 'email'> {
+  const traits = parseOryTraits(identity.traits, {
+    identityId: identity.id,
+    source: 'kratos_session',
+  })
+  return {
+    name: readString(traits, 'name'),
+    email: readString(traits, 'email'),
+  }
+}
+
 // Rich path: build the user from a full Kratos Identity (traits + credentials).
 // Used wherever we've fetched the identity via the admin API — admin lookups and
 // the live profile query.

--- a/src/core/server/auth/ory/session.ts
+++ b/src/core/server/auth/ory/session.ts
@@ -21,7 +21,11 @@ import {
 } from './find-identity'
 import { oryAuthFlows } from './flows'
 import { isKratosSessionFresh } from './freshness'
-import { fromKratosSessionIdentity, fromOryIdentity } from './identity'
+import {
+  fromKratosSessionIdentity,
+  fromOryIdentity,
+  readIdentityDisplayProfile,
+} from './identity'
 import {
   revokeKratosSession,
   revokeKratosSessionsForIdentity,
@@ -92,6 +96,19 @@ export async function getUserProfile(): Promise<AuthUser | null> {
   })
 
   return identity ? fromOryIdentity(identity) : null
+}
+
+// Display-only profile for the pre-provisioning /settings page. Unlike
+// getUserProfile (which requires a fully provisioned identity), this reads
+// name/email straight off the Kratos session, so it works for a recovery
+// session whose identity has no external_id yet.
+export async function getSettingsProfile(): Promise<Pick<
+  AuthUser,
+  'name' | 'email'
+> | null> {
+  const identity = (await readKratosSession())?.identity
+  if (!identity) return null
+  return readIdentityDisplayProfile(identity)
 }
 
 // Tears down the current login: revokes the OAuth tokens and the Kratos


### PR DESCRIPTION
Accessing `/settings` during recovery flow crashes for identities without an `external_id`

`/settings` is intentionally ungated so post-recovery password reset works with only a Kratos session, but it called `getUserProfile()` → `requireExternalId()`, which throws for a not-yet-bootstrapped identity — so anyone recovering a half-provisioned account never sees the reset form. This swaps the page to a trait-only `getSettingsProfile()` that reads `name`/`email` without requiring `external_id`; 

The next OAuth sign-in still backfills `external_id` as before.