### PR TITLE
feat: improve builds list page ui

### DIFF
--- a/src/features/dashboard/templates/builds/table-body.tsx
+++ b/src/features/dashboard/templates/builds/table-body.tsx
@@ -5,7 +5,7 @@ import { useVirtualRows } from '@/lib/hooks/use-virtual-rows'
 import { cn } from '@/lib/utils'
 import { DataTableBody, DataTableCell, DataTableRow } from '@/ui/data-table'
 import { RowHoverFrame } from '@/ui/row-hover-frame'
-import { isRightAlignedColumn } from './table-config'
+import { ID_COLUMN_ID, isRightAlignedColumn } from './table-config'
 
 const ROW_HEIGHT_PX = 40
 const VIRTUAL_OVERSCAN = 8
@@ -51,7 +51,7 @@ export function BuildsTableBody({
           <DataTableRow
             key={row.id}
             className={cn(
-              'group/row relative h-10 min-w-full cursor-pointer -mx-2 px-2 hover:bg-bg-1 border-b-0 transition-none w-[calc(100%+16px)]',
+              'group/row relative h-10 min-w-full cursor-pointer -mx-2 px-2 hover:bg-bg-1 border-b-0 transition-none w-[calc(100%+16px)] gap-8',
               'hover:z-20 focus-within:z-10',
               { 'bg-bg-1 animate-pulse': isBuilding }
             )}
@@ -63,7 +63,8 @@ export function BuildsTableBody({
                 cell={cell}
                 className={cn(
                   'shrink-0',
-                  isRightAlignedColumn(cell.column.id) && 'justify-end'
+                  isRightAlignedColumn(cell.column.id) && 'justify-end',
+                  cell.column.id === ID_COLUMN_ID && 'pl-4'
                 )}
               >
                 {flexRender(cell.column.columnDef.cell, cell.getContext())}

--- a/src/features/dashboard/templates/builds/table-config.tsx
+++ b/src/features/dashboard/templates/builds/table-config.tsx
@@ -20,13 +20,19 @@ import {
 
 export const fallbackData: ListedBuildModel[] = []
 
+// Builds arrive newest-first from the API and are never re-sorted client-side;
+// this column carries the fixed default-sort (desc) indicator in the header.
+export const DEFAULT_SORT_COLUMN_ID = 'createdAt'
+
+// Extra left padding balances spacing between the left-aligned and right-aligned column groups.
+export const ID_COLUMN_ID = 'id'
+
 const RIGHT_ALIGNED_COLUMNS = new Set([
+  'duration',
   'cpuCount',
   'memoryMB',
   'diskSizeMB',
   'envdVersion',
-  'createdAt',
-  'duration',
 ])
 
 export const isRightAlignedColumn = (id: string) =>
@@ -60,6 +66,28 @@ export const buildsColumns: ColumnDef<ListedBuildModel>[] = [
     ),
   },
   {
+    accessorKey: 'createdAt',
+    header: 'Started',
+    size: 68,
+    enableResizing: false,
+    cell: ({ row }) => <StartedAt timestamp={row.original.createdAt} />,
+  },
+  {
+    accessorKey: 'duration',
+    header: 'Duration',
+    size: 68,
+    enableResizing: false,
+    cell: ({ row }) => (
+      <div className="w-full text-end">
+        <Duration
+          createdAt={row.original.createdAt}
+          finishedAt={row.original.finishedAt}
+          isBuilding={row.original.status === 'building'}
+        />
+      </div>
+    ),
+  },
+  {
     accessorKey: 'id',
     header: 'ID',
     size: 128,
@@ -89,32 +117,10 @@ export const buildsColumns: ColumnDef<ListedBuildModel>[] = [
   },
   {
     accessorKey: 'envdVersion',
-    header: 'ENVD Ver.',
+    header: 'ENVD',
     size: 96,
     enableResizing: false,
     cell: ({ row }) => <Envd version={row.original.envdVersion} />,
-  },
-  {
-    accessorKey: 'createdAt',
-    header: 'Started',
-    size: 110,
-    enableResizing: false,
-    cell: ({ row }) => <StartedAt timestamp={row.original.createdAt} />,
-  },
-  {
-    accessorKey: 'duration',
-    header: 'Duration',
-    size: 110,
-    enableResizing: false,
-    cell: ({ row }) => (
-      <div className="w-full text-end">
-        <Duration
-          createdAt={row.original.createdAt}
-          finishedAt={row.original.finishedAt}
-          isBuilding={row.original.status === 'building'}
-        />
-      </div>
-    ),
   },
 ]
 

--- a/src/features/dashboard/templates/builds/table-config.tsx
+++ b/src/features/dashboard/templates/builds/table-config.tsx
@@ -118,7 +118,7 @@ export const buildsColumns: ColumnDef<ListedBuildModel>[] = [
   {
     accessorKey: 'envdVersion',
     header: 'ENVD',
-    size: 96,
+    size: 48,
     enableResizing: false,
     cell: ({ row }) => <Envd version={row.original.envdVersion} />,
   },

--- a/src/features/dashboard/templates/builds/table.tsx
+++ b/src/features/dashboard/templates/builds/table.tsx
@@ -40,7 +40,9 @@ import { BuildsTableBody } from './table-body'
 import {
   buildsColumns,
   buildsTableConfig,
+  DEFAULT_SORT_COLUMN_ID,
   fallbackData,
+  ID_COLUMN_ID,
   isRightAlignedColumn,
 } from './table-config'
 
@@ -237,14 +239,20 @@ const BuildsTable = ({
           {table.getHeaderGroups().map((headerGroup) => (
             <DataTableRow
               key={headerGroup.id}
-              className="border-b-0 -mx-2 px-2 w-[calc(100%+16px)]"
+              className="border-b-0 -mx-2 px-2 w-[calc(100%+16px)] gap-8"
             >
               {headerGroup.headers.map((header) => (
                 <DataTableHead
                   key={header.id}
                   header={header}
-                  className="shrink-0"
+                  className={cn(
+                    'shrink-0',
+                    header.id === ID_COLUMN_ID && 'pl-4'
+                  )}
                   align={isRightAlignedColumn(header.id) ? 'right' : 'left'}
+                  sorting={
+                    header.id === DEFAULT_SORT_COLUMN_ID ? true : undefined
+                  }
                 >
                   <span>
                     {header.isPlaceholder

--- a/src/ui/data-table.tsx
+++ b/src/ui/data-table.tsx
@@ -59,7 +59,7 @@ function DataTableHead<TData, TValue>({
         }
       >
         {children}
-        {canSort && (
+        {(canSort || sorting !== undefined) && (
           <div
             className={cn(
               'size-5 min-w-5 flex items-center justify-center',


### PR DESCRIPTION
Updates the templates builds list page to match the Figma design

- Reorder columns: Status · Template · Started · Duration · ID · CPU · Memory · Storage · ENVD
- Move Duration up to position 4 and right-align it; rename the ENVD header
- Highlight Started as the default (desc) sort with an arrow
- Add 16px left padding to the ID column and widen the row gap to 32px

| Before | After |
| ------- | ------- |
| <img height="500" alt="CleanShot 2026-06-30 at 11 54 30@2x" src="https://github.com/user-attachments/assets/5aa9d5b8-a204-4fb1-ab99-5a39a9591c97" /> | <img height="500" alt="CleanShot 2026-06-30 at 11 54 13@2x" src="https://github.com/user-attachments/assets/86119a1e-2c43-4895-bc40-57a71e6abc70" /> |


closes EN-1150