### PR TITLE
fix: improve hover state for the webhooks list

### DIFF
--- a/src/features/dashboard/settings/webhooks/table-row.tsx
+++ b/src/features/dashboard/settings/webhooks/table-row.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useRouter } from 'next/navigation'
+import Link from 'next/link'
 import { Fragment, useState } from 'react'
 import { PROTECTED_URLS } from '@/configs/urls'
 import { SandboxLifecycleEventTypeSchema } from '@/core/modules/sandboxes/lifecycle-event-types'
@@ -101,7 +101,7 @@ const WebhookNameAndUrl = ({ name, url }: WebhookNameAndUrlProps) => {
           onMouseEnter={() => setIsUrlHovered(true)}
           onMouseLeave={() => setIsUrlHovered(false)}
           aria-label={`Copy webhook URL ${url}`}
-          className="w-fit max-w-full min-w-0 justify-start font-mono uppercase prose-label-numeric"
+          className="relative z-10 w-fit max-w-full min-w-0 justify-start font-mono uppercase prose-label-numeric"
         >
           <span className="truncate">{url}</span>
         </Button>
@@ -134,7 +134,9 @@ const WebhookEventBadges = ({ events }: WebhookEventBadgesProps) => {
     return (
       <Tooltip>
         <TooltipTrigger asChild>
-          <Badge className="cursor-pointer">ALL ({events.length})</Badge>
+          <Badge className="relative z-10 cursor-pointer">
+            ALL ({events.length})
+          </Badge>
         </TooltipTrigger>
         <TooltipContent>
           <div className="flex flex-wrap items-center gap-1 prose-label uppercase">
@@ -167,6 +169,7 @@ const WebhookRowActions = ({ webhook }: WebhookRowActionsProps) => {
       <DropdownMenuTrigger asChild>
         <IconButton
           aria-label={`Open actions for ${webhook.name}`}
+          className="relative z-10 size-5"
           onClick={(e) => e.stopPropagation()}
         >
           <IndicatorDotsIcon className="-rotate-90" />
@@ -198,7 +201,6 @@ const WebhookRowActions = ({ webhook }: WebhookRowActionsProps) => {
 
 export const WebhookTableRow = ({ webhook }: WebhookRowProps) => {
   const { team } = useDashboard()
-  const router = useRouter()
 
   const createdAt = webhook.createdAt
     ? new Date(webhook.createdAt).toLocaleDateString('en-US', {
@@ -209,23 +211,22 @@ export const WebhookTableRow = ({ webhook }: WebhookRowProps) => {
     : '-'
 
   const webhookHref = PROTECTED_URLS.WEBHOOK(team.slug, webhook.id)
-  const handleRowClick = (event: React.MouseEvent<HTMLTableRowElement>) => {
-    if (!(event.target instanceof Node)) return
-    if (!event.currentTarget.contains(event.target)) return
-
-    router.push(webhookHref)
-  }
 
   return (
     <TableRow
       className={cn(
-        'group/row relative cursor-pointer border-b-0 transition-none',
+        'group/row relative z-0 cursor-pointer border-b-0 transition-none',
         'border-stroke/80 hover:z-20 focus-within:z-10',
         'has-[button[aria-haspopup=menu][data-state=open]]:z-10'
       )}
-      onClick={handleRowClick}
     >
       <TableCell className={cn(rowCellClassName, 'max-w-0')}>
+        <Link
+          href={webhookHref}
+          prefetch={false}
+          aria-label={`Open webhook ${webhook.name}`}
+          className="absolute -inset-x-3 -inset-y-px z-1"
+        />
         <RowHoverFrame
           className={cn(
             '-inset-x-3 -z-10 group-hover/row:bg-bg-1',
@@ -251,7 +252,7 @@ export const WebhookTableRow = ({ webhook }: WebhookRowProps) => {
         </div>
       </TableCell>
 
-      <TableCell className={cn(rowCellClassName, 'w-10 pl-6 text-right')}>
+      <TableCell className={cn(rowCellClassName, 'w-10 pl-5 text-right')}>
         <WebhookRowActions webhook={webhook} />
       </TableCell>
     </TableRow>

--- a/src/features/dashboard/settings/webhooks/table-row.tsx
+++ b/src/features/dashboard/settings/webhooks/table-row.tsx
@@ -219,7 +219,7 @@ export const WebhookTableRow = ({ webhook }: WebhookRowProps) => {
   return (
     <TableRow
       className={cn(
-        'group/row relative cursor-pointer hover:bg-bg-1 border-b-0 transition-none',
+        'group/row relative cursor-pointer border-b-0 transition-none',
         'border-stroke/80 hover:z-20 focus-within:z-10',
         'has-[button[aria-haspopup=menu][data-state=open]]:z-10'
       )}
@@ -228,6 +228,7 @@ export const WebhookTableRow = ({ webhook }: WebhookRowProps) => {
       <TableCell className={cn(rowCellClassName, 'max-w-0')}>
         <RowHoverFrame
           className={cn(
+            '-inset-x-3 -z-10 group-hover/row:bg-bg-1',
             'group-has-[button[aria-haspopup=menu][data-state=open]]/row:border-stroke',
             'group-has-[button[aria-haspopup=menu][data-state=open]]/row:[--corner-mark-color:var(--color-fg-tertiary)]'
           )}

--- a/src/features/dashboard/settings/webhooks/webhooks-page-content.tsx
+++ b/src/features/dashboard/settings/webhooks/webhooks-page-content.tsx
@@ -159,7 +159,7 @@ export const WebhooksPageContent = ({
           </Suspense>
         </div>
 
-        <div className="bg-bg w-full overflow-x-auto">
+        <div className="bg-bg -mx-3 overflow-x-auto px-3">
           <Suspense
             fallback={
               <WebhooksTable isLoading totalWebhookCount={0} webhooks={[]} />


### PR DESCRIPTION
Improve hover state for the webhooks list

| Before | After |
|--------|--------|
| <img width="954" height="109" alt="Screenshot 2026-06-29 at 16 52 01" src="https://github.com/user-attachments/assets/b9dd8dc4-91f6-4b27-b714-ca945fce187c" /> | <img width="955" height="143" alt="image" src="https://github.com/user-attachments/assets/04bcef15-6371-4b16-b417-fc934c0996ab" /> | 
