### PR TITLE
fix: scale template overview title to avoid line wrap

### DIFF
--- a/src/features/dashboard/templates/detail/overview/skeleton.tsx
+++ b/src/features/dashboard/templates/detail/overview/skeleton.tsx
@@ -5,7 +5,7 @@ export function TemplateOverviewSkeleton() {
   return (
     <div className="flex flex-col gap-8">
       <OverviewSection label="Template" divider={false}>
-        <div className="flex flex-wrap items-center justify-between gap-x-6 gap-y-2">
+        <div className="flex flex-col gap-1">
           <Skeleton className="h-8 w-40" />
           <Skeleton className="h-5 w-56" />
         </div>

--- a/src/features/dashboard/templates/detail/overview/template-section.tsx
+++ b/src/features/dashboard/templates/detail/overview/template-section.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import type { ReactNode } from 'react'
+import type { CSSProperties, ReactNode } from 'react'
 import type { TemplateDetail } from '@/core/modules/templates/models'
 import { getTemplateDisplayName } from '@/features/dashboard/templates/helpers'
 import { useClipboard } from '@/lib/hooks/use-clipboard'
@@ -35,8 +35,11 @@ export function TemplateSection({ template, teamSlug }: TemplateSectionProps) {
 
   return (
     <OverviewSection label="Template" divider={false}>
-      <div className="flex flex-wrap items-center justify-between gap-x-6 gap-y-2">
-        <h2 className="prose-value-big font-mono uppercase tracking-tight break-all">
+      <div className="@container flex flex-col gap-1">
+        <h2
+          style={{ '--char-count': displayName.length } as CSSProperties}
+          className="prose-value-big-fit font-mono uppercase tracking-tight break-all"
+        >
           {displayName}
         </h2>
         <TemplateIdCopy templateID={template.templateID} />

--- a/src/styles/theme.css
+++ b/src/styles/theme.css
@@ -596,7 +596,7 @@
  * query context (e.g. Tailwind's `@container`). 0.6 ≈ glyph advance per em. */
 @utility prose-value-big-fit {
   font-size: clamp(
-    1rem,
+    0.9375rem,
     calc(100cqi / (var(--char-count, 1) * 0.6)),
     2rem
   ) !important;

--- a/src/styles/theme.css
+++ b/src/styles/theme.css
@@ -591,6 +591,19 @@
   font-weight: 700 !important;
 }
 
+/* Scales a monospace value down by character count to fit its container's
+ * inline size, avoiding line wrap. Requires `--char-count` and a container
+ * query context (e.g. Tailwind's `@container`). 0.6 ≈ glyph advance per em. */
+@utility prose-value-big-fit {
+  font-size: clamp(
+    1rem,
+    calc(100cqi / (var(--char-count, 1) * 0.6)),
+    2rem
+  ) !important;
+  line-height: 1.1 !important;
+  font-weight: 700 !important;
+}
+
 /* Loader utilities */
 @utility loader {
   display: inline-flex;


### PR DESCRIPTION
Long template names wrapped onto multiple lines in the overview header because the title was fixed at 32px. The title now scales down by character count (via a CSS container query) between 16px and 32px, staying on one line for all but extreme names. The new `prose-value-big-fit` utility does this in pure CSS — no JS measurement — leaning on the title's existing monospace font (glyph advance ≈ 0.6em).

| Before | After |
| ------- | ------- |
| <img width="1722" height="1272" alt="CleanShot 2026-06-30 at 13 35 03@2x" src="https://github.com/user-attachments/assets/43b7d86b-7b4c-437c-93f2-497210991bfb" /> | <img width="1716" height="1164" alt="CleanShot 2026-06-30 at 13 34 14@2x" src="https://github.com/user-attachments/assets/602a1ad9-081d-484b-888d-4913b34b44ef" /> |

Title font is scaled between 15-32px, otherwise will still wrap.