### PR TITLE
feat(templates): improve highlight date and time in template list created/updated column

### DIFF
--- a/src/features/dashboard/templates/list/table-cells.tsx
+++ b/src/features/dashboard/templates/list/table-cells.tsx
@@ -313,18 +313,59 @@ export function TemplateNameCell({
   )
 }
 
-export function CreatedAtCell({
-  getValue,
-}: CellContext<Template | DefaultTemplate, unknown>) {
+export interface TemplatesTableMeta {
+  sortedColumnId?: string
+}
+
+type DateColumnId = 'createdAt' | 'updatedAt'
+
+const DATE_CELL_FORMAT_OPTIONS = {
+  includeSeconds: false,
+  includeYear: true,
+  includeTimezone: true,
+} as const
+
+function DateTimeCell({
+  ctx,
+  columnId,
+}: {
+  ctx: CellContext<Template | DefaultTemplate, unknown>
+  columnId: DateColumnId
+}) {
+  'use no memo'
+
+  const { getValue, table, row } = ctx
   const dateValue = getValue() as string
 
-  const formattedTimestamp = useMemo(() => {
-    return formatLocalLogStyleTimestamp(dateValue, {
-      includeSeconds: false,
-      includeYear: true,
-      includeTimezone: true,
-    })
-  }, [dateValue])
+  const formatted = useMemo(
+    () => formatLocalLogStyleTimestamp(dateValue, DATE_CELL_FORMAT_OPTIONS),
+    [dateValue]
+  )
+
+  const meta = table.options.meta as TemplatesTableMeta | undefined
+  const isSortedColumn = meta?.sortedColumnId === columnId
+
+  // Compare against the full loaded row model (not the virtualized window) so
+  // the first/last on-screen rows still see their true neighbours. Adjacency is
+  // a best guess over loaded pages; it may shift as more rows load in.
+  const rows = table.getRowModel().rows
+  const datePart = formatted?.datePart
+
+  const isTimePromoted = useMemo(() => {
+    if (!isSortedColumn || !datePart) return false
+
+    const sharesDate = (index: number) => {
+      const neighbor = rows[index]
+      if (!neighbor) return false
+      const neighborValue = neighbor.getValue(columnId) as string
+      return (
+        formatLocalLogStyleTimestamp(neighborValue, DATE_CELL_FORMAT_OPTIONS)
+          ?.datePart === datePart
+      )
+    }
+
+    return sharesDate(row.index - 1) || sharesDate(row.index + 1)
+  }, [isSortedColumn, datePart, rows, row.index, columnId])
 
   return (
     <div
@@ -332,45 +373,27 @@ export function CreatedAtCell({
         'h-full overflow-x-hidden whitespace-nowrap font-mono prose-table-numeric'
       )}
     >
-      <span className="text-fg-tertiary">
-        {formattedTimestamp?.datePart ?? '--'}
+      <span className="text-fg-secondary">{formatted?.datePart ?? '--'}</span>{' '}
+      <span
+        className={isTimePromoted ? 'text-fg-secondary' : 'text-fg-tertiary'}
+      >
+        {formatted?.timePart ?? '--'}
       </span>{' '}
-      {formattedTimestamp?.timePart ?? '--'}{' '}
-      <span className="text-fg-tertiary">
-        {formattedTimestamp?.timezonePart ?? ''}
-      </span>
+      <span className="text-fg-tertiary">{formatted?.timezonePart ?? ''}</span>
     </div>
   )
 }
 
-export function UpdatedAtCell({
-  getValue,
-}: CellContext<Template | DefaultTemplate, unknown>) {
-  const dateValue = getValue() as string
+export function CreatedAtCell(
+  ctx: CellContext<Template | DefaultTemplate, unknown>
+) {
+  return <DateTimeCell ctx={ctx} columnId="createdAt" />
+}
 
-  const formattedTimestamp = useMemo(() => {
-    return formatLocalLogStyleTimestamp(dateValue, {
-      includeSeconds: false,
-      includeYear: true,
-      includeTimezone: true,
-    })
-  }, [dateValue])
-
-  return (
-    <div
-      className={cn(
-        'h-full overflow-x-hidden whitespace-nowrap font-mono prose-table-numeric'
-      )}
-    >
-      <span className="text-fg-tertiary">
-        {formattedTimestamp?.datePart ?? '--'}
-      </span>{' '}
-      {formattedTimestamp?.timePart ?? '--'}{' '}
-      <span className="text-fg-tertiary">
-        {formattedTimestamp?.timezonePart ?? ''}
-      </span>
-    </div>
-  )
+export function UpdatedAtCell(
+  ctx: CellContext<Template | DefaultTemplate, unknown>
+) {
+  return <DateTimeCell ctx={ctx} columnId="updatedAt" />
 }
 
 export function VisibilityCell({

--- a/src/features/dashboard/templates/list/table-cells.tsx
+++ b/src/features/dashboard/templates/list/table-cells.tsx
@@ -313,10 +313,6 @@ export function TemplateNameCell({
   )
 }
 
-export interface TemplatesTableMeta {
-  sortedColumnId?: string
-}
-
 type DateColumnId = 'createdAt' | 'updatedAt'
 
 const DATE_CELL_FORMAT_OPTIONS = {
@@ -342,17 +338,14 @@ function DateTimeCell({
     [dateValue]
   )
 
-  const meta = table.options.meta as TemplatesTableMeta | undefined
-  const isSortedColumn = meta?.sortedColumnId === columnId
-
   // Compare against the full loaded row model (not the virtualized window) so
   // the first/last on-screen rows still see their true neighbours. Adjacency is
   // a best guess over loaded pages; it may shift as more rows load in.
   const rows = table.getRowModel().rows
   const datePart = formatted?.datePart
 
-  const isTimePromoted = useMemo(() => {
-    if (!isSortedColumn || !datePart) return false
+  const { isDateEmphasized, isTimeEmphasized } = useMemo(() => {
+    if (!datePart) return { isDateEmphasized: false, isTimeEmphasized: false }
 
     const sharesDate = (index: number) => {
       const neighbor = rows[index]
@@ -364,8 +357,14 @@ function DateTimeCell({
       )
     }
 
-    return sharesDate(row.index - 1) || sharesDate(row.index + 1)
-  }, [isSortedColumn, datePart, rows, row.index, columnId])
+    const sameAsAbove = sharesDate(row.index - 1)
+    const sameAsBelow = sharesDate(row.index + 1)
+
+    return {
+      isDateEmphasized: !sameAsAbove,
+      isTimeEmphasized: sameAsAbove || sameAsBelow,
+    }
+  }, [datePart, rows, row.index, columnId])
 
   return (
     <div
@@ -373,10 +372,10 @@ function DateTimeCell({
         'h-full overflow-x-hidden whitespace-nowrap font-mono prose-table-numeric'
       )}
     >
-      <span className="text-fg-secondary">{formatted?.datePart ?? '--'}</span>{' '}
-      <span
-        className={isTimePromoted ? 'text-fg-secondary' : 'text-fg-tertiary'}
-      >
+      <span className={isDateEmphasized ? 'text-fg' : 'text-fg-tertiary'}>
+        {formatted?.datePart ?? '--'}
+      </span>{' '}
+      <span className={isTimeEmphasized ? 'text-fg' : 'text-fg-tertiary'}>
         {formatted?.timePart ?? '--'}
       </span>{' '}
       <span className="text-fg-tertiary">{formatted?.timezonePart ?? ''}</span>

--- a/src/features/dashboard/templates/list/table-cells.tsx
+++ b/src/features/dashboard/templates/list/table-cells.tsx
@@ -338,9 +338,6 @@ function DateTimeCell({
     [dateValue]
   )
 
-  // Compare against the full loaded row model (not the virtualized window) so
-  // the first/last on-screen rows still see their true neighbours. Adjacency is
-  // a best guess over loaded pages; it may shift as more rows load in.
   const rows = table.getRowModel().rows
   const datePart = formatted?.datePart
 

--- a/src/features/dashboard/templates/list/table.tsx
+++ b/src/features/dashboard/templates/list/table.tsx
@@ -33,12 +33,14 @@ import HelpTooltip from '@/ui/help-tooltip'
 import { SIDEBAR_TRANSITION_CLASSNAMES } from '@/ui/primitives/sidebar'
 import {
   TEMPLATES_DEFAULT_SORT_BASE,
+  TEMPLATES_DEFAULT_SORT_COLUMN_ID,
   TEMPLATES_DEFAULT_SORT_DESC,
   TEMPLATES_PAGE_SIZE,
 } from './constants'
 import TemplatesHeader from './header'
 import { useTemplateTableStore } from './stores/table-store'
 import { TemplatesTableBody as TableBody } from './table-body'
+import type { TemplatesTableMeta } from './table-cells'
 import { fallbackData, templatesTableConfig, useColumns } from './table-config'
 
 const COLUMN_TO_SORT_BASE: Record<string, string> = {
@@ -71,6 +73,7 @@ export default function TemplatesTable() {
     ? sortColumn.desc !== false
     : TEMPLATES_DEFAULT_SORT_DESC
   const sort = `${sortBase}_${isDesc ? 'desc' : 'asc'}` as TemplatesSort
+  const sortedColumnId = sortColumn?.id ?? TEMPLATES_DEFAULT_SORT_COLUMN_ID
 
   const {
     data,
@@ -140,6 +143,7 @@ export default function TemplatesTable() {
     onGlobalFilterChange: setGlobalFilter,
     onSortingChange: setSorting,
     onColumnSizingChange: setColumnSizing,
+    meta: { sortedColumnId } satisfies TemplatesTableMeta,
   } as TableOptions<Template>)
 
   const columnSizeVars = useColumnSizeVars(table)

--- a/src/features/dashboard/templates/list/table.tsx
+++ b/src/features/dashboard/templates/list/table.tsx
@@ -33,14 +33,12 @@ import HelpTooltip from '@/ui/help-tooltip'
 import { SIDEBAR_TRANSITION_CLASSNAMES } from '@/ui/primitives/sidebar'
 import {
   TEMPLATES_DEFAULT_SORT_BASE,
-  TEMPLATES_DEFAULT_SORT_COLUMN_ID,
   TEMPLATES_DEFAULT_SORT_DESC,
   TEMPLATES_PAGE_SIZE,
 } from './constants'
 import TemplatesHeader from './header'
 import { useTemplateTableStore } from './stores/table-store'
 import { TemplatesTableBody as TableBody } from './table-body'
-import type { TemplatesTableMeta } from './table-cells'
 import { fallbackData, templatesTableConfig, useColumns } from './table-config'
 
 const COLUMN_TO_SORT_BASE: Record<string, string> = {
@@ -73,7 +71,6 @@ export default function TemplatesTable() {
     ? sortColumn.desc !== false
     : TEMPLATES_DEFAULT_SORT_DESC
   const sort = `${sortBase}_${isDesc ? 'desc' : 'asc'}` as TemplatesSort
-  const sortedColumnId = sortColumn?.id ?? TEMPLATES_DEFAULT_SORT_COLUMN_ID
 
   const {
     data,
@@ -143,7 +140,6 @@ export default function TemplatesTable() {
     onGlobalFilterChange: setGlobalFilter,
     onSortingChange: setSorting,
     onColumnSizingChange: setColumnSizing,
-    meta: { sortedColumnId } satisfies TemplatesTableMeta,
   } as TableOptions<Template>)
 
   const columnSizeVars = useColumnSizeVars(table)


### PR DESCRIPTION
Improve highlighting of the date and time in the Created/Updated columns of the
Templates list to better visually group rows by day.

## Why?

Team behavior is split: most teams have only a few templates (dates alone
differentiate rows), while templates-heavy teams create dozens to thousands per
day (only times differentiate rows). For ~65% of active paying teams the first
page of the table mixes both regimes, so a fixed emphasis on either the date or
the time is wrong for part of the page. The highlight now adapts per row and
emphasizes the part that actually changed.

## Highlight rules

For each row, its date is compared with the rows directly above and below
(per column):

- **New date** (differs from the row above): the date is rendered using
  text/primary.
- **Start of a same-day group** (new date + the row below shares it): both the
  date and the time are rendered using text/primary.
- **Continuation of a same-day group** (the row above shares the date): only the
  time is rendered using text/primary; the date drops to text/tertiary.
- Everything not promoted (including the timezone suffix) stays text/tertiary.

This applies to both the Created and Updated columns at all times, regardless of
which column the table is sorted by or the sort direction. (Previously the logic
only ran on the actively sorted column.)

<img width="1092" height="1130" alt="Screenshot 2026-07-08 at 13 21 35" src="https://github.com/user-attachments/assets/38147cb2-030e-4522-a45a-a237e343d40a" />