### PR TITLE
feat: support switch to UTC for usage page

### DIFF
--- a/src/app/dashboard/[teamSlug]/usage/page.tsx
+++ b/src/app/dashboard/[teamSlug]/usage/page.tsx
@@ -4,10 +4,12 @@ import { featureFlags } from '@/core/modules/feature-flags/feature-flags.server'
 import { getAuthContext } from '@/core/server/auth'
 import { getTeamIdFromSlug } from '@/core/server/functions/team/get-team-id-from-slug'
 import { getUsage } from '@/core/server/functions/usage/get-usage'
+import { BillingTimezoneBanner } from '@/features/dashboard/usage/billing-timezone-banner'
 import { EMPTY_USAGE } from '@/features/dashboard/usage/redesign/usage-fallback'
 import { UsageMetricDetail } from '@/features/dashboard/usage/redesign/usage-metric-detail'
 import { UsageChartsProvider } from '@/features/dashboard/usage/usage-charts-context'
 import { UsageMetricChart } from '@/features/dashboard/usage/usage-metric-chart'
+import { UsageTimezoneProvider } from '@/features/dashboard/usage/usage-timezone'
 import { UsageTopTimeRangeControls } from '@/features/dashboard/usage/usage-top-time-range-controls'
 import ErrorBoundary from '@/ui/error'
 import Frame from '@/ui/frame'
@@ -44,9 +46,11 @@ export default async function UsagePage({
   // when usage can't be loaded instead of erroring the whole screen.
   if (newUsagePage) {
     return (
-      <UsageChartsProvider data={result?.data ?? EMPTY_USAGE}>
-        <UsageMetricDetail metric="cost" />
-      </UsageChartsProvider>
+      <UsageTimezoneProvider>
+        <UsageChartsProvider data={result?.data ?? EMPTY_USAGE}>
+          <UsageMetricDetail metric="cost" />
+        </UsageChartsProvider>
+      </UsageTimezoneProvider>
     )
   }
 
@@ -65,43 +69,47 @@ export default async function UsagePage({
   }
 
   return (
-    <UsageChartsProvider data={result.data}>
-      <div className="h-full max-h-full min-h-0 overflow-y-auto">
-        <div className="container mx-auto p-0 md:p-8 2xl:px-24 2xl:py-8 max-w-[1800px] lg:flex lg:flex-col lg:h-full">
-          <Frame
-            classNames={{
-              wrapper: 'w-full lg:flex-1 lg:min-h-[700px] lg:max-h-full',
-              frame: 'lg:h-full max-lg:border-0 lg:flex lg:flex-col',
-            }}
-          >
-            <div className="hidden lg:flex lg:justify-end lg:px-3 lg:pt-3">
-              <UsageTopTimeRangeControls />
-            </div>
-            <div className="grid grid-cols-1 lg:grid-cols-2 lg:grid-rows-2 lg:min-h-0 lg:flex-1">
-              <UsageMetricChart
-                metric="sandboxes"
-                className="min-h-[48svh] lg:min-h-0 lg:h-full"
-                timeRangeControlsClassName="flex lg:hidden"
-              />
-              <UsageMetricChart
-                metric="cost"
-                className="min-h-[48svh] lg:min-h-0 lg:h-full"
-                timeRangeControlsClassName="hidden"
-              />
-              <UsageMetricChart
-                metric="vcpu"
-                className="min-h-[48svh] lg:min-h-0 lg:h-full lg:border-t lg:border-stroke"
-                timeRangeControlsClassName="flex lg:hidden"
-              />
-              <UsageMetricChart
-                metric="ram"
-                className="min-h-[48svh] lg:min-h-0 lg:h-full lg:border-t lg:border-stroke"
-                timeRangeControlsClassName="hidden"
-              />
-            </div>
-          </Frame>
+    <UsageTimezoneProvider>
+      <UsageChartsProvider data={result.data}>
+        <div className="h-full max-h-full min-h-0 overflow-y-auto">
+          <div className="container mx-auto p-0 md:p-8 2xl:px-24 2xl:py-8 max-w-[1800px] lg:flex lg:flex-col lg:h-full">
+            <Frame
+              classNames={{
+                wrapper: 'w-full lg:flex-1 lg:min-h-[700px] lg:max-h-full',
+                frame: 'lg:h-full max-lg:border-0 lg:flex lg:flex-col',
+              }}
+            >
+              <BillingTimezoneBanner className="m-3 mb-0 lg:hidden" />
+              <div className="hidden lg:flex lg:items-start lg:gap-3 lg:px-3 lg:pt-3">
+                <BillingTimezoneBanner className="mr-auto" />
+                <UsageTopTimeRangeControls className="ml-auto" />
+              </div>
+              <div className="grid grid-cols-1 lg:grid-cols-2 lg:grid-rows-2 lg:min-h-0 lg:flex-1">
+                <UsageMetricChart
+                  metric="sandboxes"
+                  className="min-h-[48svh] lg:min-h-0 lg:h-full"
+                  timeRangeControlsClassName="flex lg:hidden"
+                />
+                <UsageMetricChart
+                  metric="cost"
+                  className="min-h-[48svh] lg:min-h-0 lg:h-full"
+                  timeRangeControlsClassName="hidden"
+                />
+                <UsageMetricChart
+                  metric="vcpu"
+                  className="min-h-[48svh] lg:min-h-0 lg:h-full lg:border-t lg:border-stroke"
+                  timeRangeControlsClassName="flex lg:hidden"
+                />
+                <UsageMetricChart
+                  metric="ram"
+                  className="min-h-[48svh] lg:min-h-0 lg:h-full lg:border-t lg:border-stroke"
+                  timeRangeControlsClassName="hidden"
+                />
+              </div>
+            </Frame>
+          </div>
         </div>
-      </div>
-    </UsageChartsProvider>
+      </UsageChartsProvider>
+    </UsageTimezoneProvider>
   )
 }

--- a/src/features/dashboard/timezone/context.tsx
+++ b/src/features/dashboard/timezone/context.tsx
@@ -9,10 +9,10 @@ import {
   useMemo,
   useState,
 } from 'react'
-import { type Timezone, TimezoneSchema } from './schema'
+import { type Timezone, UTC_TIMEZONE } from './schema'
 import { parseTimezone } from './utils'
 
-const DEFAULT_TIMEZONE = TimezoneSchema.parse('UTC')
+const DEFAULT_TIMEZONE = UTC_TIMEZONE
 
 interface TimezoneContextValue {
   timezone: Timezone
@@ -81,6 +81,33 @@ export const TimezoneProvider = ({
       setTimezone,
     }),
     [setTimezone, timezone]
+  )
+
+  return (
+    <TimezoneContext.Provider value={value}>
+      {children}
+    </TimezoneContext.Provider>
+  )
+}
+
+interface TimezoneOverrideProps {
+  children: ReactNode
+  timezone: Timezone
+}
+
+const setTimezoneNoop = async () => false
+
+/**
+ * Pins `useTimezone()` to a fixed timezone for a subtree without touching the
+ * persisted preference. `setTimezone` is disabled under the override.
+ */
+export const TimezoneOverride = ({
+  children,
+  timezone,
+}: TimezoneOverrideProps) => {
+  const value = useMemo(
+    () => ({ timezone, setTimezone: setTimezoneNoop }),
+    [timezone]
   )
 
   return (

--- a/src/features/dashboard/timezone/index.ts
+++ b/src/features/dashboard/timezone/index.ts
@@ -1,6 +1,6 @@
-export { TimezoneProvider, useTimezone } from './context'
+export { TimezoneOverride, TimezoneProvider, useTimezone } from './context'
 export type { Timezone } from './schema'
-export { TimezoneSchema } from './schema'
+export { TimezoneSchema, UTC_TIMEZONE } from './schema'
 export {
   formatTimezoneLabel,
   getBrowserTimezone,

--- a/src/features/dashboard/timezone/schema.ts
+++ b/src/features/dashboard/timezone/schema.ts
@@ -18,4 +18,6 @@ const TimezoneSchema = z
 
 type Timezone = z.infer<typeof TimezoneSchema>
 
-export { TimezoneSchema, type Timezone }
+const UTC_TIMEZONE = TimezoneSchema.parse('UTC')
+
+export { TimezoneSchema, UTC_TIMEZONE, type Timezone }

--- a/src/features/dashboard/usage/billing-timezone-banner.tsx
+++ b/src/features/dashboard/usage/billing-timezone-banner.tsx
@@ -1,0 +1,45 @@
+'use client'
+
+import { useMemo } from 'react'
+import { cn } from '@/lib/utils'
+import { formatTimezoneAbbreviation } from '@/lib/utils/formatting'
+import { Button } from '@/ui/primitives/button'
+import { InfoIcon } from '@/ui/primitives/icons'
+import { useUsageTimezone } from './usage-timezone'
+import { isBillingTimezoneBannerVisible } from './usage-timezone-utils'
+
+export function BillingTimezoneBanner({ className }: { className?: string }) {
+  const { userTimezone, isPinnedToUtc, setPinnedToUtc } = useUsageTimezone()
+
+  const userTimezoneAbbreviation = useMemo(
+    () => formatTimezoneAbbreviation(new Date(), userTimezone),
+    [userTimezone]
+  )
+
+  if (!isBillingTimezoneBannerVisible(userTimezone)) {
+    return null
+  }
+
+  return (
+    <div
+      className={cn(
+        'border-accent-info-highlight bg-bg-1 flex flex-wrap items-center gap-x-2 gap-y-2 border-l-[3px] py-1.5 pr-1.5 pl-3',
+        className
+      )}
+    >
+      <InfoIcon className="text-accent-info-highlight size-4 shrink-0" />
+      <span className="prose-label text-fg-secondary">
+        {`Billing uses UTC, which differs from your default timezone (${userTimezoneAbbreviation}).`}
+      </span>
+      <Button
+        variant="secondary"
+        size="small"
+        onClick={() => setPinnedToUtc(!isPinnedToUtc)}
+      >
+        {isPinnedToUtc
+          ? `Switch back to ${userTimezoneAbbreviation}`
+          : 'View in UTC'}
+      </Button>
+    </div>
+  )
+}

--- a/src/features/dashboard/usage/constants.ts
+++ b/src/features/dashboard/usage/constants.ts
@@ -23,6 +23,14 @@ export const INITIAL_TIMEFRAME_FALLBACK_RANGE_MS = 30 * 24 * 60 * 60 * 1000
 export const HOURLY_SAMPLING_THRESHOLD_DAYS = 3
 export const WEEKLY_SAMPLING_THRESHOLD_DAYS = 60
 
+/**
+ * How far a timeframe may deviate from a preset's boundaries and still be
+ * treated as that preset. Shared between the time-range controls (preset
+ * highlight) and the UTC pin (timeframe re-anchoring) — the two must not
+ * drift, or a highlighted preset would fail to re-anchor.
+ */
+export const PRESET_MATCH_TOLERANCE_MS = 24 * 60 * 60 * 1000
+
 type CalendarDateParts = ReturnType<typeof getDateParts>
 
 const shiftToMonthStart = (

--- a/src/features/dashboard/usage/redesign/usage-metric-detail.tsx
+++ b/src/features/dashboard/usage/redesign/usage-metric-detail.tsx
@@ -4,6 +4,7 @@ import { useId, useState } from 'react'
 import { cn } from '@/lib/utils'
 import { ChevronDownIcon, CpuIcon } from '@/ui/primitives/icons'
 import { Tabs, TabsList, TabsTrigger } from '@/ui/primitives/tabs'
+import { BillingTimezoneBanner } from '../billing-timezone-banner'
 import { useUsageCharts } from '../usage-charts-context'
 import { UsageTopTimeRangeControls } from '../usage-top-time-range-controls'
 import { USAGE_METRICS, type UsageMetricKey } from './metrics'
@@ -38,8 +39,9 @@ export function UsageMetricDetail({ metric }: { metric: UsageMetricKey }) {
   return (
     <div className="h-full max-h-full min-h-0 overflow-y-auto">
       <div className="flex w-full flex-col gap-4 p-6">
-        <div className="flex flex-wrap items-center gap-1">
+        <div className="flex flex-wrap items-center gap-x-3 gap-y-2">
           <UsageTopTimeRangeControls />
+          <BillingTimezoneBanner className="ml-auto" />
         </div>
 
         <SingleMetricChart

--- a/src/features/dashboard/usage/usage-time-range-controls.tsx
+++ b/src/features/dashboard/usage/usage-time-range-controls.tsx
@@ -17,7 +17,10 @@ import {
 import { Separator } from '@/ui/primitives/separator'
 import { TimeRangePicker } from '@/ui/time-range-picker'
 import { type TimeRangePreset, TimeRangePresets } from '@/ui/time-range-presets'
-import { getUsageTimeRangePresets } from './constants'
+import {
+  getUsageTimeRangePresets,
+  PRESET_MATCH_TOLERANCE_MS,
+} from './constants'
 import {
   determineSamplingMode,
   normalizeToEndOfSamplingPeriod,
@@ -56,7 +59,7 @@ export function UsageTimeRangeControls({
         timeRangePresets,
         timeframe.start,
         timeframe.end,
-        1000 * 60 * 60 * 24 // 1 day in tolerance
+        PRESET_MATCH_TOLERANCE_MS
       ),
     [timeRangePresets, timeframe.start, timeframe.end]
   )

--- a/src/features/dashboard/usage/usage-timezone-utils.ts
+++ b/src/features/dashboard/usage/usage-timezone-utils.ts
@@ -1,9 +1,9 @@
 import { type Timezone, UTC_TIMEZONE } from '@/features/dashboard/timezone'
 import { findMatchingPreset } from '@/lib/utils/time-range'
-import { getUsageTimeRangePresets } from './constants'
-
-// Same tolerance the time-range controls use to highlight the active preset.
-const PRESET_MATCH_TOLERANCE_MS = 24 * 60 * 60 * 1000
+import {
+  getUsageTimeRangePresets,
+  PRESET_MATCH_TOLERANCE_MS,
+} from './constants'
 
 export function resolveUsageTimezone(
   userTimezone: Timezone,
@@ -15,8 +15,9 @@ export function resolveUsageTimezone(
 /**
  * A preset-aligned timeframe describes calendar boundaries ("This month"), so
  * switching timezone re-anchors it to the new timezone's boundaries — that is
- * what makes totals match billing when pinning to UTC. Returns null for custom
- * ranges, which are absolute instants and must be kept as picked.
+ * what makes totals match billing when pinning to UTC. Ranges within the
+ * highlight tolerance of a preset are treated as that preset; only genuinely
+ * custom ranges return null and are kept as picked.
  */
 export function reanchorTimeframeToTimezone(
   timeframe: { start: number; end: number },

--- a/src/features/dashboard/usage/usage-timezone-utils.ts
+++ b/src/features/dashboard/usage/usage-timezone-utils.ts
@@ -1,0 +1,45 @@
+import { type Timezone, UTC_TIMEZONE } from '@/features/dashboard/timezone'
+import { findMatchingPreset } from '@/lib/utils/time-range'
+import { getUsageTimeRangePresets } from './constants'
+
+// Same tolerance the time-range controls use to highlight the active preset.
+const PRESET_MATCH_TOLERANCE_MS = 24 * 60 * 60 * 1000
+
+export function resolveUsageTimezone(
+  userTimezone: Timezone,
+  isPinnedToUtc: boolean
+): Timezone {
+  return isPinnedToUtc ? UTC_TIMEZONE : userTimezone
+}
+
+/**
+ * A preset-aligned timeframe describes calendar boundaries ("This month"), so
+ * switching timezone re-anchors it to the new timezone's boundaries — that is
+ * what makes totals match billing when pinning to UTC. Returns null for custom
+ * ranges, which are absolute instants and must be kept as picked.
+ */
+export function reanchorTimeframeToTimezone(
+  timeframe: { start: number; end: number },
+  fromTimezone: Timezone,
+  toTimezone: Timezone
+): { start: number; end: number } | null {
+  const matchedPresetId = findMatchingPreset(
+    getUsageTimeRangePresets(fromTimezone),
+    timeframe.start,
+    timeframe.end,
+    PRESET_MATCH_TOLERANCE_MS
+  )
+  if (!matchedPresetId) return null
+
+  const preset = getUsageTimeRangePresets(toTimezone).find(
+    (candidate) => candidate.id === matchedPresetId
+  )
+
+  return preset?.getValue() ?? null
+}
+
+export function isBillingTimezoneBannerVisible(
+  userTimezone: Timezone
+): boolean {
+  return userTimezone !== UTC_TIMEZONE
+}

--- a/src/features/dashboard/usage/usage-timezone-utils.ts
+++ b/src/features/dashboard/usage/usage-timezone-utils.ts
@@ -1,9 +1,24 @@
 import { type Timezone, UTC_TIMEZONE } from '@/features/dashboard/timezone'
 import { findMatchingPreset } from '@/lib/utils/time-range'
+import type { TimeRangePreset } from '@/ui/time-range-presets'
 import {
   getUsageTimeRangePresets,
   PRESET_MATCH_TOLERANCE_MS,
 } from './constants'
+
+const CALENDAR_ANCHORED_PRESET_IDS = new Set([
+  'this-month',
+  'last-month',
+  'this-year',
+  'last-year',
+])
+
+// Identical ranges (e.g. "this-month" vs "last-30-days" on the 30th of a
+// 30-day month) must resolve to the calendar preset, or pinning to UTC can
+// re-anchor to a rolling window that misses the billing month.
+const byCalendarAnchoredFirst = (a: TimeRangePreset, b: TimeRangePreset) =>
+  Number(CALENDAR_ANCHORED_PRESET_IDS.has(b.id)) -
+  Number(CALENDAR_ANCHORED_PRESET_IDS.has(a.id))
 
 export function resolveUsageTimezone(
   userTimezone: Timezone,
@@ -25,7 +40,7 @@ export function reanchorTimeframeToTimezone(
   toTimezone: Timezone
 ): { start: number; end: number } | null {
   const matchedPresetId = findMatchingPreset(
-    getUsageTimeRangePresets(fromTimezone),
+    getUsageTimeRangePresets(fromTimezone).toSorted(byCalendarAnchoredFirst),
     timeframe.start,
     timeframe.end,
     PRESET_MATCH_TOLERANCE_MS

--- a/src/features/dashboard/usage/usage-timezone.tsx
+++ b/src/features/dashboard/usage/usage-timezone.tsx
@@ -53,22 +53,24 @@ export function UsageTimezoneProvider({ children }: { children: ReactNode }) {
 
   const setPinnedToUtc = useCallback(
     (pinned: boolean) => {
-      const now = Date.now()
-      const reanchoredTimeframe = reanchorTimeframeToTimezone(
-        {
-          start: params.start ?? now - INITIAL_TIMEFRAME_FALLBACK_RANGE_MS,
-          end: params.end ?? now,
-        },
-        resolveUsageTimezone(userTimezone, isPinnedToUtc),
-        resolveUsageTimezone(userTimezone, pinned)
-      )
+      void setParams((prev) => {
+        const now = Date.now()
+        const reanchoredTimeframe = reanchorTimeframeToTimezone(
+          {
+            start: prev.start ?? now - INITIAL_TIMEFRAME_FALLBACK_RANGE_MS,
+            end: prev.end ?? now,
+          },
+          resolveUsageTimezone(userTimezone, prev.utc),
+          resolveUsageTimezone(userTimezone, pinned)
+        )
 
-      void setParams({
-        utc: pinned || null,
-        ...(reanchoredTimeframe ?? {}),
+        return {
+          utc: pinned || null,
+          ...(reanchoredTimeframe ?? {}),
+        }
       })
     },
-    [params.start, params.end, userTimezone, isPinnedToUtc, setParams]
+    [userTimezone, setParams]
   )
 
   const effectiveTimezone = resolveUsageTimezone(userTimezone, isPinnedToUtc)

--- a/src/features/dashboard/usage/usage-timezone.tsx
+++ b/src/features/dashboard/usage/usage-timezone.tsx
@@ -1,0 +1,104 @@
+'use client'
+
+import { parseAsBoolean, parseAsInteger, useQueryStates } from 'nuqs'
+import {
+  createContext,
+  type ReactNode,
+  useCallback,
+  useContext,
+  useMemo,
+} from 'react'
+import {
+  type Timezone,
+  TimezoneOverride,
+  useTimezone,
+} from '@/features/dashboard/timezone'
+import { INITIAL_TIMEFRAME_FALLBACK_RANGE_MS } from './constants'
+import {
+  reanchorTimeframeToTimezone,
+  resolveUsageTimezone,
+} from './usage-timezone-utils'
+
+interface UsageTimezoneContextValue {
+  userTimezone: Timezone
+  effectiveTimezone: Timezone
+  isPinnedToUtc: boolean
+  setPinnedToUtc: (pinned: boolean) => void
+}
+
+const UsageTimezoneContext = createContext<UsageTimezoneContextValue | null>(
+  null
+)
+
+/**
+ * Billing meters and invoices are aggregated over UTC boundaries, so the usage
+ * page offers a page-scoped UTC pin (via the `utc` query param) that shadows
+ * the dashboard timezone preference without persisting anything.
+ */
+export function UsageTimezoneProvider({ children }: { children: ReactNode }) {
+  const { timezone: userTimezone } = useTimezone()
+
+  // `start`/`end` mirror the timeframe params owned by usage-charts-context;
+  // sharing one useQueryStates call lets a pin flip re-anchor them atomically.
+  const [params, setParams] = useQueryStates(
+    {
+      utc: parseAsBoolean.withDefault(false),
+      start: parseAsInteger,
+      end: parseAsInteger,
+    },
+    { history: 'push', shallow: true }
+  )
+
+  const isPinnedToUtc = params.utc
+
+  const setPinnedToUtc = useCallback(
+    (pinned: boolean) => {
+      const now = Date.now()
+      const reanchoredTimeframe = reanchorTimeframeToTimezone(
+        {
+          start: params.start ?? now - INITIAL_TIMEFRAME_FALLBACK_RANGE_MS,
+          end: params.end ?? now,
+        },
+        resolveUsageTimezone(userTimezone, isPinnedToUtc),
+        resolveUsageTimezone(userTimezone, pinned)
+      )
+
+      void setParams({
+        utc: pinned || null,
+        ...(reanchoredTimeframe ?? {}),
+      })
+    },
+    [params.start, params.end, userTimezone, isPinnedToUtc, setParams]
+  )
+
+  const effectiveTimezone = resolveUsageTimezone(userTimezone, isPinnedToUtc)
+
+  const value = useMemo(
+    () => ({
+      userTimezone,
+      effectiveTimezone,
+      isPinnedToUtc,
+      setPinnedToUtc,
+    }),
+    [userTimezone, effectiveTimezone, isPinnedToUtc, setPinnedToUtc]
+  )
+
+  return (
+    <UsageTimezoneContext.Provider value={value}>
+      <TimezoneOverride timezone={effectiveTimezone}>
+        {children}
+      </TimezoneOverride>
+    </UsageTimezoneContext.Provider>
+  )
+}
+
+export function useUsageTimezone() {
+  const context = useContext(UsageTimezoneContext)
+  if (!context) {
+    throw new Error(
+      'useUsageTimezone must be used within UsageTimezoneProvider'
+    )
+  }
+
+  return context
+}

--- a/src/lib/utils/time-range.ts
+++ b/src/lib/utils/time-range.ts
@@ -1,7 +1,9 @@
 import type { TimeRangePreset } from '@/ui/time-range-presets'
 
 /**
- * Finds which preset matches the given timeframe (with tolerance)
+ * Finds which preset matches the given timeframe (with tolerance).
+ * Presets can overlap within the tolerance (e.g. "This month" vs "Last 30
+ * days" near month ends), so the closest match wins, not the first one.
  */
 export function findMatchingPreset(
   presets: TimeRangePreset[],
@@ -9,16 +11,22 @@ export function findMatchingPreset(
   end: number,
   toleranceMs = 10 * 1000 // 10 seconds
 ): string | undefined {
+  let bestId: string | undefined
+  let bestDeviation = Infinity
+
   for (const preset of presets) {
     const { start: presetStart, end: presetEnd } = preset.getValue()
+    const startDiff = Math.abs(start - presetStart)
+    const endDiff = Math.abs(end - presetEnd)
 
-    if (
-      Math.abs(start - presetStart) <= toleranceMs &&
-      Math.abs(end - presetEnd) <= toleranceMs
-    ) {
-      return preset.id
+    if (startDiff > toleranceMs || endDiff > toleranceMs) continue
+
+    const deviation = startDiff + endDiff
+    if (deviation < bestDeviation) {
+      bestDeviation = deviation
+      bestId = preset.id
     }
   }
 
-  return undefined
+  return bestId
 }

--- a/tests/unit/time-range.test.ts
+++ b/tests/unit/time-range.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from 'vitest'
+import { findMatchingPreset } from '@/lib/utils/time-range'
+import type { TimeRangePreset } from '@/ui/time-range-presets'
+
+const DAY_MS = 24 * 60 * 60 * 1000
+
+const makePreset = (
+  id: string,
+  start: number,
+  end: number
+): TimeRangePreset => ({
+  id,
+  label: id,
+  getValue: () => ({ start, end }),
+})
+
+describe('findMatchingPreset', () => {
+  it('matches a preset within tolerance', () => {
+    const presets = [makePreset('a', 0, 10 * DAY_MS)]
+
+    expect(findMatchingPreset(presets, 1000, 10 * DAY_MS - 1000, 5000)).toBe(
+      'a'
+    )
+  })
+
+  it('returns undefined when no preset is within tolerance', () => {
+    const presets = [makePreset('a', 0, 10 * DAY_MS)]
+
+    expect(
+      findMatchingPreset(presets, 2 * DAY_MS, 12 * DAY_MS, 5000)
+    ).toBeUndefined()
+  })
+
+  it('prefers the closest preset over an earlier loose overlap', () => {
+    const exact = { start: 0, end: 31 * DAY_MS }
+    const presets = [
+      makePreset('loose', exact.start + DAY_MS, exact.end),
+      makePreset('exact', exact.start, exact.end),
+    ]
+
+    expect(findMatchingPreset(presets, exact.start, exact.end, DAY_MS)).toBe(
+      'exact'
+    )
+  })
+
+  it('breaks deviation ties by preset order', () => {
+    const presets = [
+      makePreset('first', 0, 10 * DAY_MS),
+      makePreset('second', 0, 10 * DAY_MS),
+    ]
+
+    expect(findMatchingPreset(presets, 0, 10 * DAY_MS, DAY_MS)).toBe('first')
+  })
+})

--- a/tests/unit/usage-timezone-utils.test.ts
+++ b/tests/unit/usage-timezone-utils.test.ts
@@ -11,6 +11,7 @@ import {
 } from '@/features/dashboard/usage/usage-timezone-utils'
 
 const prague = TimezoneSchema.parse('Europe/Prague')
+const tokyo = TimezoneSchema.parse('Asia/Tokyo')
 
 const getPresetRange = (
   timezone: typeof prague,
@@ -109,6 +110,22 @@ describe('reanchorTimeframeToTimezone', () => {
     const pragueThisMonth = getPresetRange(prague, 'this-month')
 
     expect(reanchorOrThrow(pragueThisMonth, prague, UTC_TIMEZONE)).toEqual(
+      getPresetRange(UTC_TIMEZONE, 'this-month')
+    )
+  })
+
+  // On the 30th of a 30-day month "this-month" and "last-30-days" are
+  // identical, so the match is a pure tie; the calendar preset must win. With
+  // Tokyo a calendar day ahead of UTC, guessing "last-30-days" would re-anchor
+  // to UTC May 31 - Jun 29 instead of the June billing month.
+  it('resolves identical-range ties to the calendar preset', () => {
+    // Tokyo 2026-06-30 00:30, UTC date still June 29.
+    vi.setSystemTime(new Date('2026-06-29T15:30:00.000Z'))
+
+    const tokyoThisMonth = getPresetRange(tokyo, 'this-month')
+    expect(tokyoThisMonth).toEqual(getPresetRange(tokyo, 'last-30-days'))
+
+    expect(reanchorOrThrow(tokyoThisMonth, tokyo, UTC_TIMEZONE)).toEqual(
       getPresetRange(UTC_TIMEZONE, 'this-month')
     )
   })

--- a/tests/unit/usage-timezone-utils.test.ts
+++ b/tests/unit/usage-timezone-utils.test.ts
@@ -96,4 +96,31 @@ describe('reanchorTimeframeToTimezone', () => {
       )
     ).toBeNull()
   })
+
+  // Near month ends "this-month" also falls within the loose match tolerance
+  // of "last-30-days"; the exact preset must win or a day of usage would be
+  // dropped from the re-anchored range.
+  it.each([
+    '2026-07-30T10:00:00.000Z',
+    '2026-07-31T10:00:00.000Z',
+  ])('keeps "this-month" boundaries when re-anchoring at %s', (systemTime) => {
+    vi.setSystemTime(new Date(systemTime))
+
+    const pragueThisMonth = getPresetRange(prague, 'this-month')
+
+    expect(reanchorOrThrow(pragueThisMonth, prague, UTC_TIMEZONE)).toEqual(
+      getPresetRange(UTC_TIMEZONE, 'this-month')
+    )
+  })
+
+  it('round-trips "this-month" on the last day of a 31-day month', () => {
+    vi.setSystemTime(new Date('2026-07-31T10:00:00.000Z'))
+
+    const pragueThisMonth = getPresetRange(prague, 'this-month')
+    const utcThisMonth = reanchorOrThrow(pragueThisMonth, prague, UTC_TIMEZONE)
+
+    expect(
+      reanchorTimeframeToTimezone(utcThisMonth, UTC_TIMEZONE, prague)
+    ).toEqual(pragueThisMonth)
+  })
 })

--- a/tests/unit/usage-timezone-utils.test.ts
+++ b/tests/unit/usage-timezone-utils.test.ts
@@ -1,0 +1,99 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import {
+  TimezoneSchema,
+  UTC_TIMEZONE,
+} from '@/features/dashboard/timezone/schema'
+import { getUsageTimeRangePresets } from '@/features/dashboard/usage/constants'
+import {
+  isBillingTimezoneBannerVisible,
+  reanchorTimeframeToTimezone,
+  resolveUsageTimezone,
+} from '@/features/dashboard/usage/usage-timezone-utils'
+
+const prague = TimezoneSchema.parse('Europe/Prague')
+
+const getPresetRange = (
+  timezone: typeof prague,
+  presetId: string
+): { start: number; end: number } => {
+  const preset = getUsageTimeRangePresets(timezone).find(
+    (option) => option.id === presetId
+  )
+  if (!preset) throw new Error(`Expected ${presetId} preset to exist`)
+
+  return preset.getValue()
+}
+
+describe('resolveUsageTimezone', () => {
+  it('returns the user timezone when not pinned to UTC', () => {
+    expect(resolveUsageTimezone(prague, false)).toBe(prague)
+    expect(resolveUsageTimezone(UTC_TIMEZONE, false)).toBe(UTC_TIMEZONE)
+  })
+
+  it('returns UTC when pinned', () => {
+    expect(resolveUsageTimezone(prague, true)).toBe(UTC_TIMEZONE)
+    expect(resolveUsageTimezone(UTC_TIMEZONE, true)).toBe(UTC_TIMEZONE)
+  })
+})
+
+describe('isBillingTimezoneBannerVisible', () => {
+  it('shows the banner for non-UTC user timezones', () => {
+    expect(isBillingTimezoneBannerVisible(prague)).toBe(true)
+  })
+
+  it('hides the banner when the user timezone is already UTC', () => {
+    expect(isBillingTimezoneBannerVisible(UTC_TIMEZONE)).toBe(false)
+  })
+})
+
+describe('reanchorTimeframeToTimezone', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date('2026-07-10T10:00:00.000Z'))
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  const reanchorOrThrow = (
+    ...args: Parameters<typeof reanchorTimeframeToTimezone>
+  ) => {
+    const reanchored = reanchorTimeframeToTimezone(...args)
+    if (!reanchored) throw new Error('Expected timeframe to re-anchor')
+
+    return reanchored
+  }
+
+  it('re-anchors a preset-aligned range to the target timezone boundaries', () => {
+    const pragueThisMonth = getPresetRange(prague, 'this-month')
+
+    const reanchored = reanchorOrThrow(pragueThisMonth, prague, UTC_TIMEZONE)
+
+    expect(reanchored).toEqual(getPresetRange(UTC_TIMEZONE, 'this-month'))
+    // Prague is UTC+2 in July, so the UTC month starts 2 hours later.
+    expect(reanchored.start - pragueThisMonth.start).toBe(2 * 60 * 60 * 1000)
+  })
+
+  it('round-trips back to the original boundaries', () => {
+    const pragueThisMonth = getPresetRange(prague, 'this-month')
+    const utcThisMonth = reanchorOrThrow(pragueThisMonth, prague, UTC_TIMEZONE)
+
+    expect(
+      reanchorTimeframeToTimezone(utcThisMonth, UTC_TIMEZONE, prague)
+    ).toEqual(pragueThisMonth)
+  })
+
+  it('returns null for custom ranges so they are kept as picked', () => {
+    const twoWeeks = 14 * 24 * 60 * 60 * 1000
+    const customEnd = new Date('2026-06-20T13:37:00.000Z').getTime()
+
+    expect(
+      reanchorTimeframeToTimezone(
+        { start: customEnd - twoWeeks, end: customEnd },
+        prague,
+        UTC_TIMEZONE
+      )
+    ).toBeNull()
+  })
+})


### PR DESCRIPTION
Adds a page-scoped UTC switch to the usage page so displayed totals can match billing, which aggregates over UTC calendar boundaries.

- shows an info banner when the user's timezone differs from UTC, with a one-click "View in UTC" toggle held in the `utc` query param — the persisted timezone preference is untouched
- pins all charts, presets, and time pickers on the page to UTC via a `TimezoneOverride` provider that shadows `useTimezone()` for the subtree, so existing consumers need no changes
- toggling re-anchors preset-aligned ranges ("This month", "Last 30 days", …) to the target timezone's calendar boundaries; custom ranges are kept as picked
- preset matching now prefers the closest match instead of the first within tolerance, so toggling near month ends doesn't drop a day from the range
- unit tests cover timezone resolution, re-anchoring (incl. month-boundary regressions and round-trips), and preset matching

closes DASH-162
