### PR TITLE
feat: track sign_up events via GA4 Measurement Protocol

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -55,6 +55,12 @@ NEXT_PUBLIC_E2B_DOMAIN=e2b.dev
 ### Billing API URL (Required if NEXT_PUBLIC_INCLUDE_BILLING=1)
 # BILLING_API_URL=https://billing.e2b.dev
 
+### GA4 Measurement Protocol credentials for server-emitted events (sign_up).
+### Create the secret in GA4 Admin -> Data streams -> <stream> -> Measurement
+### Protocol API secrets. Set in production only.
+# GA4_MEASUREMENT_ID=
+# GA4_API_SECRET=
+
 ### Vercel URL (automatically set in Vercel deployments)
 # VERCEL_URL=
 

--- a/src/app/api/auth/oauth/callback/ory/route.ts
+++ b/src/app/api/auth/oauth/callback/ory/route.ts
@@ -10,7 +10,10 @@ import {
   openOryFlowState,
 } from '@/core/server/auth/ory/oauth-flow'
 import { resolveOryRedirectUri } from '@/core/server/auth/ory/oauth-relay'
-import { readKratosExternalId } from '@/core/server/auth/ory/session'
+import {
+  readKratosAuthMethod,
+  readKratosExternalId,
+} from '@/core/server/auth/ory/session'
 import {
   ORY_SIGNUP_METADATA_COOKIE,
   reconcileSessionCookies,
@@ -22,6 +25,7 @@ import {
   buildOryLogoutUrl,
   ORY_POST_LOGOUT_PATH,
 } from '@/core/server/auth/ory/signout'
+import { trackOrySignUpEvent } from '@/core/server/auth/ory/signup-tracking'
 import { l, serializeErrorForLog } from '@/core/shared/clients/logger/logger'
 import { relativeUrlSchema } from '@/core/shared/schemas/url'
 
@@ -95,6 +99,11 @@ export async function GET(request: NextRequest) {
         )
       )
     }
+
+    trackOrySignUpEvent({
+      cookies: request.cookies,
+      method: await readKratosAuthMethod(),
+    })
   }
 
   const sealed = await sealSessionCookie({

--- a/src/core/server/auth/ory/session.ts
+++ b/src/core/server/auth/ory/session.ts
@@ -88,6 +88,22 @@ export async function readKratosExternalId(): Promise<string | null> {
   return kratos?.active ? (kratos.identity?.external_id ?? null) : null
 }
 
+// Signup method for analytics, read off the Kratos session's completed
+// authentication methods: the social provider (github/google) when present,
+// 'email' for password/OTP credentials. Reuses the request-cached session read.
+export async function readKratosAuthMethod(): Promise<string | null> {
+  const methods = (await readKratosSession())?.authentication_methods
+  const latest = methods?.[methods.length - 1]
+  if (!latest) return null
+
+  const provider = latest.provider?.trim().toLowerCase()
+  if (provider) return provider
+
+  return latest.method === 'password' || latest.method === 'code'
+    ? 'email'
+    : (latest.method ?? null)
+}
+
 export async function getUserProfile(): Promise<AuthUser | null> {
   const identityId = (await readKratosSession())?.identity?.id
   if (!identityId) return null

--- a/src/core/server/auth/ory/signup-tracking.ts
+++ b/src/core/server/auth/ory/signup-tracking.ts
@@ -4,7 +4,6 @@ import { after } from 'next/server'
 import {
   type Ga4Event,
   gaSessionCookieName,
-  generateFallbackGaClientId,
   isGa4Configured,
   parseGaClientId,
   parseGaSessionId,
@@ -31,6 +30,17 @@ export function trackOrySignUpEvent(input: TrackOrySignUpInput): void {
   if (!isGa4Configured()) return
 
   const gaClientId = parseGaClientId(input.cookies.get(GA_CLIENT_COOKIE)?.value)
+
+  // A missing _ga cookie means the user blocked analytics; emitting a
+  // synthetic client_id would bypass that choice.
+  if (!gaClientId) {
+    l.info(
+      { key: 'oauth_callback:sign_up_tracking_skipped' },
+      'Skipping GA4 sign_up event because no GA client cookie is present'
+    )
+    return
+  }
+
   const event = buildSignUpEvent(input)
 
   // Reconciliation anchor: compare counts of this log line against GA4 to
@@ -38,15 +48,12 @@ export function trackOrySignUpEvent(input: TrackOrySignUpInput): void {
   l.info(
     {
       key: 'oauth_callback:sign_up_tracked',
-      context: {
-        attributed: !!gaClientId,
-        method: input.method ?? 'unknown',
-      },
+      context: { method: input.method ?? 'unknown' },
     },
     'Queued GA4 sign_up event for newly bootstrapped user'
   )
 
-  after(() => sendGa4Event(gaClientId ?? generateFallbackGaClientId(), event))
+  after(() => sendGa4Event(gaClientId, event))
 }
 
 function buildSignUpEvent(input: TrackOrySignUpInput): Ga4Event {

--- a/src/core/server/auth/ory/signup-tracking.ts
+++ b/src/core/server/auth/ory/signup-tracking.ts
@@ -1,0 +1,69 @@
+import 'server-only'
+
+import { after } from 'next/server'
+import {
+  type Ga4Event,
+  gaSessionCookieName,
+  generateFallbackGaClientId,
+  isGa4Configured,
+  parseGaClientId,
+  parseGaSessionId,
+  sendGa4Event,
+} from '@/core/shared/clients/ga4/measurement-protocol.server'
+import { l } from '@/core/shared/clients/logger/logger'
+
+const GA_CLIENT_COOKIE = '_ga'
+
+type CookieReader = {
+  get(name: string): { value: string } | undefined
+}
+
+type TrackOrySignUpInput = {
+  cookies: CookieReader
+  method: string | null
+}
+
+// Emits the GA4 sign_up key event for a freshly bootstrapped account. The
+// payload is built eagerly — request cookies are not readable once the
+// response has been sent — and delivered via after() so the signup redirect
+// never waits on Google.
+export function trackOrySignUpEvent(input: TrackOrySignUpInput): void {
+  if (!isGa4Configured()) return
+
+  const gaClientId = parseGaClientId(input.cookies.get(GA_CLIENT_COOKIE)?.value)
+  const event = buildSignUpEvent(input)
+
+  // Reconciliation anchor: compare counts of this log line against GA4 to
+  // quantify drift from re-bootstrapped returning users (see callback route).
+  l.info(
+    {
+      key: 'oauth_callback:sign_up_tracked',
+      context: {
+        attributed: !!gaClientId,
+        method: input.method ?? 'unknown',
+      },
+    },
+    'Queued GA4 sign_up event for newly bootstrapped user'
+  )
+
+  after(() => sendGa4Event(gaClientId ?? generateFallbackGaClientId(), event))
+}
+
+function buildSignUpEvent(input: TrackOrySignUpInput): Ga4Event {
+  const measurementId = process.env.GA4_MEASUREMENT_ID
+  const sessionId = measurementId
+    ? parseGaSessionId(
+        input.cookies.get(gaSessionCookieName(measurementId))?.value
+      )
+    : null
+
+  return {
+    name: 'sign_up',
+    params: {
+      // Events without engagement time are dropped from several GA4 reports.
+      engagement_time_msec: 1,
+      ...(sessionId ? { session_id: sessionId } : {}),
+      ...(input.method ? { method: input.method } : {}),
+    },
+  }
+}

--- a/src/core/shared/clients/ga4/measurement-protocol.server.ts
+++ b/src/core/shared/clients/ga4/measurement-protocol.server.ts
@@ -71,6 +71,7 @@ export async function sendGa4Event(
         events: [{ name: event.name, params }],
       }),
       signal: AbortSignal.timeout(SEND_TIMEOUT_MS),
+      opentelemetry: { ignore: true },
     })
 
     if (!response.ok) {

--- a/src/core/shared/clients/ga4/measurement-protocol.server.ts
+++ b/src/core/shared/clients/ga4/measurement-protocol.server.ts
@@ -41,14 +41,6 @@ export function parseGaSessionId(
   return match?.[1] ?? null
 }
 
-// Keeps event counts intact when the _ga cookie is blocked or absent; the
-// event lands unattributed instead of being dropped.
-export function generateFallbackGaClientId(): string {
-  const random = Math.floor(Math.random() * 0x7fffffff)
-  const timestamp = Math.floor(Date.now() / 1000)
-  return `${random}.${timestamp}`
-}
-
 export async function sendGa4Event(
   clientId: string,
   event: Ga4Event

--- a/src/core/shared/clients/ga4/measurement-protocol.server.ts
+++ b/src/core/shared/clients/ga4/measurement-protocol.server.ts
@@ -1,0 +1,95 @@
+import 'server-only'
+
+import { l, serializeErrorForLog } from '@/core/shared/clients/logger/logger'
+
+const COLLECT_ENDPOINT = 'https://www.google-analytics.com/mp/collect'
+const SEND_TIMEOUT_MS = 2_000
+
+export type Ga4Event = {
+  name: string
+  params: Record<string, string | number | boolean>
+}
+
+export function isGa4Configured(): boolean {
+  return !!(process.env.GA4_MEASUREMENT_ID && process.env.GA4_API_SECRET)
+}
+
+// _ga looks like `GA1.1.1247869242.1718123456`; the client_id is the trailing
+// `<random>.<first-visit-timestamp>` pair.
+export function parseGaClientId(
+  cookieValue: string | undefined
+): string | null {
+  const segments = cookieValue?.split('.') ?? []
+  if (segments.length < 4) return null
+
+  const clientId = segments.slice(-2).join('.')
+  return /^\d+\.\d+$/.test(clientId) ? clientId : null
+}
+
+export function gaSessionCookieName(measurementId: string): string {
+  return `_ga_${measurementId.replace(/^G-/, '')}`
+}
+
+// The per-stream cookie carries the session id in its third dot-segment:
+// `GS1.1.1718123456.5...` (legacy) or `GS2.1.s1718123456$o5...` (current).
+export function parseGaSessionId(
+  cookieValue: string | undefined
+): string | null {
+  if (!cookieValue?.startsWith('GS')) return null
+
+  const match = cookieValue.split('.')[2]?.match(/^s?(\d+)/)
+  return match?.[1] ?? null
+}
+
+// Keeps event counts intact when the _ga cookie is blocked or absent; the
+// event lands unattributed instead of being dropped.
+export function generateFallbackGaClientId(): string {
+  const random = Math.floor(Math.random() * 0x7fffffff)
+  const timestamp = Math.floor(Date.now() / 1000)
+  return `${random}.${timestamp}`
+}
+
+export async function sendGa4Event(
+  clientId: string,
+  event: Ga4Event
+): Promise<void> {
+  const measurementId = process.env.GA4_MEASUREMENT_ID
+  const apiSecret = process.env.GA4_API_SECRET
+  if (!measurementId || !apiSecret) return
+
+  const url = `${COLLECT_ENDPOINT}?measurement_id=${encodeURIComponent(measurementId)}&api_secret=${encodeURIComponent(apiSecret)}`
+  const params =
+    process.env.VERCEL_ENV === 'production'
+      ? event.params
+      : { ...event.params, debug_mode: true }
+
+  try {
+    const response = await fetch(url, {
+      method: 'POST',
+      body: JSON.stringify({
+        client_id: clientId,
+        events: [{ name: event.name, params }],
+      }),
+      signal: AbortSignal.timeout(SEND_TIMEOUT_MS),
+    })
+
+    if (!response.ok) {
+      l.warn(
+        {
+          key: 'ga4:send_event_failed',
+          context: { event: event.name, status: response.status },
+        },
+        'GA4 Measurement Protocol returned a non-2xx status'
+      )
+    }
+  } catch (error) {
+    l.warn(
+      {
+        key: 'ga4:send_event_failed',
+        context: { event: event.name },
+        error: serializeErrorForLog(error),
+      },
+      'GA4 Measurement Protocol request failed'
+    )
+  }
+}

--- a/src/lib/env.ts
+++ b/src/lib/env.ts
@@ -9,6 +9,9 @@ export const serverSchema = z.object({
   POSTHOG_API_KEY: z.string().min(1).optional(),
   POSTHOG_PROJECT_ID: z.string().min(1).optional(),
 
+  GA4_MEASUREMENT_ID: z.string().min(1).optional(),
+  GA4_API_SECRET: z.string().min(1).optional(),
+
   LAUNCHDARKLY_SDK_KEY: z.string().min(1).optional(),
 
   // JWE key for the e2b_session cookie. Generate with `openssl rand -hex 32`.

--- a/tests/integration/auth-ory-callback.test.ts
+++ b/tests/integration/auth-ory-callback.test.ts
@@ -13,6 +13,8 @@ import {
 const exchangeMock = vi.hoisted(() => vi.fn())
 const bootstrapMock = vi.hoisted(() => vi.fn())
 const readExternalIdMock = vi.hoisted(() => vi.fn())
+const readAuthMethodMock = vi.hoisted(() => vi.fn())
+const trackSignUpMock = vi.hoisted(() => vi.fn())
 
 vi.mock('@/core/server/auth/ory/oauth-client', () => ({
   exchangeOryCallback: exchangeMock,
@@ -24,6 +26,11 @@ vi.mock('@/core/server/auth/ory/dashboard-bootstrap', () => ({
 
 vi.mock('@/core/server/auth/ory/session', () => ({
   readKratosExternalId: readExternalIdMock,
+  readKratosAuthMethod: readAuthMethodMock,
+}))
+
+vi.mock('@/core/server/auth/ory/signup-tracking', () => ({
+  trackOrySignUpEvent: trackSignUpMock,
 }))
 
 vi.mock('@/core/shared/clients/logger/logger', () => ({
@@ -71,6 +78,8 @@ describe('Ory OAuth callback', () => {
     bootstrapMock.mockReset().mockResolvedValue(true)
     // Default to an unprovisioned identity so bootstrap runs as before.
     readExternalIdMock.mockReset().mockResolvedValue(null)
+    readAuthMethodMock.mockReset().mockResolvedValue('github')
+    trackSignUpMock.mockReset()
   })
 
   afterEach(() => {
@@ -123,13 +132,17 @@ describe('Ory OAuth callback', () => {
     expect(response.cookies.get(E2B_SESSION_COOKIE)?.value).toBeUndefined()
   })
 
-  it('bootstraps when the identity has no external_id yet', async () => {
+  it('bootstraps and tracks sign_up when the identity has no external_id yet', async () => {
     await GET(await callbackRequest())
 
     expect(bootstrapMock).toHaveBeenCalledOnce()
+    expect(trackSignUpMock).toHaveBeenCalledOnce()
+    expect(trackSignUpMock).toHaveBeenCalledWith(
+      expect.objectContaining({ method: 'github' })
+    )
   })
 
-  it('skips bootstrap when the identity already has an external_id', async () => {
+  it('skips bootstrap and sign_up tracking when the identity already has an external_id', async () => {
     readExternalIdMock.mockResolvedValueOnce('user-ext-123')
 
     const response = await GET(
@@ -137,6 +150,7 @@ describe('Ory OAuth callback', () => {
     )
 
     expect(bootstrapMock).not.toHaveBeenCalled()
+    expect(trackSignUpMock).not.toHaveBeenCalled()
     // The session is still sealed and the user lands on their destination.
     const sealed = response.cookies.get(E2B_SESSION_COOKIE)?.value
     expect(await openSessionCookie(sealed)).toEqual(tokens)

--- a/tests/unit/ga4-measurement-protocol.test.ts
+++ b/tests/unit/ga4-measurement-protocol.test.ts
@@ -1,7 +1,6 @@
 import { describe, expect, it } from 'vitest'
 import {
   gaSessionCookieName,
-  generateFallbackGaClientId,
   parseGaClientId,
   parseGaSessionId,
 } from '@/core/shared/clients/ga4/measurement-protocol.server'
@@ -51,11 +50,5 @@ describe('parseGaSessionId', () => {
     expect(parseGaSessionId('garbage')).toBeNull()
     expect(parseGaSessionId('GA1.1.1247869242.1718123456')).toBeNull()
     expect(parseGaSessionId('GS2.1')).toBeNull()
-  })
-})
-
-describe('generateFallbackGaClientId', () => {
-  it('matches the client id shape', () => {
-    expect(generateFallbackGaClientId()).toMatch(/^\d+\.\d+$/)
   })
 })

--- a/tests/unit/ga4-measurement-protocol.test.ts
+++ b/tests/unit/ga4-measurement-protocol.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it } from 'vitest'
+import {
+  gaSessionCookieName,
+  generateFallbackGaClientId,
+  parseGaClientId,
+  parseGaSessionId,
+} from '@/core/shared/clients/ga4/measurement-protocol.server'
+
+describe('parseGaClientId', () => {
+  it('extracts the client id from a standard _ga cookie', () => {
+    expect(parseGaClientId('GA1.1.1247869242.1718123456')).toBe(
+      '1247869242.1718123456'
+    )
+  })
+
+  it('handles domain-depth variants', () => {
+    expect(parseGaClientId('GA1.2.111.222')).toBe('111.222')
+  })
+
+  it('rejects malformed values', () => {
+    expect(parseGaClientId(undefined)).toBeNull()
+    expect(parseGaClientId('')).toBeNull()
+    expect(parseGaClientId('garbage')).toBeNull()
+    expect(parseGaClientId('GA1.1.abc.def')).toBeNull()
+    expect(parseGaClientId('GA1.1.123')).toBeNull()
+  })
+})
+
+describe('gaSessionCookieName', () => {
+  it('derives the cookie name from the measurement id', () => {
+    expect(gaSessionCookieName('G-SCSZ10RP74')).toBe('_ga_SCSZ10RP74')
+  })
+})
+
+describe('parseGaSessionId', () => {
+  it('parses the legacy GS1 format', () => {
+    expect(parseGaSessionId('GS1.1.1718123456.5.1.1718123500.0.0.0')).toBe(
+      '1718123456'
+    )
+  })
+
+  it('parses the current GS2 format', () => {
+    expect(
+      parseGaSessionId('GS2.1.s1718123456$o5$g1$t1718123500$j0$l0$h0')
+    ).toBe('1718123456')
+  })
+
+  it('rejects malformed values', () => {
+    expect(parseGaSessionId(undefined)).toBeNull()
+    expect(parseGaSessionId('')).toBeNull()
+    expect(parseGaSessionId('garbage')).toBeNull()
+    expect(parseGaSessionId('GA1.1.1247869242.1718123456')).toBeNull()
+    expect(parseGaSessionId('GS2.1')).toBeNull()
+  })
+})
+
+describe('generateFallbackGaClientId', () => {
+  it('matches the client id shape', () => {
+    expect(generateFallbackGaClientId()).toMatch(/^\d+\.\d+$/)
+  })
+})


### PR DESCRIPTION
Fires a server-side GA4 `sign_up` event from the Ory OAuth callback when a new account is bootstrapped, stitched to the web session via the `_ga` cookies so the event attributes to its traffic source. Falls back to a random client_id when the cookie is absent so counts stay intact.