### PR TITLE
feat(templates): improve list badge and tooltip styling

### DIFF
--- a/src/features/dashboard/templates/list/table-cells.tsx
+++ b/src/features/dashboard/templates/list/table-cells.tsx
@@ -15,7 +15,6 @@ import { formatLocalLogStyleTimestamp } from '@/lib/utils/formatting'
 import { useTRPC } from '@/trpc/client'
 import { AlertDialog } from '@/ui/alert-dialog'
 import { E2BBadge } from '@/ui/brand'
-import HelpTooltip from '@/ui/help-tooltip'
 import { Badge } from '@/ui/primitives/badge'
 import {
   DropdownMenu,
@@ -35,19 +34,25 @@ import {
   UnlockIcon,
 } from '@/ui/primitives/icons'
 import { Loader } from '@/ui/primitives/loader'
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from '@/ui/primitives/tooltip'
 import { useDashboard } from '../../context'
 
 function E2BTemplateBadge() {
   return (
-    <HelpTooltip
-      trigger={<E2BBadge />}
-      classNames={{ content: 'max-w-[208px]' }}
-    >
-      <p className="text-fg-secondary font-sans text-xs whitespace-break-spaces">
-        This template was created by&nbsp;E2B. It is one of the default
-        templates every user has access to.
-      </p>
-    </HelpTooltip>
+    <Tooltip delayDuration={200}>
+      <TooltipTrigger tabIndex={-1} asChild>
+        <E2BBadge />
+      </TooltipTrigger>
+      <TooltipContent className="max-w-[208px] p-2">
+        <p className="text-fg-secondary font-sans text-xs">
+          Created and managed by E2B. Accessible to everyone.
+        </p>
+      </TooltipContent>
+    </Tooltip>
   )
 }
 
@@ -269,26 +274,27 @@ export function TemplateNameCell({
     >
       <span className="truncate">{nameValue}</span>
       {additionalNames.length > 0 && (
-        <HelpTooltip
-          trigger={
-            <span className="relative z-10 text-fg-tertiary bg-bg-muted rounded px-1.5 py-0.5 text-xs font-medium">
+        <Tooltip delayDuration={200}>
+          <TooltipTrigger tabIndex={-1} asChild>
+            <Badge variant="default" className="relative z-10">
               +{additionalNames.length}
-            </span>
-          }
-        >
-          <div className="flex flex-col gap-1">
-            <span className="text-fg-secondary text-xs">
-              Also available under:
-            </span>
-            <ul className="flex flex-col gap-0.5 list-disc ml-4 mr-2">
-              {additionalNames.map((name) => (
-                <li key={name} className="font-mono text-xs text-fg-tertiary">
-                  {name}
-                </li>
-              ))}
-            </ul>
-          </div>
-        </HelpTooltip>
+            </Badge>
+          </TooltipTrigger>
+          <TooltipContent className="p-2">
+            <div className="flex flex-col gap-1 font-sans">
+              <span className="text-fg-tertiary text-xs">
+                Also available as:
+              </span>
+              <ul className="flex flex-col gap-0.5 list-disc ml-4 mr-2">
+                {additionalNames.map((name) => (
+                  <li key={name} className="font-mono text-xs text-fg">
+                    {name}
+                  </li>
+                ))}
+              </ul>
+            </div>
+          </TooltipContent>
+        </Tooltip>
       )}
       {isDefault && <E2BTemplateBadge />}
       {nameValue !== '--' && (

--- a/src/features/dashboard/templates/list/table-cells.tsx
+++ b/src/features/dashboard/templates/list/table-cells.tsx
@@ -45,7 +45,7 @@ function E2BTemplateBadge() {
   return (
     <Tooltip delayDuration={200}>
       <TooltipTrigger tabIndex={-1} asChild>
-        <E2BBadge />
+        <E2BBadge className="relative z-10" />
       </TooltipTrigger>
       <TooltipContent className="max-w-[208px] p-2">
         <p className="text-fg-secondary font-sans text-xs">
@@ -276,7 +276,11 @@ export function TemplateNameCell({
       {additionalNames.length > 0 && (
         <Tooltip delayDuration={200}>
           <TooltipTrigger tabIndex={-1} asChild>
-            <Badge variant="default" className="relative z-10">
+            <Badge
+              variant="default"
+              size="xs"
+              className="relative z-10 text-fg-tertiary"
+            >
               +{additionalNames.length}
             </Badge>
           </TooltipTrigger>
@@ -296,7 +300,8 @@ export function TemplateNameCell({
           </TooltipContent>
         </Tooltip>
       )}
-      {isDefault && <E2BTemplateBadge />}
+      {/* {isDefault && <E2BTemplateBadge />} */}
+      <E2BTemplateBadge />
       {nameValue !== '--' && (
         <button
           type="button"

--- a/src/features/dashboard/templates/list/table-cells.tsx
+++ b/src/features/dashboard/templates/list/table-cells.tsx
@@ -273,34 +273,38 @@ export function TemplateNameCell({
       )}
     >
       <span className="truncate">{nameValue}</span>
-      {additionalNames.length > 0 && (
-        <Tooltip delayDuration={200}>
-          <TooltipTrigger tabIndex={-1} asChild>
-            <Badge
-              variant="default"
-              size="xs"
-              className="relative z-10 text-fg-tertiary"
-            >
-              +{additionalNames.length}
-            </Badge>
-          </TooltipTrigger>
-          <TooltipContent className="p-2">
-            <div className="flex flex-col gap-1 font-sans">
-              <span className="text-fg-tertiary text-xs">
-                Also available as:
-              </span>
-              <ul className="flex flex-col gap-0.5 list-disc ml-4 mr-2">
-                {additionalNames.map((name) => (
-                  <li key={name} className="font-mono text-xs text-fg">
-                    {name}
-                  </li>
-                ))}
-              </ul>
-            </div>
-          </TooltipContent>
-        </Tooltip>
+      {(additionalNames.length > 0 || isDefault) && (
+        <div className="flex items-center gap-1">
+          {additionalNames.length > 0 && (
+            <Tooltip delayDuration={200}>
+              <TooltipTrigger tabIndex={-1} asChild>
+                <Badge
+                  variant="default"
+                  size="xs"
+                  className="relative z-10 px-0.5 text-fg-tertiary"
+                >
+                  +{additionalNames.length}
+                </Badge>
+              </TooltipTrigger>
+              <TooltipContent className="p-2">
+                <div className="flex flex-col gap-1 font-sans">
+                  <span className="text-fg-tertiary text-xs">
+                    Also available as:
+                  </span>
+                  <ul className="flex flex-col gap-0.5 list-disc ml-4 mr-2">
+                    {additionalNames.map((name) => (
+                      <li key={name} className="font-mono text-xs text-fg">
+                        {name}
+                      </li>
+                    ))}
+                  </ul>
+                </div>
+              </TooltipContent>
+            </Tooltip>
+          )}
+          {isDefault && <E2BTemplateBadge />}
+        </div>
       )}
-      {isDefault && <E2BTemplateBadge />}
       {nameValue !== '--' && (
         <button
           type="button"

--- a/src/features/dashboard/templates/list/table-cells.tsx
+++ b/src/features/dashboard/templates/list/table-cells.tsx
@@ -300,8 +300,7 @@ export function TemplateNameCell({
           </TooltipContent>
         </Tooltip>
       )}
-      {/* {isDefault && <E2BTemplateBadge />} */}
-      <E2BTemplateBadge />
+      {isDefault && <E2BTemplateBadge />}
       {nameValue !== '--' && (
         <button
           type="button"

--- a/src/ui/brand.tsx
+++ b/src/ui/brand.tsx
@@ -58,7 +58,7 @@ export const E2BLogoSmall = ({
 )
 
 export const E2BBadge = ({ className, ...props }: BadgeProps) => (
-  <Badge className={cn('h-4', className)} variant="default" {...props}>
+  <Badge className={className} variant="default" size="xs" {...props}>
     <span className="inline-flex h-[8px] w-[25px] items-center justify-center">
       <E2BLogoSmall className="h-[7px] w-auto" />
     </span>

--- a/src/ui/primitives/badge.tsx
+++ b/src/ui/primitives/badge.tsx
@@ -31,6 +31,7 @@ const badgeVariants = cva(
         hover: 'hover:ring-1 ring-[currentColor]',
       },
       size: {
+        xs: 'h-4 px-1 gap-0.5',
         sm: 'h-4.5 px-1 gap-0.5',
         md: 'h-5.5 px-2 gap-1',
         lg: 'h-6.5 px-2 gap-1.5',


### PR DESCRIPTION
Improve list badge and tooltip styling to match the figma:

<img width="520" height="330" alt="image" src="https://github.com/user-attachments/assets/6d5a16dc-1bbf-4150-b3f2-99543a7d919e" />
<img width="2880" height="1600" alt="image" src="https://github.com/user-attachments/assets/cd5eb92b-3fee-4ebf-a833-4fadead6dfb1" />
