### PR TITLE
feat: improve password change ux for fresh sessions

### DIFF
--- a/src/core/server/api/routers/user.ts
+++ b/src/core/server/api/routers/user.ts
@@ -4,7 +4,7 @@ import { featureFlags } from '@/core/modules/feature-flags/feature-flags.server'
 import {
   type AuthUser,
   getUserProfile,
-  handleCredentialChangeSuccess,
+  handleInSessionPasswordChange,
   updateUser,
 } from '@/core/server/auth'
 import { createTRPCRouter } from '@/core/server/trpc/init'
@@ -129,9 +129,10 @@ export const userRouter = createTRPCRouter({
       })
 
       if (result.ok) {
-        // Invalidate sessions when the password changed.
+        // A password change signs out every OTHER device but keeps the current
+        // one signed in (recovery's sign-out-everywhere path is separate).
         if (input.password) {
-          await handleCredentialChangeSuccess()
+          await handleInSessionPasswordChange()
         }
 
         return { status: 'ok' as const, user: result.user }

--- a/src/core/server/auth/index.ts
+++ b/src/core/server/auth/index.ts
@@ -6,6 +6,8 @@ export {
   getSettingsProfile,
   getUserProfile,
   handleCredentialChangeSuccess,
+  handleInSessionPasswordChange,
+  isCurrentSessionFresh,
   revokeCurrentSession,
   signOut,
   startReauthForAccountSettings,

--- a/src/core/server/auth/ory/kratos-session-edge.ts
+++ b/src/core/server/auth/ory/kratos-session-edge.ts
@@ -1,5 +1,5 @@
 import type { NextRequest } from 'next/server'
-import { APP_OWNED_COOKIES } from './session-cookie'
+import { cookieHeaderWithoutAppOwned } from './session-cookie'
 
 // Edge-safe Kratos session check for the middleware gate. getServerSession()
 // reads next/headers and can't run in the edge runtime, so we hit Kratos
@@ -13,11 +13,7 @@ export async function isKratosSessionActive(
   request: NextRequest
 ): Promise<boolean> {
   const sdkUrl = process.env.NEXT_PUBLIC_ORY_SDK_URL ?? process.env.ORY_SDK_URL
-  const cookie = request.cookies
-    .getAll()
-    .filter((c) => !APP_OWNED_COOKIES.has(c.name))
-    .map((c) => `${c.name}=${c.value}`)
-    .join('; ')
+  const cookie = cookieHeaderWithoutAppOwned(request.cookies.getAll())
   if (!sdkUrl || !cookie) return false
 
   try {

--- a/src/core/server/auth/ory/kratos-session.ts
+++ b/src/core/server/auth/ory/kratos-session.ts
@@ -2,7 +2,7 @@ import 'server-only'
 
 import { ResponseError } from '@ory/client-fetch'
 import { l, serializeErrorForLog } from '@/core/shared/clients/logger/logger'
-import { getOryIdentityApi } from './client'
+import { getOryFrontendApi, getOryIdentityApi } from './client'
 import { readOryError } from './ory-error'
 
 // Ory uses optimistic locking on identity rows; concurrent writes (e.g. our
@@ -45,6 +45,26 @@ export async function revokeKratosSessionsForIdentity(
 ): Promise<void> {
   await revokeWithRetries('revoke_kratos_sessions', () =>
     getOryIdentityApi().deleteIdentitySessions({ id: identityId })
+  )
+}
+
+/**
+ * Revokes every Kratos session for the current identity EXCEPT the one the
+ * forwarded session cookie belongs to (Kratos public DELETE /sessions, i.e.
+ * `disableMyOtherSessions`).
+ *
+ * Used after an in-session password change so the user stays signed in on the
+ * device they made the change from while every other device is signed out of
+ * the dashboard. Cookie-authenticated rather than admin-PAT: "current" is
+ * defined by the forwarded session, so it targets exactly this device. The
+ * admin API has no all-except-current variant (deleteIdentitySessions includes
+ * the current session).
+ */
+export async function disableOtherKratosSessions(
+  cookie: string
+): Promise<void> {
+  await revokeWithRetries('disable_other_kratos_sessions', () =>
+    getOryFrontendApi().disableMyOtherSessions({ cookie })
   )
 }
 

--- a/src/core/server/auth/ory/session-cookie.ts
+++ b/src/core/server/auth/ory/session-cookie.ts
@@ -11,10 +11,23 @@ export const E2B_SESSION_COOKIE = 'e2b_session'
 export const ORY_SIGNUP_METADATA_COOKIE = 'e2b-ory-signup-metadata'
 
 // Cookies the dashboard owns — never forwarded across the Ory trust boundary.
-export const APP_OWNED_COOKIES = new Set<string>([
+const APP_OWNED_COOKIES = new Set<string>([
   E2B_SESSION_COOKIE,
   ORY_SIGNUP_METADATA_COOKIE,
 ])
+
+// Serializes a cookie list into a `Cookie` header for forwarding to Ory, with
+// the app-owned cookies stripped. Takes the cookie list rather than reading
+// next/headers so it stays edge-safe and serves both the middleware
+// (NextRequest cookies) and server components (next/headers cookies).
+export function cookieHeaderWithoutAppOwned(
+  cookieList: ReadonlyArray<{ name: string; value: string }>
+): string {
+  return cookieList
+    .filter((cookie) => !APP_OWNED_COOKIES.has(cookie.name))
+    .map((cookie) => `${cookie.name}=${cookie.value}`)
+    .join('; ')
+}
 
 // Persist across browser restarts. The cookie only caches tokens — a stale or
 // expired cookie is re-minted from the live Kratos session, so the lifetime is

--- a/src/core/server/auth/ory/session.ts
+++ b/src/core/server/auth/ory/session.ts
@@ -27,11 +27,13 @@ import {
   readIdentityDisplayProfile,
 } from './identity'
 import {
+  disableOtherKratosSessions,
   revokeKratosSession,
   revokeKratosSessionsForIdentity,
 } from './kratos-session'
 import { revokeOryOAuthSessionsForSubject } from './oauth-session'
 import {
+  cookieHeaderWithoutAppOwned,
   E2B_SESSION_COOKIE,
   openSessionCookie,
   sessionCookieDeleteOptions,
@@ -175,6 +177,18 @@ export async function startReauthForAccountSettings(): Promise<ReauthDispatch> {
   return {
     to: buildOryStartURL('reauth', ACCOUNT_SETTINGS_REAUTH_RETURN_TO),
   }
+}
+
+export async function isCurrentSessionFresh(): Promise<boolean> {
+  const kratos = await readKratosSession()
+  return isKratosSessionFresh(kratos?.authenticated_at)
+}
+
+export async function handleInSessionPasswordChange(): Promise<void> {
+  const cookie = cookieHeaderWithoutAppOwned((await cookies()).getAll())
+  if (!cookie) return
+
+  await disableOtherKratosSessions(cookie)
 }
 
 export async function handleCredentialChangeSuccess(): Promise<void> {

--- a/src/core/server/auth/ory/session.ts
+++ b/src/core/server/auth/ory/session.ts
@@ -185,10 +185,14 @@ export async function isCurrentSessionFresh(): Promise<boolean> {
 }
 
 export async function handleInSessionPasswordChange(): Promise<void> {
+  const identityId = (await readKratosSession())?.identity?.id
   const cookie = cookieHeaderWithoutAppOwned((await cookies()).getAll())
-  if (!cookie) return
+  if (!identityId || !cookie) return
 
-  await disableOtherKratosSessions(cookie)
+  await Promise.all([
+    disableOtherKratosSessions(cookie),
+    revokeOryOAuthSessionsForSubject(identityId),
+  ])
 }
 
 export async function handleCredentialChangeSuccess(): Promise<void> {

--- a/src/features/dashboard/account/password-settings-server.tsx
+++ b/src/features/dashboard/account/password-settings-server.tsx
@@ -1,4 +1,5 @@
 import type { AccountPageSearchParams } from '@/app/dashboard/[teamSlug]/account/page'
+import { isCurrentSessionFresh } from '@/core/server/auth'
 import { PasswordSettings } from './password-settings'
 
 interface PasswordSettingsServerProps {
@@ -10,7 +11,10 @@ export async function PasswordSettingsServer({
   className,
   searchParams,
 }: PasswordSettingsServerProps) {
-  const reauth = (await searchParams).reauth ?? '0'
+  const [{ reauth = '0' }, isSessionFresh] = await Promise.all([
+    searchParams,
+    isCurrentSessionFresh(),
+  ])
 
   const showPasswordChangeForm = reauth === '1'
 
@@ -18,6 +22,7 @@ export async function PasswordSettingsServer({
     <PasswordSettings
       className={className}
       showPasswordChangeForm={showPasswordChangeForm}
+      isSessionFresh={isSessionFresh}
     />
   )
 }

--- a/src/features/dashboard/account/password-settings.tsx
+++ b/src/features/dashboard/account/password-settings.tsx
@@ -51,11 +51,13 @@ type FormValues = z.infer<typeof formSchema>
 interface PasswordSettingsProps {
   className?: string
   showPasswordChangeForm: boolean
+  isSessionFresh: boolean
 }
 
 export function PasswordSettings({
   className,
   showPasswordChangeForm,
+  isSessionFresh,
 }: PasswordSettingsProps) {
   'use no memo'
 
@@ -64,12 +66,12 @@ export function PasswordSettings({
   const trpc = useTRPC()
   const [reauthDialogOpen, setReauthDialogOpen] = useState(false)
   const [clientShowPasswordForm, setClientShowPasswordForm] = useState(
-    showPasswordChangeForm
+    showPasswordChangeForm || isSessionFresh
   )
 
   useEffect(() => {
-    setClientShowPasswordForm(showPasswordChangeForm)
-  }, [showPasswordChangeForm])
+    setClientShowPasswordForm(showPasswordChangeForm || isSessionFresh)
+  }, [showPasswordChangeForm, isSessionFresh])
 
   const form = useForm<FormValues>({
     resolver: zodResolver(formSchema),
@@ -118,6 +120,11 @@ export function PasswordSettings({
   }
 
   function handleChangePassword() {
+    if (isSessionFresh) {
+      setClientShowPasswordForm(true)
+      return
+    }
+
     setReauthDialogOpen(true)
   }
 
@@ -179,10 +186,12 @@ export function PasswordSettings({
             </Form>
           ) : (
             <>
-              <p className="text-fg-secondary text-md">
-                To change your password, you'll need to re-authenticate for
-                security.
-              </p>
+              {!isSessionFresh && (
+                <p className="text-fg-secondary text-md">
+                  To change your password, you'll need to re-authenticate for
+                  security.
+                </p>
+              )}
               <Button
                 type="button"
                 onClick={handleChangePassword}

--- a/tests/integration/auth-ory-account-security.test.ts
+++ b/tests/integration/auth-ory-account-security.test.ts
@@ -8,8 +8,10 @@ const patchIdentityMock = vi.hoisted(() => vi.fn())
 const revokeOAuthSessionsMock = vi.hoisted(() => vi.fn())
 const revokeKratosSessionsMock = vi.hoisted(() => vi.fn())
 const revokeKratosSessionMock = vi.hoisted(() => vi.fn())
+const disableOtherKratosSessionsMock = vi.hoisted(() => vi.fn())
 const openSessionCookieMock = vi.hoisted(() => vi.fn())
 const cookieDeleteMock = vi.hoisted(() => vi.fn())
+const cookieGetAllMock = vi.hoisted(() => vi.fn())
 
 vi.mock('@ory/nextjs/app', () => ({
   getServerSession: getServerSessionMock,
@@ -19,6 +21,7 @@ vi.mock('next/headers', () => ({
   cookies: () =>
     Promise.resolve({
       get: vi.fn(() => ({ value: 'sealed-cookie' })),
+      getAll: cookieGetAllMock,
       delete: cookieDeleteMock,
     }),
   headers: () =>
@@ -29,6 +32,15 @@ vi.mock('next/headers', () => ({
 
 vi.mock('@/core/server/auth/ory/session-cookie', () => ({
   E2B_SESSION_COOKIE: 'e2b_session',
+  cookieHeaderWithoutAppOwned: (
+    cookieList: ReadonlyArray<{ name: string; value: string }>
+  ) => {
+    const appOwned = new Set(['e2b_session', 'e2b-ory-signup-metadata'])
+    return cookieList
+      .filter((c) => !appOwned.has(c.name))
+      .map((c) => `${c.name}=${c.value}`)
+      .join('; ')
+  },
   openSessionCookie: openSessionCookieMock,
   sessionCookieDeleteOptions: (host: string | null | undefined) => ({
     name: 'e2b_session',
@@ -52,6 +64,7 @@ vi.mock('@/core/server/auth/ory/oauth-session', () => ({
 vi.mock('@/core/server/auth/ory/kratos-session', () => ({
   revokeKratosSessionsForIdentity: revokeKratosSessionsMock,
   revokeKratosSession: revokeKratosSessionMock,
+  disableOtherKratosSessions: disableOtherKratosSessionsMock,
 }))
 
 vi.mock('@/core/shared/clients/logger/logger', () => ({
@@ -59,8 +72,13 @@ vi.mock('@/core/shared/clients/logger/logger', () => ({
   serializeErrorForLog: vi.fn((error: unknown) => error),
 }))
 
-const { getAuthContext, handleCredentialChangeSuccess, signOut, updateUser } =
-  await import('@/core/server/auth/ory/session')
+const {
+  getAuthContext,
+  handleCredentialChangeSuccess,
+  handleInSessionPasswordChange,
+  signOut,
+  updateUser,
+} = await import('@/core/server/auth/ory/session')
 
 const currentIdentity = {
   id: 'kratos-uuid',
@@ -103,12 +121,17 @@ describe('Ory account security (Kratos session + e2b_session)', () => {
     revokeOAuthSessionsMock.mockReset().mockResolvedValue(undefined)
     revokeKratosSessionsMock.mockReset().mockResolvedValue(undefined)
     revokeKratosSessionMock.mockReset().mockResolvedValue(undefined)
+    disableOtherKratosSessionsMock.mockReset().mockResolvedValue(undefined)
     openSessionCookieMock.mockReset().mockResolvedValue({
       accessToken: 'hydra-access-token',
       idToken: 'hydra-id-token',
       expiresAt: 1_900_000_000,
     })
     cookieDeleteMock.mockReset()
+    cookieGetAllMock.mockReset().mockReturnValue([
+      { name: 'ory_session_token', value: 'kratos-cookie' },
+      { name: 'e2b_session', value: 'sealed-cookie' },
+    ])
   })
 
   afterEach(() => {
@@ -199,6 +222,23 @@ describe('Ory account security (Kratos session + e2b_session)', () => {
       path: '/',
       domain: '.app.e2b.dev',
     })
+  })
+
+  it('keeps the current device on an in-session password change: revokes only other sessions', async () => {
+    getServerSessionMock.mockResolvedValue(kratosSession())
+
+    await handleInSessionPasswordChange()
+
+    // Other Kratos sessions are revoked via the forwarded session cookie, with
+    // app-owned cookies (e2b_session) stripped before forwarding.
+    expect(disableOtherKratosSessionsMock).toHaveBeenCalledWith(
+      'ory_session_token=kratos-cookie'
+    )
+    // The current device stays signed in: no everywhere-revoke, no OAuth
+    // teardown, no e2b_session cookie clear.
+    expect(revokeKratosSessionsMock).not.toHaveBeenCalled()
+    expect(revokeOAuthSessionsMock).not.toHaveBeenCalled()
+    expect(cookieDeleteMock).not.toHaveBeenCalled()
   })
 
   it('signs out via Hydra RP-logout and revokes only the current Kratos session', async () => {

--- a/tests/integration/auth-ory-account-security.test.ts
+++ b/tests/integration/auth-ory-account-security.test.ts
@@ -229,15 +229,16 @@ describe('Ory account security (Kratos session + e2b_session)', () => {
 
     await handleInSessionPasswordChange()
 
-    // Other Kratos sessions are revoked via the forwarded session cookie, with
-    // app-owned cookies (e2b_session) stripped before forwarding.
+    // Other devices are signed out fully: their Kratos session via the forwarded
+    // cookie (app-owned cookies stripped), and the subject's Hydra OAuth grants
+    // so their cached refresh tokens die too.
     expect(disableOtherKratosSessionsMock).toHaveBeenCalledWith(
       'ory_session_token=kratos-cookie'
     )
-    // The current device stays signed in: no everywhere-revoke, no OAuth
-    // teardown, no e2b_session cookie clear.
+    expect(revokeOAuthSessionsMock).toHaveBeenCalledWith('kratos-uuid')
+    // The current device stays signed in: no all-sessions Kratos revoke and no
+    // e2b_session cookie clear — it re-mints from its live Kratos session.
     expect(revokeKratosSessionsMock).not.toHaveBeenCalled()
-    expect(revokeOAuthSessionsMock).not.toHaveBeenCalled()
     expect(cookieDeleteMock).not.toHaveBeenCalled()
   })
 

--- a/tests/unit/user-router.test.ts
+++ b/tests/unit/user-router.test.ts
@@ -5,14 +5,14 @@ const authMock = vi.hoisted(() => ({
   getAuthContext: vi.fn(),
   getUserProfile: vi.fn(),
   updateUser: vi.fn(),
-  handleCredentialChangeSuccess: vi.fn(),
+  handleInSessionPasswordChange: vi.fn(),
 }))
 
 vi.mock('@/core/server/auth', () => ({
   getAuthContext: authMock.getAuthContext,
   getUserProfile: authMock.getUserProfile,
   updateUser: authMock.updateUser,
-  handleCredentialChangeSuccess: authMock.handleCredentialChangeSuccess,
+  handleInSessionPasswordChange: authMock.handleInSessionPasswordChange,
 }))
 
 vi.mock('@/lib/utils/server', () => ({
@@ -43,7 +43,7 @@ describe('userRouter.update', () => {
     })
     authMock.getUserProfile.mockReset()
     authMock.updateUser.mockReset()
-    authMock.handleCredentialChangeSuccess.mockReset()
+    authMock.handleInSessionPasswordChange.mockReset()
   })
 
   afterEach(() => {
@@ -85,5 +85,18 @@ describe('userRouter.update', () => {
       password: 'new-password',
       name: undefined,
     })
+    expect(authMock.handleInSessionPasswordChange).toHaveBeenCalled()
+  })
+
+  it('keeps the current device signed in (no session teardown) on a name change', async () => {
+    authMock.updateUser.mockResolvedValue({ ok: true, user: authUser })
+
+    const ctx = await createTRPCContext({ headers: new Headers() })
+    const caller = createCaller(ctx)
+
+    const result = await caller.update({ name: 'Ada Lovelace' })
+
+    expect(result).toEqual({ status: 'ok', user: authUser })
+    expect(authMock.handleInSessionPasswordChange).not.toHaveBeenCalled()
   })
 })


### PR DESCRIPTION
## Summary
Changing your password from **Account settings** no longer forces a redundant re-auth when the session is already fresh, and no longer signs you out of the current device. Forgot-password (recovery) keeps its sign-out-everywhere behavior.

## Why
The dashboard's auth boundary is the **Kratos session** — the `e2b_session` cookie only caches Hydra tokens and is re-minted from it. The old success path revoked *all* Kratos sessions + subject-wide Hydra OAuth sessions and cleared the cookie, which killed the current device. Separately, the UI forced the re-auth round-trip before showing the form even though the server already accepts a fresh change.

## Changes
- **Freshness-aware UI** — `isCurrentSessionFresh()` surfaces the same 15-min window the server enforces; the form renders directly when fresh, the re-auth dialog only when stale. The server's `reauth` response stays as the fallback if freshness lapses mid-form.
- **Keep current device** — new `handleInSessionPasswordChange()` revokes only *other* sessions via Kratos `disableMyOtherSessions` (`DELETE /sessions`), leaving the current session, cookie, and Hydra tokens intact. Recovery still uses `handleCredentialChangeSuccess()` (everywhere).