### PR TITLE
feat(usage): redesigned usage page skeleton behind feature flag

### DIFF
--- a/src/app/dashboard/[teamSlug]/usage/page.tsx
+++ b/src/app/dashboard/[teamSlug]/usage/page.tsx
@@ -1,4 +1,10 @@
+import { redirect } from 'next/navigation'
+import { AUTH_URLS } from '@/configs/urls'
+import { featureFlags } from '@/core/modules/feature-flags/feature-flags.server'
+import { getAuthContext } from '@/core/server/auth'
+import { getTeamIdFromSlug } from '@/core/server/functions/team/get-team-id-from-slug'
 import { getUsage } from '@/core/server/functions/usage/get-usage'
+import { UsageRedesignPage } from '@/features/dashboard/usage/redesign/usage-redesign'
 import { UsageChartsProvider } from '@/features/dashboard/usage/usage-charts-context'
 import { UsageMetricChart } from '@/features/dashboard/usage/usage-metric-chart'
 import { UsageTopTimeRangeControls } from '@/features/dashboard/usage/usage-top-time-range-controls'
@@ -11,6 +17,30 @@ export default async function UsagePage({
   params: Promise<{ teamSlug: string }>
 }) {
   const { teamSlug } = await params
+
+  const authContext = await getAuthContext()
+
+  if (!authContext) {
+    redirect(AUTH_URLS.SIGN_IN)
+  }
+
+  const teamId = await getTeamIdFromSlug(teamSlug, authContext.accessToken)
+
+  const newUsagePage = await featureFlags.isEnabled('newUsagePage', {
+    user: {
+      id: authContext.user.id,
+      email: authContext.user.email ?? undefined,
+    },
+    team:
+      teamId.ok && teamId.data
+        ? { id: teamId.data, slug: teamSlug }
+        : undefined,
+  })
+
+  if (newUsagePage) {
+    return <UsageRedesignPage />
+  }
+
   const result = await getUsage({ teamSlug })
 
   if (!result?.data || result.serverError || result.validationErrors) {

--- a/src/core/modules/feature-flags/definitions.ts
+++ b/src/core/modules/feature-flags/definitions.ts
@@ -23,6 +23,13 @@ export const FEATURE_FLAGS = {
       'Enables the new sandbox list with pagination and paused sandbox coverage.',
     exposure: 'both',
   },
+  newUsagePage: {
+    kind: 'boolean',
+    key: 'new-usage-page',
+    defaultValue: false,
+    description: 'Enables the redesigned (Dashboard 2.0) usage page skeleton.',
+    exposure: 'server',
+  },
   disableE2BAccessTokenProvisioning: {
     kind: 'boolean',
     key: 'disable_e2b_access_token_provisioning',

--- a/src/features/dashboard/usage/redesign/usage-redesign-chart.tsx
+++ b/src/features/dashboard/usage/redesign/usage-redesign-chart.tsx
@@ -1,0 +1,88 @@
+'use client'
+
+import { Area, AreaChart, CartesianGrid, XAxis, YAxis } from 'recharts'
+import { ChartContainer } from '@/ui/primitives/chart'
+
+// Static placeholder series — the redesigned usage page is not yet wired to data.
+const MOCK_SERIES = [
+  { label: '1 Mar', value: 420 },
+  { label: '2 Mar', value: 610 },
+  { label: '3 Mar', value: 580 },
+  { label: '4 Mar', value: 720 },
+  { label: '5 Mar', value: 690 },
+  { label: '6 Mar', value: 540 },
+  { label: '7 Mar', value: 510 },
+  { label: '8 Mar', value: 480 },
+  { label: '9 Mar', value: 360 },
+  { label: '10 Mar', value: 220 },
+  { label: '11 Mar', value: 470 },
+  { label: '12 Mar', value: 560 },
+  { label: '13 Mar', value: 630 },
+  { label: '14 Mar', value: 700 },
+  { label: '15 Mar', value: 760 },
+  { label: '16 Mar', value: 820 },
+  { label: '17 Mar', value: 780 },
+  { label: '18 Mar', value: 690 },
+  { label: '19 Mar', value: 640 },
+  { label: '20 Mar', value: 590 },
+  { label: '21 Mar', value: 520 },
+  { label: '22 Mar', value: 460 },
+  { label: '23 Mar', value: 410 },
+  { label: '24 Mar', value: 380 },
+]
+
+const X_TICKS = ['1 Mar', '7 Mar', '14 Mar', '24 Mar']
+
+export function UsageRedesignChart() {
+  return (
+    <ChartContainer config={{}} className="aspect-auto h-45 w-full">
+      <AreaChart
+        data={MOCK_SERIES}
+        margin={{ top: 4, right: 4, bottom: 0, left: 0 }}
+      >
+        <defs>
+          <linearGradient id="usageRedesignFill" x1="0" y1="0" x2="0" y2="1">
+            <stop
+              offset="0%"
+              stopColor="var(--graph-area-accent-main-from)"
+              stopOpacity={1}
+            />
+            <stop
+              offset="100%"
+              stopColor="var(--graph-area-accent-main-from)"
+              stopOpacity={0}
+            />
+          </linearGradient>
+        </defs>
+        <CartesianGrid
+          vertical={false}
+          strokeDasharray="3 3"
+          stroke="var(--stroke)"
+        />
+        <XAxis
+          dataKey="label"
+          ticks={X_TICKS}
+          tickLine={false}
+          axisLine={false}
+          tickMargin={8}
+          interval="preserveStartEnd"
+        />
+        <YAxis
+          width={40}
+          tickLine={false}
+          axisLine={false}
+          tickFormatter={(value) => `$${value}`}
+        />
+        <Area
+          type="step"
+          dataKey="value"
+          stroke="var(--accent-main-highlight)"
+          strokeWidth={1.5}
+          fill="url(#usageRedesignFill)"
+          fillOpacity={1}
+          isAnimationActive={false}
+        />
+      </AreaChart>
+    </ChartContainer>
+  )
+}

--- a/src/features/dashboard/usage/redesign/usage-redesign.tsx
+++ b/src/features/dashboard/usage/redesign/usage-redesign.tsx
@@ -1,0 +1,174 @@
+'use client'
+
+import { useState } from 'react'
+import { cn } from '@/lib/utils'
+import { Badge } from '@/ui/primitives/badge'
+import { Button } from '@/ui/primitives/button'
+import {
+  ChevronDownIcon,
+  FilterIcon,
+  HistoryIcon,
+  KeyIcon,
+  SearchIcon,
+  TemplateIcon,
+  UnpackIcon,
+} from '@/ui/primitives/icons'
+import { Input } from '@/ui/primitives/input'
+import { UsageRedesignChart } from './usage-redesign-chart'
+
+type GroupBy = 'template' | 'api-key'
+
+// Static placeholder rows — the redesigned usage page is not yet wired to data.
+const MOCK_ROWS: { name: string; madeByE2B: boolean; cost: string }[] = [
+  { name: 'base', madeByE2B: true, cost: '$7,124.24' },
+  { name: 'code-interpreter-v1', madeByE2B: true, cost: '$4,124.24' },
+  { name: 'desktop', madeByE2B: true, cost: '$1,124.50' },
+  { name: 'runtime-eval-v4', madeByE2B: false, cost: '$452.00' },
+  { name: 'runtime-eval-v3', madeByE2B: false, cost: '$312.00' },
+  { name: 'runtime-eval-v2', madeByE2B: false, cost: '$99.23' },
+  { name: 'runtime-eval-v1', madeByE2B: false, cost: '$0.00' },
+]
+
+export function UsageRedesignPage() {
+  const [groupBy, setGroupBy] = useState<GroupBy>('template')
+
+  return (
+    <div className="h-full max-h-full min-h-0 overflow-y-auto">
+      <div className="mx-auto flex max-w-[1200px] flex-col gap-6 p-3 md:p-8">
+        <UsageControls />
+
+        <div className="flex flex-col gap-4">
+          <TotalCost />
+          <UsageRedesignChart />
+        </div>
+
+        <div className="flex flex-col">
+          <TabSwitcher value={groupBy} onChange={setGroupBy} />
+          <CostList />
+        </div>
+      </div>
+    </div>
+  )
+}
+
+function UsageControls() {
+  return (
+    <div className="flex flex-wrap items-center gap-1">
+      <div className="relative w-full max-w-[280px]">
+        <SearchIcon className="text-icon-tertiary pointer-events-none absolute left-2.5 top-1/2 size-4 -translate-y-1/2" />
+        <Input
+          placeholder="Search by name"
+          readOnly
+          className="pl-8.5"
+          aria-label="Search by name"
+        />
+      </div>
+
+      <Button variant="secondary" type="button">
+        <HistoryIcon />
+        This month (April)
+        <UnpackIcon />
+      </Button>
+
+      <Button variant="secondary" type="button">
+        <FilterIcon />
+        Filter
+      </Button>
+    </div>
+  )
+}
+
+function TotalCost() {
+  return (
+    <div className="flex flex-wrap items-baseline gap-3">
+      <span className="prose-value-big text-fg font-mono uppercase">
+        $15,124.24
+      </span>
+      <span className="prose-label text-fg-tertiary uppercase">
+        total cost for 1 Apr – 19 Apr
+      </span>
+    </div>
+  )
+}
+
+function TabSwitcher({
+  value,
+  onChange,
+}: {
+  value: GroupBy
+  onChange: (value: GroupBy) => void
+}) {
+  return (
+    <div className="border-stroke flex gap-6 border-b">
+      <Tab
+        active={value === 'template'}
+        onClick={() => onChange('template')}
+        icon={<TemplateIcon />}
+        label="By template"
+      />
+      <Tab
+        active={value === 'api-key'}
+        onClick={() => onChange('api-key')}
+        icon={<KeyIcon />}
+        label="By API key"
+      />
+    </div>
+  )
+}
+
+function Tab({
+  active,
+  onClick,
+  icon,
+  label,
+}: {
+  active: boolean
+  onClick: () => void
+  icon: React.ReactNode
+  label: string
+}) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      className={cn(
+        'prose-body-highlight flex cursor-pointer items-center gap-1.5 border-b py-2.5 -mb-px',
+        '[&_svg]:size-4',
+        active
+          ? 'border-accent-main-highlight text-fg [&_svg]:text-fg'
+          : 'border-transparent text-fg-tertiary [&_svg]:text-icon-tertiary'
+      )}
+    >
+      {icon}
+      {label}
+    </button>
+  )
+}
+
+function CostList() {
+  return (
+    <div className="flex flex-col">
+      {MOCK_ROWS.map((row) => (
+        <div
+          key={row.name}
+          className="border-stroke flex items-center justify-between border-b py-3"
+        >
+          <div className="flex items-center gap-1.5">
+            <span className="prose-body text-fg">{row.name}</span>
+            {row.madeByE2B && (
+              <Badge variant="default" size="sm">
+                by E2B
+              </Badge>
+            )}
+          </div>
+          <div className="flex items-center gap-2">
+            <span className="prose-body-numeric text-fg font-mono">
+              {row.cost}
+            </span>
+            <ChevronDownIcon className="text-icon-tertiary size-4" />
+          </div>
+        </div>
+      ))}
+    </div>
+  )
+}

--- a/tests/unit/feature-flags.test.ts
+++ b/tests/unit/feature-flags.test.ts
@@ -67,6 +67,7 @@ describe('createFeatureFlagService', () => {
       FEATURE_FLAGS.agentsEnabled,
       FEATURE_FLAGS.isAdmin,
       FEATURE_FLAGS.newSandboxList,
+      FEATURE_FLAGS.newUsagePage,
       FEATURE_FLAGS.disableE2BAccessTokenProvisioning,
     ])
     expect(result).toEqual([
@@ -92,6 +93,15 @@ describe('createFeatureFlagService', () => {
         kind: 'boolean',
         description:
           'Enables the new sandbox list with pagination and paused sandbox coverage.',
+        defaultValue: false,
+        value: true,
+      },
+      {
+        id: 'newUsagePage',
+        key: 'new-usage-page',
+        kind: 'boolean',
+        description:
+          'Enables the redesigned (Dashboard 2.0) usage page skeleton.',
         defaultValue: false,
         value: true,
       },


### PR DESCRIPTION
Adds a static, visual-only skeleton of the usage page redesign, gated behind a new server-side `newUsagePage` (`new-usage-page`) feature flag that swaps into the existing `/dashboard/[teamSlug]/usage` route only when enabled — the current charts page is the untouched OFF fallback. The skeleton (`src/features/dashboard/usage/redesign/`) renders the full layout with mock data: header controls, the total-cost figure, a recharts step-area timeline graph, a By template / By API key tab switcher, and a static cost list. The LaunchDarkly flag was created in the `dashboard` project with its default rule serving `false` in all environments and left OFF. No data wiring, sidebar, or existing-behavior changes are included.