### PR TITLE
feat(usage): wire redesigned usage page to cost data with hover

### DIFF
--- a/src/app/dashboard/[teamSlug]/usage/page.tsx
+++ b/src/app/dashboard/[teamSlug]/usage/page.tsx
@@ -37,10 +37,6 @@ export default async function UsagePage({
         : undefined,
   })
 
-  if (newUsagePage) {
-    return <UsageRedesignPage />
-  }
-
   const result = await getUsage({ teamSlug })
 
   if (!result?.data || result.serverError || result.validationErrors) {
@@ -54,6 +50,14 @@ export default async function UsagePage({
         }
         description="Could not load usage data"
       />
+    )
+  }
+
+  if (newUsagePage) {
+    return (
+      <UsageChartsProvider data={result.data}>
+        <UsageRedesignPage />
+      </UsageChartsProvider>
     )
   }
 

--- a/src/features/dashboard/usage/redesign/usage-redesign-chart.tsx
+++ b/src/features/dashboard/usage/redesign/usage-redesign-chart.tsx
@@ -1,58 +1,65 @@
 'use client'
 
-import { Area, AreaChart, CartesianGrid, XAxis, YAxis } from 'recharts'
-import { ChartContainer } from '@/ui/primitives/chart'
+import { useMemo } from 'react'
+import {
+  Area,
+  AreaChart,
+  CartesianGrid,
+  type TooltipProps,
+  XAxis,
+  YAxis,
+} from 'recharts'
+import { cn } from '@/lib/utils'
+import { formatAxisNumber, formatCurrency } from '@/lib/utils/formatting'
+import { cardVariants } from '@/ui/primitives/card'
+import { ChartContainer, ChartTooltip } from '@/ui/primitives/chart'
+import { useUsageCharts } from '../usage-charts-context'
 
-// Static placeholder series — the redesigned usage page is not yet wired to data.
-const MOCK_SERIES = [
-  { label: '1 Mar', value: 420 },
-  { label: '2 Mar', value: 610 },
-  { label: '3 Mar', value: 580 },
-  { label: '4 Mar', value: 720 },
-  { label: '5 Mar', value: 690 },
-  { label: '6 Mar', value: 540 },
-  { label: '7 Mar', value: 510 },
-  { label: '8 Mar', value: 480 },
-  { label: '9 Mar', value: 360 },
-  { label: '10 Mar', value: 220 },
-  { label: '11 Mar', value: 470 },
-  { label: '12 Mar', value: 560 },
-  { label: '13 Mar', value: 630 },
-  { label: '14 Mar', value: 700 },
-  { label: '15 Mar', value: 760 },
-  { label: '16 Mar', value: 820 },
-  { label: '17 Mar', value: 780 },
-  { label: '18 Mar', value: 690 },
-  { label: '19 Mar', value: 640 },
-  { label: '20 Mar', value: 590 },
-  { label: '21 Mar', value: 520 },
-  { label: '22 Mar', value: 460 },
-  { label: '23 Mar', value: 410 },
-  { label: '24 Mar', value: 380 },
-]
+// The billing API only exposes team-level cost, so there is a single "Default"
+// group. Keeping the chart driven by this list means adding real per-template /
+// per-API-key grouping later is just a matter of extending it plus the point mapping.
+const GROUPS = [
+  { key: 'default', name: 'Default', color: 'var(--accent-main-highlight)' },
+] as const
 
-const X_TICKS = ['1 Mar', '7 Mar', '14 Mar', '24 Mar']
+type GroupKey = (typeof GROUPS)[number]['key']
+
+type UsageChartPoint = { label: string; total: number } & Record<
+  GroupKey,
+  number
+>
 
 export function UsageRedesignChart() {
+  const { displayedData } = useUsageCharts()
+
+  const data = useMemo<UsageChartPoint[]>(
+    () =>
+      displayedData.cost.map((point) => ({
+        label: point.x,
+        // Single group today; total is the sum across all groups.
+        default: point.y,
+        total: point.y,
+      })),
+    [displayedData.cost]
+  )
+
   return (
     <ChartContainer config={{}} className="aspect-auto h-45 w-full">
-      <AreaChart
-        data={MOCK_SERIES}
-        margin={{ top: 4, right: 4, bottom: 0, left: 0 }}
-      >
+      <AreaChart data={data} margin={{ top: 4, right: 4, bottom: 0, left: 0 }}>
         <defs>
-          <linearGradient id="usageRedesignFill" x1="0" y1="0" x2="0" y2="1">
-            <stop
-              offset="0%"
-              stopColor="var(--graph-area-accent-main-from)"
-              stopOpacity={1}
-            />
-            <stop
-              offset="100%"
-              stopColor="var(--graph-area-accent-main-from)"
-              stopOpacity={0}
-            />
-          </linearGradient>
+          {GROUPS.map((group) => (
+            <linearGradient
+              key={group.key}
+              id={`usage-fill-${group.key}`}
+              x1="0"
+              y1="0"
+              x2="0"
+              y2="1"
+            >
+              <stop offset="0%" stopColor={group.color} stopOpacity={0.3} />
+              <stop offset="100%" stopColor={group.color} stopOpacity={0} />
+            </linearGradient>
+          ))}
         </defs>
         <CartesianGrid
           vertical={false}
@@ -61,28 +68,79 @@ export function UsageRedesignChart() {
         />
         <XAxis
           dataKey="label"
-          ticks={X_TICKS}
           tickLine={false}
           axisLine={false}
           tickMargin={8}
+          minTickGap={40}
           interval="preserveStartEnd"
         />
         <YAxis
           width={40}
           tickLine={false}
           axisLine={false}
-          tickFormatter={(value) => `$${value}`}
+          tickFormatter={(value) => `$${formatAxisNumber(value)}`}
         />
-        <Area
-          type="step"
-          dataKey="value"
-          stroke="var(--accent-main-highlight)"
-          strokeWidth={1.5}
-          fill="url(#usageRedesignFill)"
-          fillOpacity={1}
-          isAnimationActive={false}
+        <ChartTooltip
+          cursor={{ stroke: 'var(--stroke)', strokeDasharray: '3 3' }}
+          content={<UsageTooltip />}
         />
+        {GROUPS.map((group) => (
+          <Area
+            key={group.key}
+            type="step"
+            dataKey={group.key}
+            stackId="usage"
+            stroke={group.color}
+            strokeWidth={1.5}
+            fill={`url(#usage-fill-${group.key})`}
+            fillOpacity={1}
+            isAnimationActive={false}
+          />
+        ))}
       </AreaChart>
     </ChartContainer>
+  )
+}
+
+function UsageTooltip({ active, payload }: TooltipProps<number, string>) {
+  if (!active || !payload?.length) {
+    return null
+  }
+
+  const point = payload[0]?.payload as UsageChartPoint | undefined
+
+  if (!point) {
+    return null
+  }
+
+  return (
+    <div
+      className={cn(
+        cardVariants({ variant: 'layer' }),
+        'flex min-w-[180px] flex-col gap-2 px-3 py-2 shadow-xl'
+      )}
+    >
+      <div className="flex flex-col gap-1">
+        {GROUPS.map((group) => (
+          <div
+            key={group.key}
+            className="flex items-center justify-between gap-6"
+          >
+            <span className="prose-body text-fg">{group.name}</span>
+            <span className="prose-body-numeric text-fg font-mono">
+              {formatCurrency(point[group.key])}
+            </span>
+          </div>
+        ))}
+      </div>
+      <div className="flex items-center justify-between gap-6">
+        <span className="prose-label text-fg-tertiary uppercase">
+          total · {point.label}
+        </span>
+        <span className="prose-body-numeric text-fg font-mono">
+          {formatCurrency(point.total)}
+        </span>
+      </div>
+    </div>
   )
 }

--- a/src/features/dashboard/usage/redesign/usage-redesign.tsx
+++ b/src/features/dashboard/usage/redesign/usage-redesign.tsx
@@ -1,37 +1,14 @@
 'use client'
 
-import { useState } from 'react'
-import { cn } from '@/lib/utils'
-import { Badge } from '@/ui/primitives/badge'
+import { formatCurrency, formatDateRange } from '@/lib/utils/formatting'
 import { Button } from '@/ui/primitives/button'
-import {
-  ChevronDownIcon,
-  FilterIcon,
-  HistoryIcon,
-  KeyIcon,
-  SearchIcon,
-  TemplateIcon,
-  UnpackIcon,
-} from '@/ui/primitives/icons'
+import { FilterIcon, SearchIcon } from '@/ui/primitives/icons'
 import { Input } from '@/ui/primitives/input'
+import { useUsageCharts } from '../usage-charts-context'
+import { UsageTopTimeRangeControls } from '../usage-top-time-range-controls'
 import { UsageRedesignChart } from './usage-redesign-chart'
 
-type GroupBy = 'template' | 'api-key'
-
-// Static placeholder rows — the redesigned usage page is not yet wired to data.
-const MOCK_ROWS: { name: string; madeByE2B: boolean; cost: string }[] = [
-  { name: 'base', madeByE2B: true, cost: '$7,124.24' },
-  { name: 'code-interpreter-v1', madeByE2B: true, cost: '$4,124.24' },
-  { name: 'desktop', madeByE2B: true, cost: '$1,124.50' },
-  { name: 'runtime-eval-v4', madeByE2B: false, cost: '$452.00' },
-  { name: 'runtime-eval-v3', madeByE2B: false, cost: '$312.00' },
-  { name: 'runtime-eval-v2', madeByE2B: false, cost: '$99.23' },
-  { name: 'runtime-eval-v1', madeByE2B: false, cost: '$0.00' },
-]
-
 export function UsageRedesignPage() {
-  const [groupBy, setGroupBy] = useState<GroupBy>('template')
-
   return (
     <div className="h-full max-h-full min-h-0 overflow-y-auto">
       <div className="mx-auto flex max-w-[1200px] flex-col gap-6 p-3 md:p-8">
@@ -40,11 +17,6 @@ export function UsageRedesignPage() {
         <div className="flex flex-col gap-4">
           <TotalCost />
           <UsageRedesignChart />
-        </div>
-
-        <div className="flex flex-col">
-          <TabSwitcher value={groupBy} onChange={setGroupBy} />
-          <CostList />
         </div>
       </div>
     </div>
@@ -59,18 +31,15 @@ function UsageControls() {
         <Input
           placeholder="Search by name"
           readOnly
+          disabled
           className="pl-8.5"
           aria-label="Search by name"
         />
       </div>
 
-      <Button variant="secondary" type="button">
-        <HistoryIcon />
-        This month (April)
-        <UnpackIcon />
-      </Button>
+      <UsageTopTimeRangeControls />
 
-      <Button variant="secondary" type="button">
+      <Button variant="secondary" type="button" disabled>
         <FilterIcon />
         Filter
       </Button>
@@ -79,96 +48,16 @@ function UsageControls() {
 }
 
 function TotalCost() {
+  const { totals, timeframe } = useUsageCharts()
+
   return (
     <div className="flex flex-wrap items-baseline gap-3">
       <span className="prose-value-big text-fg font-mono uppercase">
-        $15,124.24
+        {formatCurrency(totals.cost)}
       </span>
       <span className="prose-label text-fg-tertiary uppercase">
-        total cost for 1 Apr – 19 Apr
+        total cost for {formatDateRange(timeframe.start, timeframe.end)}
       </span>
-    </div>
-  )
-}
-
-function TabSwitcher({
-  value,
-  onChange,
-}: {
-  value: GroupBy
-  onChange: (value: GroupBy) => void
-}) {
-  return (
-    <div className="border-stroke flex gap-6 border-b">
-      <Tab
-        active={value === 'template'}
-        onClick={() => onChange('template')}
-        icon={<TemplateIcon />}
-        label="By template"
-      />
-      <Tab
-        active={value === 'api-key'}
-        onClick={() => onChange('api-key')}
-        icon={<KeyIcon />}
-        label="By API key"
-      />
-    </div>
-  )
-}
-
-function Tab({
-  active,
-  onClick,
-  icon,
-  label,
-}: {
-  active: boolean
-  onClick: () => void
-  icon: React.ReactNode
-  label: string
-}) {
-  return (
-    <button
-      type="button"
-      onClick={onClick}
-      className={cn(
-        'prose-body-highlight flex cursor-pointer items-center gap-1.5 border-b py-2.5 -mb-px',
-        '[&_svg]:size-4',
-        active
-          ? 'border-accent-main-highlight text-fg [&_svg]:text-fg'
-          : 'border-transparent text-fg-tertiary [&_svg]:text-icon-tertiary'
-      )}
-    >
-      {icon}
-      {label}
-    </button>
-  )
-}
-
-function CostList() {
-  return (
-    <div className="flex flex-col">
-      {MOCK_ROWS.map((row) => (
-        <div
-          key={row.name}
-          className="border-stroke flex items-center justify-between border-b py-3"
-        >
-          <div className="flex items-center gap-1.5">
-            <span className="prose-body text-fg">{row.name}</span>
-            {row.madeByE2B && (
-              <Badge variant="default" size="sm">
-                by E2B
-              </Badge>
-            )}
-          </div>
-          <div className="flex items-center gap-2">
-            <span className="prose-body-numeric text-fg font-mono">
-              {row.cost}
-            </span>
-            <ChevronDownIcon className="text-icon-tertiary size-4" />
-          </div>
-        </div>
-      ))}
     </div>
   )
 }


### PR DESCRIPTION
Connects the redesigned (Dashboard 2.0) usage page — previously a static skeleton behind the `newUsagePage` flag — to live billing data, reusing the existing `UsageChartsProvider` pipeline (query-param timeframe, sampling, and cost = `price_for_ram + price_for_cpu`). The total cost and step/area chart now reflect real data, the date-range control is fully functional, and hovering shows a crosshair with a tooltip breaking down cost and daily total. Per product direction, grouping by template/API key is not implemented: the chart shows a single `Default` group, but the data model is group-aware (driven by a `GROUPS` array) so real grouping is a small future change. The `By template / By API key` tabs and breakdown table were removed, and Search + Filter remain as disabled placeholders. Verified with `tsc`, `biome check`, and the feature-flags unit test.