### PR TITLE
feat(webhooks): close context dropdown on field select

### DIFF
--- a/src/features/dashboard/settings/webhooks/delete-webhook-dialog.tsx
+++ b/src/features/dashboard/settings/webhooks/delete-webhook-dialog.tsx
@@ -24,19 +24,25 @@ import { Loader } from '@/ui/primitives/loader'
 import type { Webhook } from './types'
 
 interface DeleteWebhookDialogProps {
-  children: React.ReactNode
+  children?: React.ReactNode
   webhook: Webhook
+  open?: boolean
+  onOpenChange?: (open: boolean) => void
 }
 
 export const DeleteWebhookDialog = ({
   children: trigger,
   webhook,
+  open: controlledOpen,
+  onOpenChange,
 }: DeleteWebhookDialogProps) => {
   const { team } = useDashboard()
   const { toast } = useToast()
   const trpc = useTRPC()
   const queryClient = useQueryClient()
-  const [open, setOpen] = useState(false)
+  const [uncontrolledOpen, setUncontrolledOpen] = useState(false)
+  const open = controlledOpen ?? uncontrolledOpen
+  const setOpen = onOpenChange ?? setUncontrolledOpen
 
   const listQueryKey = trpc.webhooks.list.queryOptions({
     teamSlug: team.slug,
@@ -66,7 +72,7 @@ export const DeleteWebhookDialog = ({
 
   return (
     <Dialog open={open} onOpenChange={setOpen}>
-      <DialogTrigger asChild>{trigger}</DialogTrigger>
+      {trigger && <DialogTrigger asChild>{trigger}</DialogTrigger>}
       <DialogContent
         hideClose
         className="flex flex-row items-center gap-6 sm:max-w-[516px] py-4 pr-8 pl-5"

--- a/src/features/dashboard/settings/webhooks/table-row.tsx
+++ b/src/features/dashboard/settings/webhooks/table-row.tsx
@@ -163,39 +163,73 @@ const WebhookEventBadges = ({ events }: WebhookEventBadgesProps) => {
 
 const WebhookRowActions = ({ webhook }: WebhookRowActionsProps) => {
   const [dropDownOpen, setDropDownOpen] = useState(false)
+  const [editOpen, setEditOpen] = useState(false)
+  const [deleteOpen, setDeleteOpen] = useState(false)
+  const [editSecretOpen, setEditSecretOpen] = useState(false)
+
+  const handleDialogSelect = (
+    event: Event,
+    setDialogOpen: (open: boolean) => void
+  ) => {
+    event.preventDefault()
+    setDropDownOpen(false)
+    setDialogOpen(true)
+  }
 
   return (
-    <DropdownMenu open={dropDownOpen} onOpenChange={setDropDownOpen}>
-      <DropdownMenuTrigger asChild>
-        <IconButton
-          aria-label={`Open actions for ${webhook.name}`}
-          className="relative z-10 size-5"
-          onClick={(e) => e.stopPropagation()}
-        >
-          <IndicatorDotsIcon className="-rotate-90" />
-        </IconButton>
-      </DropdownMenuTrigger>
-      <DropdownMenuContent>
-        <DropdownMenuGroup>
-          <UpsertWebhookDialog mode="update" webhook={webhook}>
-            <DropdownMenuItem inset onSelect={(e) => e.preventDefault()}>
+    <>
+      <DropdownMenu open={dropDownOpen} onOpenChange={setDropDownOpen}>
+        <DropdownMenuTrigger asChild>
+          <IconButton
+            aria-label={`Open actions for ${webhook.name}`}
+            className="relative z-10 size-5"
+            onClick={(e) => e.stopPropagation()}
+          >
+            <IndicatorDotsIcon className="-rotate-90" />
+          </IconButton>
+        </DropdownMenuTrigger>
+        <DropdownMenuContent>
+          <DropdownMenuGroup>
+            <DropdownMenuItem
+              inset
+              onSelect={(event) => handleDialogSelect(event, setEditOpen)}
+            >
               <EditIcon className={actionIconClassName} /> Edit
             </DropdownMenuItem>
-          </UpsertWebhookDialog>
-          <DeleteWebhookDialog webhook={webhook}>
-            <DropdownMenuItem inset onSelect={(e) => e.preventDefault()}>
+            <DropdownMenuItem
+              inset
+              onSelect={(event) => handleDialogSelect(event, setDeleteOpen)}
+            >
               <RemoveIcon className={actionIconClassName} />
               Delete
             </DropdownMenuItem>
-          </DeleteWebhookDialog>
-          <UpdateWebhookSecretDialog webhook={webhook}>
-            <DropdownMenuItem inset onSelect={(e) => e.preventDefault()}>
+            <DropdownMenuItem
+              inset
+              onSelect={(event) => handleDialogSelect(event, setEditSecretOpen)}
+            >
               <PrivateIcon className={actionIconClassName} /> Edit secret
             </DropdownMenuItem>
-          </UpdateWebhookSecretDialog>
-        </DropdownMenuGroup>
-      </DropdownMenuContent>
-    </DropdownMenu>
+          </DropdownMenuGroup>
+        </DropdownMenuContent>
+      </DropdownMenu>
+
+      <UpsertWebhookDialog
+        mode="update"
+        webhook={webhook}
+        open={editOpen}
+        onOpenChange={setEditOpen}
+      />
+      <DeleteWebhookDialog
+        webhook={webhook}
+        open={deleteOpen}
+        onOpenChange={setDeleteOpen}
+      />
+      <UpdateWebhookSecretDialog
+        webhook={webhook}
+        open={editSecretOpen}
+        onOpenChange={setEditSecretOpen}
+      />
+    </>
   )
 }
 

--- a/src/features/dashboard/settings/webhooks/update-webhook-secret-dialog.tsx
+++ b/src/features/dashboard/settings/webhooks/update-webhook-secret-dialog.tsx
@@ -38,20 +38,26 @@ import { Loader } from '@/ui/primitives/loader'
 import type { Webhook } from './types'
 
 interface UpdateWebhookSecretDialogProps {
-  children: React.ReactNode
+  children?: React.ReactNode
   webhook: Webhook
+  open?: boolean
+  onOpenChange?: (open: boolean) => void
 }
 
 export const UpdateWebhookSecretDialog = ({
   children: trigger,
   webhook,
+  open: controlledOpen,
+  onOpenChange,
 }: UpdateWebhookSecretDialogProps) => {
   'use no memo'
 
   const { team } = useDashboard()
   const trpc = useTRPC()
   const queryClient = useQueryClient()
-  const [open, setOpen] = useState(false)
+  const [uncontrolledOpen, setUncontrolledOpen] = useState(false)
+  const open = controlledOpen ?? uncontrolledOpen
+  const setOpen = onOpenChange ?? setUncontrolledOpen
 
   const listQueryKey = trpc.webhooks.list.queryOptions({
     teamSlug: team.slug,
@@ -103,7 +109,7 @@ export const UpdateWebhookSecretDialog = ({
 
   return (
     <Dialog open={open} onOpenChange={handleDialogChange}>
-      <DialogTrigger asChild>{trigger}</DialogTrigger>
+      {trigger && <DialogTrigger asChild>{trigger}</DialogTrigger>}
       <DialogContent>
         <DialogHeader className="gap-2">
           <DialogTitle>Edit '{webhook.name}' secret</DialogTitle>

--- a/src/features/dashboard/settings/webhooks/upsert-webhook-dialog.tsx
+++ b/src/features/dashboard/settings/webhooks/upsert-webhook-dialog.tsx
@@ -41,27 +41,33 @@ import {
 
 type UpsertWebhookDialogProps =
   | {
-      children: React.ReactNode
+      children?: React.ReactNode
       mode: 'create'
       webhook?: undefined
+      open?: boolean
+      onOpenChange?: (open: boolean) => void
     }
   | {
-      children: React.ReactNode
+      children?: React.ReactNode
       mode: 'update'
       webhook: Webhook
+      open?: boolean
+      onOpenChange?: (open: boolean) => void
     }
 
 export function UpsertWebhookDialog({
   children: trigger,
   mode,
   webhook,
+  open: controlledOpen,
+  onOpenChange,
 }: UpsertWebhookDialogProps) {
   'use no memo'
 
   const { team } = useDashboard()
   const trpc = useTRPC()
   const queryClient = useQueryClient()
-  const [open, setOpen] = useState(false)
+  const [uncontrolledOpen, setUncontrolledOpen] = useState(false)
   const [currentStep, setCurrentStep] = useState(1)
   const [lastSelectedEvent, setLastSelectedEvent] =
     useState<SandboxLifecycleEventType | null>(null)
@@ -72,6 +78,8 @@ export function UpsertWebhookDialog({
 
   const isUpdateMode = mode === 'update'
   const totalSteps = isUpdateMode ? 1 : 2
+  const open = controlledOpen ?? uncontrolledOpen
+  const setOpen = onOpenChange ?? setUncontrolledOpen
 
   const listQueryKey = trpc.webhooks.list.queryOptions({
     teamSlug: team.slug,
@@ -250,7 +258,7 @@ export function UpsertWebhookDialog({
   return (
     <>
       <Dialog open={open} onOpenChange={handleDialogChange}>
-        <DialogTrigger asChild>{trigger}</DialogTrigger>
+        {trigger && <DialogTrigger asChild>{trigger}</DialogTrigger>}
 
         <DialogContent className="flex flex-col gap-4 px-6 pt-5 pb-6 h-[685px] max-h-[calc(100svh-2rem)] overflow-hidden">
           <DialogHeader className="gap-0.5">


### PR DESCRIPTION
Close context dropdown on field selection

Before: When clicking a field in the dropdown and opening the modal, the dropdown did not close automatically.