### PR TITLE
fix(posthog): identify users before first pageview via init bootstrap

### DIFF
--- a/src/app/dashboard/[teamSlug]/layout.tsx
+++ b/src/app/dashboard/[teamSlug]/layout.tsx
@@ -12,6 +12,7 @@ import { featureFlags } from '@/core/modules/feature-flags/feature-flags.server'
 import { getAuthContext } from '@/core/server/auth'
 import DashboardLayoutView from '@/features/dashboard/layouts/layout'
 import { DashboardPostHogErrorBoundary } from '@/features/dashboard/posthog-error-boundary'
+import { PostHogBootstrap } from '@/features/posthog-bootstrap'
 import Sidebar from '@/features/dashboard/sidebar/sidebar'
 import {
   getQueryClient,
@@ -86,6 +87,10 @@ export default async function DashboardLayout({
 
   return (
     <HydrateClient>
+      <PostHogBootstrap
+        distinctId={authContext.user.id}
+        email={authContext.user.email ?? undefined}
+      />
       <FeatureFlagsProvider initialFlags={evaluatedFeatureFlags}>
         <DashboardTeamGate teamSlug={teamSlug} fallbackUser={authContext.user}>
           <SidebarProvider

--- a/src/app/dashboard/[teamSlug]/layout.tsx
+++ b/src/app/dashboard/[teamSlug]/layout.tsx
@@ -12,8 +12,8 @@ import { featureFlags } from '@/core/modules/feature-flags/feature-flags.server'
 import { getAuthContext } from '@/core/server/auth'
 import DashboardLayoutView from '@/features/dashboard/layouts/layout'
 import { DashboardPostHogErrorBoundary } from '@/features/dashboard/posthog-error-boundary'
-import { PostHogBootstrap } from '@/features/posthog-bootstrap'
 import Sidebar from '@/features/dashboard/sidebar/sidebar'
+import { PostHogBootstrap } from '@/features/posthog-bootstrap'
 import {
   getQueryClient,
   HydrateClient,

--- a/src/features/ory-posthog-identity-bridge.tsx
+++ b/src/features/ory-posthog-identity-bridge.tsx
@@ -27,7 +27,10 @@ export function OryPostHogIdentityBridge({
       return
     }
 
-    posthog.identify(user.id, { email: user.email, environment })
+    posthog.identify(user.id, {
+      environment,
+      ...(user.email ? { email: user.email } : {}),
+    })
     posthog.group('team', team.id, {
       environment,
       name: team.name,

--- a/src/features/posthog-bootstrap.tsx
+++ b/src/features/posthog-bootstrap.tsx
@@ -1,0 +1,22 @@
+'use client'
+
+import { useEffect } from 'react'
+import { useAppPostHogProvider } from '@/features/posthog-provider'
+
+// Feeds the server-known identity into PostHog before init, so the first
+// captured pageview is already identified instead of anonymous.
+export function PostHogBootstrap({
+  distinctId,
+  email,
+}: {
+  distinctId: string
+  email?: string
+}) {
+  const { setBootstrap } = useAppPostHogProvider()
+
+  useEffect(() => {
+    setBootstrap({ distinctID: distinctId, email })
+  }, [distinctId, email, setBootstrap])
+
+  return null
+}

--- a/src/features/posthog-provider.tsx
+++ b/src/features/posthog-provider.tsx
@@ -109,13 +109,21 @@ export function PostHogProvider({
       disable_session_recording: process.env.NODE_ENV !== 'production',
       advanced_disable_toolbar_metrics: true,
       opt_in_site_apps: true,
+      // bootstrap only carries identity/flag fields (distinctID, isIdentifiedID,
+      // featureFlags, sessionID) — it does NOT send $set person properties.
       bootstrap: {
         distinctID: bootstrap.distinctID,
         isIdentifiedID: true,
-        ...(bootstrap.email ? { $set: { email: bootstrap.email } } : {}),
       },
       loaded: (posthog) => {
         if (process.env.NODE_ENV === 'development') posthog.debug()
+        // `loaded` runs before posthog-js auto-captures the first $pageview, so
+        // setting the email here ensures that pageview is ingested with the
+        // email already on the person (matters in person-on-events mode, where
+        // event-time person properties are frozen at ingestion).
+        if (bootstrap.email) {
+          posthog.setPersonProperties({ email: bootstrap.email })
+        }
         finishLoading()
       },
     })

--- a/src/features/posthog-provider.tsx
+++ b/src/features/posthog-provider.tsx
@@ -1,9 +1,13 @@
-import { usePathname } from 'next/navigation'
 import posthog, { type Survey } from 'posthog-js'
 import { PostHogProvider as PHProvider } from 'posthog-js/react'
 import { createContext, useContext, useEffect, useState } from 'react'
 
 export type PostHogEnvironment = 'production' | 'preview' | 'development'
+
+interface PostHogBootstrapIdentity {
+  distinctID: string
+  email?: string
+}
 
 interface AppPostHogContextValue {
   enabled: boolean
@@ -11,6 +15,7 @@ interface AppPostHogContextValue {
   isLoaded: boolean
   isInitialized: boolean
   dashboardFeedbackSurvey: Survey | null
+  setBootstrap: (identity: PostHogBootstrapIdentity) => void
 }
 
 const AppPostHogContext = createContext<AppPostHogContextValue | undefined>(
@@ -38,18 +43,22 @@ export function PostHogProvider({
   enabled: boolean
   environment: PostHogEnvironment
 }) {
-  const pathname = usePathname()
   const [dashboardFeedbackSurvey, setDashboardFeedbackSurvey] =
     useState<Survey | null>(null)
   const [isLoaded, setIsLoaded] = useState(() => posthog.__loaded)
   const [isInitialized, setIsInitialized] = useState(false)
+  const [bootstrap, setBootstrap] = useState<PostHogBootstrapIdentity | null>(
+    null
+  )
 
   // Only track the dashboard app — not auth, marketing, or proxied (docs/blog)
-  // paths. PostHog initializes lazily once the user reaches a /dashboard route.
-  const shouldInit = enabled && !!pathname?.startsWith('/dashboard')
+  // paths. PostHog initializes once a bootstrap identity is available, which
+  // only happens inside the dashboard layout (see PostHogBootstrap). Gating on
+  // bootstrap guarantees the first captured pageview is already identified.
+  const shouldInit = enabled && !!bootstrap
 
   useEffect(() => {
-    if (!shouldInit || !process.env.NEXT_PUBLIC_POSTHOG_KEY) {
+    if (!shouldInit || !bootstrap || !process.env.NEXT_PUBLIC_POSTHOG_KEY) {
       return
     }
 
@@ -100,12 +109,17 @@ export function PostHogProvider({
       disable_session_recording: process.env.NODE_ENV !== 'production',
       advanced_disable_toolbar_metrics: true,
       opt_in_site_apps: true,
+      bootstrap: {
+        distinctID: bootstrap.distinctID,
+        isIdentifiedID: true,
+        ...(bootstrap.email ? { $set: { email: bootstrap.email } } : {}),
+      },
       loaded: (posthog) => {
         if (process.env.NODE_ENV === 'development') posthog.debug()
         finishLoading()
       },
     })
-  }, [environment, shouldInit])
+  }, [environment, shouldInit, bootstrap])
 
   return (
     <AppPostHogContext.Provider
@@ -115,6 +129,7 @@ export function PostHogProvider({
         isLoaded,
         dashboardFeedbackSurvey,
         isInitialized,
+        setBootstrap,
       }}
     >
       <PHProvider client={posthog}>{children}</PHProvider>


### PR DESCRIPTION
## Problem

Investigation against PostHog project **E2B (33931)** showed ~17% of `/usage` visitors were recorded as anonymous (device-UUID `distinct_id`s, no email), because posthog-js autocaptures the first `$pageview` at `init()` before the deferred `posthog.identify()` runs — and person-on-events mode freezes those anonymous properties permanently. Separately, some identified persons had `email = null` written to their profile.

## Fix

`posthog.init()` now receives a `bootstrap` identity (the server-known user id via a new `PostHogBootstrap` component rendered in the dashboard layout), so the first captured pageview is already attributed to the real user instead of an anonymous device id; init is gated on that identity so it still never fires on marketing/auth routes. Since `bootstrap` only consumes identity/flag fields (not `$set` person properties), the email is set via `posthog.setPersonProperties()` inside the `loaded` callback — which posthog-js runs before it auto-captures the first `$pageview`, so that pageview is ingested with the email already on the person. The identity bridge also now sets the `email` property only when non-null.

Both fixes are forward-only — already-ingested anonymous events cannot be re-stamped via the SDK.