### PR TITLE
feat: split e2b_session cookie if too large

### DIFF
--- a/src/app/api/auth/oauth/callback/ory/route.ts
+++ b/src/app/api/auth/oauth/callback/ory/route.ts
@@ -12,9 +12,10 @@ import {
 import { resolveOryRedirectUri } from '@/core/server/auth/ory/oauth-relay'
 import { readKratosExternalId } from '@/core/server/auth/ory/session'
 import {
-  E2B_SESSION_COOKIE,
   ORY_SIGNUP_METADATA_COOKIE,
+  reconcileSessionCookies,
   sealSessionCookie,
+  sessionCookieDeleteOptions,
   sessionCookieOptions,
 } from '@/core/server/auth/ory/session-cookie'
 import {
@@ -110,11 +111,19 @@ export async function GET(request: NextRequest) {
     ? parsedReturnTo.data
     : PROTECTED_URLS.DASHBOARD
   const response = finalize(NextResponse.redirect(new URL(destination, origin)))
-  response.cookies.set(
-    E2B_SESSION_COOKIE,
+  const { write, expire } = reconcileSessionCookies(
     sealed,
-    sessionCookieOptions(request.nextUrl.host)
+    request.cookies.getAll()
   )
+  const options = sessionCookieOptions(request.nextUrl.host)
+  for (const chunk of write) {
+    response.cookies.set(chunk.name, chunk.value, options)
+  }
+  for (const name of expire) {
+    response.cookies.delete(
+      sessionCookieDeleteOptions(request.nextUrl.host, name)
+    )
+  }
   return response
 }
 

--- a/src/core/server/auth/ory/clear-session-cookies.ts
+++ b/src/core/server/auth/ory/clear-session-cookies.ts
@@ -4,6 +4,7 @@ import type { NextRequest, NextResponse } from 'next/server'
 import {
   resolveSessionCookieDomain,
   sessionCookieDeleteOptions,
+  sessionCookieNames,
 } from './session-cookie'
 
 // Ory's identity session cookie: `ory_kratos_session` self-hosted,
@@ -20,7 +21,11 @@ export function clearAppSessionCookies(
   request: NextRequest,
   response: NextResponse
 ): void {
-  response.cookies.delete(sessionCookieDeleteOptions(request.nextUrl.host))
+  for (const name of sessionCookieNames(request.cookies.getAll())) {
+    response.cookies.delete(
+      sessionCookieDeleteOptions(request.nextUrl.host, name)
+    )
+  }
 
   const domain = resolveSessionCookieDomain(request.nextUrl.host)
   for (const { name } of request.cookies.getAll()) {

--- a/src/core/server/auth/ory/session-cookie.ts
+++ b/src/core/server/auth/ory/session-cookie.ts
@@ -11,7 +11,7 @@ export const E2B_SESSION_COOKIE = 'e2b_session'
 export const ORY_SIGNUP_METADATA_COOKIE = 'e2b-ory-signup-metadata'
 
 const SESSION_COOKIE_MAX_AGE_SECONDS = 60 * 60 * 24 * 30 // 30 days
-const MAX_SESSION_COOKIE_CHUNK = 2000
+const MAX_SESSION_COOKIE_CHUNK = 3800
 const SESSION_CHUNK_PREFIX = `${E2B_SESSION_COOKIE}.`
 
 // Cookies the dashboard owns — never forwarded across the Ory trust boundary.

--- a/src/core/server/auth/ory/session-cookie.ts
+++ b/src/core/server/auth/ory/session-cookie.ts
@@ -10,6 +10,10 @@ export const E2B_SESSION_COOKIE = 'e2b_session'
 
 export const ORY_SIGNUP_METADATA_COOKIE = 'e2b-ory-signup-metadata'
 
+const SESSION_COOKIE_MAX_AGE_SECONDS = 60 * 60 * 24 * 30 // 30 days
+const MAX_SESSION_COOKIE_CHUNK = 3800
+const SESSION_CHUNK_PREFIX = `${E2B_SESSION_COOKIE}.`
+
 // Cookies the dashboard owns — never forwarded across the Ory trust boundary.
 // e2b_session may be chunked (e2b_session.0/.1/…), so the chunk names are
 // app-owned too and must be stripped alongside the bare name.
@@ -23,8 +27,7 @@ function isAppOwnedCookie(name: string): boolean {
 
 // Serializes a cookie list into a `Cookie` header for forwarding to Ory, with
 // the app-owned cookies stripped. Takes the cookie list rather than reading
-// next/headers so it stays edge-safe and serves both the middleware
-// (NextRequest cookies) and server components (next/headers cookies).
+// next/headers so it stays edge-safe
 export function cookieHeaderWithoutAppOwned(
   cookieList: ReadonlyArray<{ name: string; value: string }>
 ): string {
@@ -33,11 +36,6 @@ export function cookieHeaderWithoutAppOwned(
     .map((cookie) => `${cookie.name}=${cookie.value}`)
     .join('; ')
 }
-
-// Persist across browser restarts. The cookie only caches tokens — a stale or
-// expired cookie is re-minted from the live Kratos session, so the lifetime is
-// intentionally generous and not the security boundary.
-const SESSION_COOKIE_MAX_AGE_SECONDS = 60 * 60 * 24 * 30
 
 export type SessionTokens = {
   accessToken: string
@@ -89,14 +87,6 @@ export async function openSessionCookie(
   }
 }
 
-// The browser caps a single cookie at ~4096 bytes including its name and
-// attributes. The sealed value is ASCII (base64url JWE), so 3800 bytes of value
-// leaves headroom for `HttpOnly; Secure; SameSite=Lax; Path=/; Max-Age=…;
-// Domain=…` and keeps every chunk under the cap.
-const MAX_SESSION_COOKIE_CHUNK = 3800
-
-const SESSION_CHUNK_PREFIX = `${E2B_SESSION_COOKIE}.`
-
 // Numeric chunk index for `e2b_session.N`, or null for anything that isn't a
 // session chunk (including the bare `e2b_session`).
 function sessionChunkIndex(name: string): number | null {
@@ -108,9 +98,6 @@ function sessionChunkIndex(name: string): number | null {
 
 export type SessionCookieChunk = { name: string; value: string }
 
-// The cookies to write plus the names to expire so the browser jar matches the
-// new value. On every write the other shape's leftovers are expired (bare↔chunked
-// transitions, or a shrink from N chunks to fewer) so no orphan cookies linger.
 export type SessionCookieReconciliation = {
   write: SessionCookieChunk[]
   expire: string[]
@@ -118,8 +105,7 @@ export type SessionCookieReconciliation = {
 
 // Splits the sealed value into the cookies to write. Values within one chunk
 // keep the bare `e2b_session` name (backward compatible with cookies already in
-// the wild); larger values fan out to `e2b_session.0`, `e2b_session.1`, … the
-// way authjs chunks its session cookie.
+// the wild); larger values fan out to `e2b_session.0`, `e2b_session.1`...
 export function splitSessionCookie(value: string): SessionCookieChunk[] {
   if (value.length <= MAX_SESSION_COOKIE_CHUNK) {
     return [{ name: E2B_SESSION_COOKIE, value }]
@@ -137,9 +123,7 @@ export function splitSessionCookie(value: string): SessionCookieChunk[] {
 }
 
 // Reassembles the sealed value from whatever cookie shape is present. Prefers
-// numbered chunks (sorted by index); falls back to a bare `e2b_session`. Never
-// mixes the two shapes, so a stale bare cookie sitting beside fresh chunks can't
-// corrupt the value.
+// numbered chunks (sorted by index); falls back to a bare `e2b_session`
 export function joinSessionCookie(
   cookieList: ReadonlyArray<{ name: string; value: string }>
 ): string | undefined {

--- a/src/core/server/auth/ory/session-cookie.ts
+++ b/src/core/server/auth/ory/session-cookie.ts
@@ -11,7 +11,7 @@ export const E2B_SESSION_COOKIE = 'e2b_session'
 export const ORY_SIGNUP_METADATA_COOKIE = 'e2b-ory-signup-metadata'
 
 const SESSION_COOKIE_MAX_AGE_SECONDS = 60 * 60 * 24 * 30 // 30 days
-const MAX_SESSION_COOKIE_CHUNK = 3800
+const MAX_SESSION_COOKIE_CHUNK = 2000
 const SESSION_CHUNK_PREFIX = `${E2B_SESSION_COOKIE}.`
 
 // Cookies the dashboard owns — never forwarded across the Ory trust boundary.

--- a/src/core/server/auth/ory/session-cookie.ts
+++ b/src/core/server/auth/ory/session-cookie.ts
@@ -11,10 +11,15 @@ export const E2B_SESSION_COOKIE = 'e2b_session'
 export const ORY_SIGNUP_METADATA_COOKIE = 'e2b-ory-signup-metadata'
 
 // Cookies the dashboard owns — never forwarded across the Ory trust boundary.
-const APP_OWNED_COOKIES = new Set<string>([
-  E2B_SESSION_COOKIE,
-  ORY_SIGNUP_METADATA_COOKIE,
-])
+// e2b_session may be chunked (e2b_session.0/.1/…), so the chunk names are
+// app-owned too and must be stripped alongside the bare name.
+function isAppOwnedCookie(name: string): boolean {
+  return (
+    name === ORY_SIGNUP_METADATA_COOKIE ||
+    name === E2B_SESSION_COOKIE ||
+    sessionChunkIndex(name) !== null
+  )
+}
 
 // Serializes a cookie list into a `Cookie` header for forwarding to Ory, with
 // the app-owned cookies stripped. Takes the cookie list rather than reading
@@ -24,7 +29,7 @@ export function cookieHeaderWithoutAppOwned(
   cookieList: ReadonlyArray<{ name: string; value: string }>
 ): string {
   return cookieList
-    .filter((cookie) => !APP_OWNED_COOKIES.has(cookie.name))
+    .filter((cookie) => !isAppOwnedCookie(cookie.name))
     .map((cookie) => `${cookie.name}=${cookie.value}`)
     .join('; ')
 }
@@ -52,7 +57,7 @@ export type SessionCookieOptions = {
 }
 
 export type SessionCookieDeleteOptions = {
-  name: typeof E2B_SESSION_COOKIE
+  name: string
   path: '/'
   domain?: string
 }
@@ -84,6 +89,105 @@ export async function openSessionCookie(
   }
 }
 
+// The browser caps a single cookie at ~4096 bytes including its name and
+// attributes. The sealed value is ASCII (base64url JWE), so 3800 bytes of value
+// leaves headroom for `HttpOnly; Secure; SameSite=Lax; Path=/; Max-Age=…;
+// Domain=…` and keeps every chunk under the cap.
+const MAX_SESSION_COOKIE_CHUNK = 3800
+
+const SESSION_CHUNK_PREFIX = `${E2B_SESSION_COOKIE}.`
+
+// Numeric chunk index for `e2b_session.N`, or null for anything that isn't a
+// session chunk (including the bare `e2b_session`).
+function sessionChunkIndex(name: string): number | null {
+  if (!name.startsWith(SESSION_CHUNK_PREFIX)) return null
+  const suffix = name.slice(SESSION_CHUNK_PREFIX.length)
+  if (!/^\d+$/.test(suffix)) return null
+  return Number(suffix)
+}
+
+export type SessionCookieChunk = { name: string; value: string }
+
+// The cookies to write plus the names to expire so the browser jar matches the
+// new value. On every write the other shape's leftovers are expired (bare↔chunked
+// transitions, or a shrink from N chunks to fewer) so no orphan cookies linger.
+export type SessionCookieReconciliation = {
+  write: SessionCookieChunk[]
+  expire: string[]
+}
+
+// Splits the sealed value into the cookies to write. Values within one chunk
+// keep the bare `e2b_session` name (backward compatible with cookies already in
+// the wild); larger values fan out to `e2b_session.0`, `e2b_session.1`, … the
+// way authjs chunks its session cookie.
+export function splitSessionCookie(value: string): SessionCookieChunk[] {
+  if (value.length <= MAX_SESSION_COOKIE_CHUNK) {
+    return [{ name: E2B_SESSION_COOKIE, value }]
+  }
+
+  const chunks: SessionCookieChunk[] = []
+  for (let start = 0, index = 0; start < value.length; index++) {
+    chunks.push({
+      name: `${SESSION_CHUNK_PREFIX}${index}`,
+      value: value.slice(start, start + MAX_SESSION_COOKIE_CHUNK),
+    })
+    start += MAX_SESSION_COOKIE_CHUNK
+  }
+  return chunks
+}
+
+// Reassembles the sealed value from whatever cookie shape is present. Prefers
+// numbered chunks (sorted by index); falls back to a bare `e2b_session`. Never
+// mixes the two shapes, so a stale bare cookie sitting beside fresh chunks can't
+// corrupt the value.
+export function joinSessionCookie(
+  cookieList: ReadonlyArray<{ name: string; value: string }>
+): string | undefined {
+  const chunks = cookieList
+    .map((cookie) => ({
+      index: sessionChunkIndex(cookie.name),
+      value: cookie.value,
+    }))
+    .filter(
+      (chunk): chunk is { index: number; value: string } => chunk.index !== null
+    )
+    .sort((a, b) => a.index - b.index)
+
+  if (chunks.length > 0) {
+    return chunks.map((chunk) => chunk.value).join('')
+  }
+
+  return cookieList.find((cookie) => cookie.name === E2B_SESSION_COOKIE)?.value
+}
+
+// Every e2b_session cookie name currently in the jar — bare or chunked — so the
+// clear paths can expire all of them, not just the bare name.
+export function sessionCookieNames(
+  cookieList: ReadonlyArray<{ name: string; value: string }>
+): string[] {
+  return cookieList
+    .filter(
+      (cookie) =>
+        cookie.name === E2B_SESSION_COOKIE ||
+        sessionChunkIndex(cookie.name) !== null
+    )
+    .map((cookie) => cookie.name)
+}
+
+// Reconciles the browser jar to a new sealed value: the chunks to write plus the
+// stale names to expire so the previous shape never outlives the new one.
+export function reconcileSessionCookies(
+  value: string,
+  existing: ReadonlyArray<{ name: string; value: string }>
+): SessionCookieReconciliation {
+  const write = splitSessionCookie(value)
+  const writeNames = new Set(write.map((chunk) => chunk.name))
+  const expire = sessionCookieNames(existing).filter(
+    (name) => !writeNames.has(name)
+  )
+  return { write, expire }
+}
+
 export function sessionCookieOptions(
   host?: string | null
 ): SessionCookieOptions {
@@ -100,12 +204,14 @@ export function sessionCookieOptions(
 }
 
 // Deleting a domain-scoped cookie requires the same domain attribute, so the
-// clear paths must pass these options rather than the bare cookie name.
+// clear paths must pass these options rather than the bare cookie name. Defaults
+// to the bare name; chunked clears pass each `e2b_session.N` name explicitly.
 export function sessionCookieDeleteOptions(
-  host?: string | null
+  host?: string | null,
+  name: string = E2B_SESSION_COOKIE
 ): SessionCookieDeleteOptions {
   return {
-    name: E2B_SESSION_COOKIE,
+    name,
     path: '/',
     domain: resolveSessionCookieDomain(host),
   }

--- a/src/core/server/auth/ory/session.ts
+++ b/src/core/server/auth/ory/session.ts
@@ -34,9 +34,10 @@ import {
 import { revokeOryOAuthSessionsForSubject } from './oauth-session'
 import {
   cookieHeaderWithoutAppOwned,
-  E2B_SESSION_COOKIE,
+  joinSessionCookie,
   openSessionCookie,
   sessionCookieDeleteOptions,
+  sessionCookieNames,
 } from './session-cookie'
 import { completeOrySignOut } from './signout-flow'
 import { revokeSessionTokens } from './token-revoke'
@@ -123,7 +124,7 @@ export async function getSettingsProfile(): Promise<Pick<
 // without signing the user out of their other devices.
 export async function revokeCurrentSession(): Promise<void> {
   const tokens = await openSessionCookie(
-    (await cookies()).get(E2B_SESSION_COOKIE)?.value
+    joinSessionCookie((await cookies()).getAll())
   )
   if (tokens) {
     await revokeSessionTokens(tokens)
@@ -226,13 +227,16 @@ const readKratosSession = cache(async () => {
 
 const readSessionTokens = cache(async () => {
   const cookieStore = await cookies()
-  return openSessionCookie(cookieStore.get(E2B_SESSION_COOKIE)?.value)
+  return openSessionCookie(joinSessionCookie(cookieStore.getAll()))
 })
 
 async function clearSessionCookie(): Promise<void> {
   try {
     const [cookieStore, headerStore] = await Promise.all([cookies(), headers()])
-    cookieStore.delete(sessionCookieDeleteOptions(headerStore.get('host')))
+    const host = headerStore.get('host')
+    for (const name of sessionCookieNames(cookieStore.getAll())) {
+      cookieStore.delete(sessionCookieDeleteOptions(host, name))
+    }
   } catch (error) {
     l.warn(
       {

--- a/src/core/server/auth/ory/signout-flow.ts
+++ b/src/core/server/auth/ory/signout-flow.ts
@@ -4,7 +4,7 @@ import { cookies } from 'next/headers'
 import { BASE_URL } from '@/configs/urls'
 import { l, serializeErrorForLog } from '@/core/shared/clients/logger/logger'
 import { normalizeOryReturnTo } from './build-start-url'
-import { E2B_SESSION_COOKIE, openSessionCookie } from './session-cookie'
+import { joinSessionCookie, openSessionCookie } from './session-cookie'
 import { buildOryLogoutUrl, ORY_POST_LOGOUT_PATH } from './signout'
 
 // Resolves the post-logout landing for the sign-out route.
@@ -34,7 +34,7 @@ export async function completeOrySignOut(
   try {
     const cookieStore = await cookies()
     const tokens = await openSessionCookie(
-      cookieStore.get(E2B_SESSION_COOKIE)?.value
+      joinSessionCookie(cookieStore.getAll())
     )
     idToken = tokens?.idToken
   } catch (error) {

--- a/src/core/server/proxy/runtime.ts
+++ b/src/core/server/proxy/runtime.ts
@@ -9,10 +9,12 @@ import {
 import oryConfig from '@/configs/ory'
 import { isKratosSessionActive } from '@/core/server/auth/ory/kratos-session-edge'
 import {
-  E2B_SESSION_COOKIE,
+  joinSessionCookie,
   openSessionCookie,
+  reconcileSessionCookies,
   sealSessionCookie,
   sessionCookieDeleteOptions,
+  sessionCookieNames,
   sessionCookieOptions,
 } from '@/core/server/auth/ory/session-cookie'
 import {
@@ -122,7 +124,7 @@ async function refreshSessionCookie(
   request: NextRequest
 ): Promise<SessionRefresh> {
   const tokens = await openSessionCookie(
-    request.cookies.get(E2B_SESSION_COOKIE)?.value
+    joinSessionCookie(request.cookies.getAll())
   )
 
   if (!tokens) return { hasToken: false, persist: noPersist }
@@ -134,16 +136,25 @@ async function refreshSessionCookie(
 
   if (result.status === 'refreshed') {
     const sealed = await sealSessionCookie(result.tokens)
-    request.cookies.set(E2B_SESSION_COOKIE, sealed)
+    const { write, expire } = reconcileSessionCookies(
+      sealed,
+      request.cookies.getAll()
+    )
+    for (const chunk of write) request.cookies.set(chunk.name, chunk.value)
+    for (const name of expire) request.cookies.delete(name)
     return {
       hasToken: true,
       persist: (response) => {
         if (response instanceof NextResponse) {
-          response.cookies.set(
-            E2B_SESSION_COOKIE,
-            sealed,
-            sessionCookieOptions(request.nextUrl.host)
-          )
+          const options = sessionCookieOptions(request.nextUrl.host)
+          for (const chunk of write) {
+            response.cookies.set(chunk.name, chunk.value, options)
+          }
+          for (const name of expire) {
+            response.cookies.delete(
+              sessionCookieDeleteOptions(request.nextUrl.host, name)
+            )
+          }
         }
         return response
       },
@@ -153,14 +164,17 @@ async function refreshSessionCookie(
   if (result.status === 'dead') {
     // The refresh token is unusable. Drop the cookie; the gate then re-mints
     // from the live Kratos session (or routes to the login UI).
-    request.cookies.delete(E2B_SESSION_COOKIE)
+    const names = sessionCookieNames(request.cookies.getAll())
+    for (const name of names) request.cookies.delete(name)
     return {
       hasToken: false,
       persist: (response) => {
         if (response instanceof NextResponse) {
-          response.cookies.delete(
-            sessionCookieDeleteOptions(request.nextUrl.host)
-          )
+          for (const name of names) {
+            response.cookies.delete(
+              sessionCookieDeleteOptions(request.nextUrl.host, name)
+            )
+          }
         }
         return response
       },

--- a/tests/integration/auth-ory-account-security.test.ts
+++ b/tests/integration/auth-ory-account-security.test.ts
@@ -30,20 +30,19 @@ vi.mock('next/headers', () => ({
     }),
 }))
 
-vi.mock('@/core/server/auth/ory/session-cookie', () => ({
-  E2B_SESSION_COOKIE: 'e2b_session',
-  cookieHeaderWithoutAppOwned: (
-    cookieList: ReadonlyArray<{ name: string; value: string }>
-  ) => {
-    const appOwned = new Set(['e2b_session', 'e2b-ory-signup-metadata'])
-    return cookieList
-      .filter((c) => !appOwned.has(c.name))
-      .map((c) => `${c.name}=${c.value}`)
-      .join('; ')
-  },
+// Keep the real chunk helpers (join/names) and the app-owned cookie filter; only
+// mock openSessionCookie (crypto) and pin the delete-options domain the tests
+// assert on.
+vi.mock('@/core/server/auth/ory/session-cookie', async (importOriginal) => ({
+  ...(await importOriginal<
+    typeof import('@/core/server/auth/ory/session-cookie')
+  >()),
   openSessionCookie: openSessionCookieMock,
-  sessionCookieDeleteOptions: (host: string | null | undefined) => ({
-    name: 'e2b_session',
+  sessionCookieDeleteOptions: (
+    host: string | null | undefined,
+    name = 'e2b_session'
+  ) => ({
+    name,
     path: '/',
     domain: host ? `.${host}` : undefined,
   }),

--- a/tests/integration/auth-ory-entrypoints.test.ts
+++ b/tests/integration/auth-ory-entrypoints.test.ts
@@ -18,13 +18,14 @@ vi.mock('@/core/server/auth/ory/kratos-session-edge', () => ({
   isKratosSessionActive: isKratosSessionActiveMock,
 }))
 
-vi.mock('@/core/server/auth/ory/session-cookie', () => ({
-  E2B_SESSION_COOKIE: 'e2b_session',
-  ORY_SIGNUP_METADATA_COOKIE: 'e2b-ory-signup-metadata',
+// Keep the real chunk helpers (split/join/reconcile/names) and cookie options;
+// only the crypto seal/open are mocked so tests can drive token state directly.
+vi.mock('@/core/server/auth/ory/session-cookie', async (importOriginal) => ({
+  ...(await importOriginal<
+    typeof import('@/core/server/auth/ory/session-cookie')
+  >()),
   openSessionCookie: openSessionCookieMock,
   sealSessionCookie: sealSessionCookieMock,
-  sessionCookieOptions: () => ({ httpOnly: true, path: '/' }),
-  sessionCookieDeleteOptions: () => ({ name: 'e2b_session', path: '/' }),
 }))
 
 vi.mock('@/core/server/auth/ory/token-refresh', () => ({
@@ -52,6 +53,14 @@ const { GET: oauthStartGET } = await import('@/app/api/auth/oauth/start/route')
 
 function request(path: string): NextRequest {
   return new NextRequest(`https://app.e2b.dev${path}`)
+}
+
+// A request carrying an e2b_session cookie — the realistic state when a token is
+// present, so the refresh's reconcile/clear paths have a cookie to act on.
+function requestWithSession(path: string): NextRequest {
+  return new NextRequest(`https://app.e2b.dev${path}`, {
+    headers: { cookie: 'e2b_session=old-sealed' },
+  })
 }
 
 describe('Ory auth entrypoints — proxy gate', () => {
@@ -151,7 +160,7 @@ describe('Ory auth entrypoints — middleware refresh (Pattern B)', () => {
     })
 
     const response = await proxy(
-      request('/dashboard/acme/sandboxes'),
+      requestWithSession('/dashboard/acme/sandboxes'),
       {} as NextFetchEvent
     )
 
@@ -165,7 +174,7 @@ describe('Ory auth entrypoints — middleware refresh (Pattern B)', () => {
     refreshSessionTokensMock.mockResolvedValue({ status: 'dead' })
 
     const response = await proxy(
-      request('/dashboard/acme/sandboxes'),
+      requestWithSession('/dashboard/acme/sandboxes'),
       {} as NextFetchEvent
     )
 

--- a/tests/unit/session-cookie.test.ts
+++ b/tests/unit/session-cookie.test.ts
@@ -1,11 +1,15 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import {
+  joinSessionCookie,
   openSessionCookie,
+  reconcileSessionCookies,
   resolveSessionCookieDomain,
   type SessionTokens,
   sealSessionCookie,
   sessionCookieDeleteOptions,
+  sessionCookieNames,
   sessionCookieOptions,
+  splitSessionCookie,
 } from '@/core/server/auth/ory/session-cookie'
 
 const tokens: SessionTokens = {
@@ -134,5 +138,139 @@ describe('e2b_session cookie domain', () => {
       path: '/',
       domain: '.e2b-staging.dev',
     })
+    expect(
+      sessionCookieDeleteOptions('app.e2b-staging.dev', 'e2b_session.1')
+    ).toEqual({
+      name: 'e2b_session.1',
+      path: '/',
+      domain: '.e2b-staging.dev',
+    })
+  })
+})
+
+describe('e2b_session cookie chunking', () => {
+  it('keeps a small value on the bare cookie name', () => {
+    expect(splitSessionCookie('short')).toEqual([
+      { name: 'e2b_session', value: 'short' },
+    ])
+  })
+
+  it('splits a large value into sequential, capped chunks', () => {
+    const value = 'x'.repeat(9000)
+    const chunks = splitSessionCookie(value)
+
+    expect(chunks.map((chunk) => chunk.name)).toEqual([
+      'e2b_session.0',
+      'e2b_session.1',
+      'e2b_session.2',
+    ])
+    expect(chunks.every((chunk) => chunk.value.length <= 3800)).toBe(true)
+    expect(chunks.map((chunk) => chunk.value).join('')).toBe(value)
+  })
+
+  it('round-trips a value through split then join', () => {
+    const value = 'y'.repeat(9000)
+    expect(joinSessionCookie(splitSessionCookie(value))).toBe(value)
+  })
+
+  it('reassembles chunks in numeric, not lexical, order', () => {
+    const value = joinSessionCookie([
+      { name: 'e2b_session.10', value: 'k' },
+      { name: 'e2b_session.2', value: 'c' },
+      { name: 'e2b_session.0', value: 'a' },
+      { name: 'e2b_session.1', value: 'b' },
+    ])
+    // `.10` must sort after `.2`, so the value ends with 'k'.
+    expect(value).toBe('abck')
+  })
+
+  it('reads a bare cookie when no chunks are present', () => {
+    expect(joinSessionCookie([{ name: 'e2b_session', value: 'sealed' }])).toBe(
+      'sealed'
+    )
+  })
+
+  it('prefers chunks over a stale bare cookie', () => {
+    expect(
+      joinSessionCookie([
+        { name: 'e2b_session', value: 'STALE' },
+        { name: 'e2b_session.0', value: 'fresh-' },
+        { name: 'e2b_session.1', value: 'value' },
+      ])
+    ).toBe('fresh-value')
+  })
+
+  it('returns undefined when no session cookie is present', () => {
+    expect(joinSessionCookie([{ name: 'other', value: 'x' }])).toBeUndefined()
+    expect(joinSessionCookie([])).toBeUndefined()
+  })
+
+  it('lists every session cookie name, ignoring unrelated cookies', () => {
+    expect(
+      sessionCookieNames([
+        { name: 'e2b_session.0', value: 'a' },
+        { name: 'e2b-selected-team-id', value: 't' },
+        { name: 'e2b_session.1', value: 'b' },
+        { name: 'e2b_session', value: 'c' },
+      ])
+    ).toEqual(['e2b_session.0', 'e2b_session.1', 'e2b_session'])
+  })
+
+  it('expires the bare cookie when a write grows into chunks', () => {
+    const { write, expire } = reconcileSessionCookies('z'.repeat(9000), [
+      { name: 'e2b_session', value: 'old' },
+    ])
+
+    expect(write.map((chunk) => chunk.name)).toEqual([
+      'e2b_session.0',
+      'e2b_session.1',
+      'e2b_session.2',
+    ])
+    expect(expire).toEqual(['e2b_session'])
+  })
+
+  it('expires leftover chunks when a write shrinks to the bare cookie', () => {
+    const { write, expire } = reconcileSessionCookies('small', [
+      { name: 'e2b_session.0', value: 'a' },
+      { name: 'e2b_session.1', value: 'b' },
+      { name: 'e2b_session.2', value: 'c' },
+    ])
+
+    expect(write).toEqual([{ name: 'e2b_session', value: 'small' }])
+    expect(expire).toEqual(['e2b_session.0', 'e2b_session.1', 'e2b_session.2'])
+  })
+
+  it('expires trailing chunks when a write shrinks to fewer chunks', () => {
+    const { write, expire } = reconcileSessionCookies('q'.repeat(9000), [
+      { name: 'e2b_session.0', value: 'a' },
+      { name: 'e2b_session.1', value: 'b' },
+      { name: 'e2b_session.2', value: 'c' },
+      { name: 'e2b_session.3', value: 'd' },
+      { name: 'e2b_session.4', value: 'e' },
+    ])
+
+    expect(write.map((chunk) => chunk.name)).toEqual([
+      'e2b_session.0',
+      'e2b_session.1',
+      'e2b_session.2',
+    ])
+    expect(expire).toEqual(['e2b_session.3', 'e2b_session.4'])
+  })
+
+  it('seals, splits, and reopens an oversized session end-to-end', async () => {
+    vi.stubEnv('E2B_SESSION_SECRET', 'unit-test-session-secret')
+
+    const large: SessionTokens = {
+      accessToken: 'a'.repeat(6000),
+      refreshToken: 'r'.repeat(2000),
+      idToken: 'i'.repeat(1000),
+      expiresAt: 1_900_000_000,
+    }
+
+    const chunks = splitSessionCookie(await sealSessionCookie(large))
+    expect(chunks.length).toBeGreaterThan(1)
+    expect(await openSessionCookie(joinSessionCookie(chunks))).toEqual(large)
+
+    vi.unstubAllEnvs()
   })
 })


### PR DESCRIPTION
The `e2b_session_` cookie carries the JWE-sealed OIDC tokens (accessToken + refreshToken + idToken). At ~3.7 KB it sits right under the browser's ~4096-byte per-cookie limit — which includes the name and all attributes. If a token grows (extra scopes/claims, longer refresh token), the cookie silently exceeds 4 KB and the browser drops it entirely → user appears logged out / access token vanishes mid-session.

## Solution
Split the sealed value across e2b_session.0, e2b_session.1, … past a safe threshold and reassemble on read — the same scheme authjs uses for authjs.session-token.

**Backward compatible**: small values stay on the bare e2b_session name; existing cookies keep working and re-chunk transparently on the next refresh.

* Small value → bare `e2b_session`. Large value → `e2b_session.0/.1/`….
* Every write reconciles the jar: writes the new chunks and expires stale ones (grow bare→chunked, shrink chunked→bare, or N→fewer chunks) so no orphan cookies linger.
* Read prefers numbered chunks (sorted numerically), falls back to the bare cookie, never mixes the two shapes.

fixes EN-1591