### PR TITLE
feat(limits): clarify usage limit applies to current billing period

### DIFF
--- a/src/features/dashboard/limits/usage-limit-section.tsx
+++ b/src/features/dashboard/limits/usage-limit-section.tsx
@@ -19,8 +19,8 @@ const UsageLimitSectionInfo = ({
 }: Pick<UsageLimitSectionProps, 'email' | 'value'>) => {
   const isValueSet = value !== null
   const limitMessage = isValueSet
-    ? `All API requests are blocked after reaching $${formatNumber(value)}`
-    : 'All API requests are blocked after reaching this limit'
+    ? `All API requests are blocked after reaching $${formatNumber(value)} in the current billing period`
+    : 'All API requests are blocked after reaching this limit in the current billing period'
 
   return (
     <div className="flex flex-col gap-2">


### PR DESCRIPTION
The usage limit description didn't specify the timeframe the limit applies to. This adds "in the current billing period" to the limit message so users understand the limit resets each billing period.