### PR TITLE
fix(tags): correct hover state on uncollapsed tag section

### DIFF
--- a/src/features/dashboard/templates/tags/table-cells.tsx
+++ b/src/features/dashboard/templates/tags/table-cells.tsx
@@ -72,7 +72,8 @@ export function ActionsCell(ctx: CellContext<TagGroup, unknown>) {
       <div
         className={cn(
           'flex items-center gap-1 max-sm:hidden',
-          'opacity-0 group-hover/section:opacity-100 group-has-focus-visible/section:opacity-100'
+          'opacity-0 group-hover/row:opacity-100',
+          'group-focus-visible/row:opacity-100 group-has-focus-visible/row:opacity-100'
         )}
       >
         <Button

--- a/src/features/dashboard/templates/tags/table.tsx
+++ b/src/features/dashboard/templates/tags/table.tsx
@@ -387,7 +387,7 @@ function GroupSection({ row, teamSlug, templateId }: GroupSectionProps) {
     : undefined
 
   return (
-    <div className="group/section flex flex-col divide-y divide-stroke/80">
+    <div className="flex flex-col divide-y divide-stroke/80">
       <DataTableRow
         data-state={dataState}
         role={canExpand ? 'button' : undefined}
@@ -396,7 +396,7 @@ function GroupSection({ row, teamSlug, templateId }: GroupSectionProps) {
         onClick={handleClick}
         onKeyDown={handleKeyDown}
         className={cn(
-          'group/row relative flex items-center gap-6 border-b-0 -mx-3 px-3 w-[calc(100%+24px)] hover:bg-bg-1 transition-none',
+          'group/row relative flex items-center gap-6 border-b-0 -mx-3 px-3 w-[calc(100%+24px)] data-[state=closed]:hover:bg-bg-1 transition-none',
           canExpand && 'cursor-pointer'
         )}
       >


### PR DESCRIPTION
Fixes the hover behavior on expanded (uncollapsed) tag sections:

| Before | After |
| ------- | ------- |
| <img width="1886" height="528" alt="CleanShot 2026-07-10 at 15 47 01@2x" src="https://github.com/user-attachments/assets/0021cc86-b703-44e3-9760-dc3c0d607e3c" /> | <img width="1840" height="514" alt="CleanShot 2026-07-10 at 15 47 34@2x" src="https://github.com/user-attachments/assets/30a8a4ec-a172-4388-92b7-38cbde7aa9a6" /> |
  

closes DASH-66