### PR TITLE
feat(auth): add legacy cli auth error UI to dashboard

### DIFF
--- a/src/app/(auth)/auth/cli/page.tsx
+++ b/src/app/(auth)/auth/cli/page.tsx
@@ -1,6 +1,5 @@
 import { redirect } from 'next/navigation'
-import { Suspense } from 'react'
-import { AUTH_URLS, PROTECTED_URLS } from '@/configs/urls'
+import { AUTH_URLS, HELP_URLS, PROTECTED_URLS } from '@/configs/urls'
 import type { FeatureFlagContext } from '@/core/modules/feature-flags/context'
 import { featureFlags } from '@/core/modules/feature-flags/feature-flags.server'
 import { createUserTeamsRepository } from '@/core/modules/teams/user-teams-repository.server'
@@ -10,6 +9,7 @@ import { isLoopbackUrl } from '@/core/shared/schemas/url'
 import { encodedRedirect } from '@/lib/utils/auth'
 import { generateE2BUserAccessToken } from '@/lib/utils/server'
 import { isVersionGreaterOrEqual } from '@/lib/utils/version'
+import { CodeBlock } from '@/ui/code-block'
 import { Alert, AlertDescription, AlertTitle } from '@/ui/primitives/alert'
 import { CloudIcon, LaptopIcon, LinkIcon } from '@/ui/primitives/icons'
 
@@ -19,6 +19,14 @@ import { CloudIcon, LaptopIcon, LinkIcon } from '@/ui/primitives/icons'
 // Old binaries (pre-2.13.0) don't send cliVersion at all (it's a new param),
 // so they correctly fall to 'legacy'.
 const MIN_CLI_VERSION_FOR_HYDRA_FLOW = '2.13.0'
+
+const CLI_UPDATE_COMMAND = 'npm install -g @e2b/cli@latest'
+
+// Shown to legacy (<2.13) CLIs when access-token provisioning is disabled.
+// The dashboard sends this string to the CLI's loopback server, which echoes
+// it back via `state=error`; keeping it in one place lets the error page
+// recognize the update-required case and surface the deprecation help link.
+const CLI_UPDATE_REQUIRED_MESSAGE = `CLI update required. Run: ${CLI_UPDATE_COMMAND}`
 
 type CLISearchParams = Promise<{
   next?: string
@@ -97,12 +105,52 @@ function CLIIcons() {
   )
 }
 
-function ErrorAlert({ message }: { message: string }) {
+function ErrorState({
+  message,
+  showDeprecationHelp = false,
+}: {
+  message?: string
+  showDeprecationHelp?: boolean
+}) {
   return (
-    <Alert variant="error" border="bottom" className="text-start">
-      <AlertTitle>Error</AlertTitle>
-      <AlertDescription>{message}</AlertDescription>
-    </Alert>
+    <div className="p-6 text-center">
+      <CLIIcons />
+      <h2 className="mt-6 text-base leading-7">Unable to link the CLI</h2>
+      <div className="mt-12 text-start">
+        {showDeprecationHelp ? (
+          <div className="flex flex-col gap-4">
+            <Alert variant="error" border="bottom">
+              <AlertTitle>CLI update required</AlertTitle>
+              <AlertDescription>
+                Your CLI is out of date. Update to the latest version to
+                continue:
+              </AlertDescription>
+            </Alert>
+            <CodeBlock lang="bash">{CLI_UPDATE_COMMAND}</CodeBlock>
+            <p className="text-fg-tertiary leading-relaxed">
+              Access tokens are deprecated.{' '}
+              <a
+                href={HELP_URLS.ACCESS_TOKEN_DEPRECATION}
+                target="_blank"
+                rel="noopener"
+                className="text-fg underline underline-offset-2 hover:opacity-80"
+              >
+                Learn more
+              </a>
+              .
+            </p>
+          </div>
+        ) : (
+          <Alert variant="error" border="bottom">
+            <AlertTitle>Error</AlertTitle>
+            <AlertDescription>
+              {message ??
+                'Something went wrong while linking the CLI. Please try again.'}
+            </AlertDescription>
+          </Alert>
+        )}
+      </div>
+    </div>
   )
 }
 
@@ -125,6 +173,15 @@ export default async function CLIAuthPage({
 
   if (state === 'success') {
     return <SuccessState />
+  }
+
+  if (state === 'error') {
+    return (
+      <ErrorState
+        message={error}
+        showDeprecationHelp={error === CLI_UPDATE_REQUIRED_MESSAGE}
+      />
+    )
   }
 
   if (!next || !isLoopbackUrl(next)) {
@@ -165,28 +222,13 @@ export default async function CLIAuthPage({
 
     if (tokenProvisioningDisabled) {
       const errorUrl = new URL(next)
-      errorUrl.searchParams.set(
-        'error',
-        'CLI update required. Run: npm install -g @e2b/cli@latest'
-      )
+      errorUrl.searchParams.set('error', CLI_UPDATE_REQUIRED_MESSAGE)
       return redirect(errorUrl.toString())
     }
   }
 
   if (error) {
-    return (
-      <div className="p-6 text-center">
-        <CLIIcons />
-        <h2 className="mt-6 text-base leading-7">
-          Linking CLI with your account
-        </h2>
-        <div className="text-fg-tertiary mt-12 leading-8">
-          <Suspense fallback={<div>Loading...</div>}>
-            <ErrorAlert message={error} />
-          </Suspense>
-        </div>
-      </div>
-    )
+    return <ErrorState message={error} />
   }
 
   try {


### PR DESCRIPTION
For CLIs version 2.13, show error redirect dashboard UI. This better indicate what happened to user.

Before: redirect to dashboard with info only in cli

After:

<img src="https://github.com/user-attachments/assets/e99da658-c492-41f3-aca7-59b56a022d3a " alt="Screenshot 2026-07-01 at 11 04 02" width="808" data-linear-height="753" />