### PR TITLE
fix(timezone): default to UTC instead of browser timezone

### DIFF
--- a/src/features/dashboard/timezone/context.tsx
+++ b/src/features/dashboard/timezone/context.tsx
@@ -6,12 +6,11 @@ import {
   type ReactNode,
   useCallback,
   useContext,
-  useEffect,
   useMemo,
   useState,
 } from 'react'
 import { type Timezone, TimezoneSchema } from './schema'
-import { getBrowserTimezone, parseTimezone } from './utils'
+import { parseTimezone } from './utils'
 
 const DEFAULT_TIMEZONE = TimezoneSchema.parse('UTC')
 
@@ -55,14 +54,6 @@ export const TimezoneProvider = ({
   const [timezone, setTimezoneState] = useState(
     parsedInitialTimezone ?? DEFAULT_TIMEZONE
   )
-
-  useEffect(() => {
-    if (parsedInitialTimezone) return
-
-    const browserTimezone = getBrowserTimezone()
-    setTimezoneState(browserTimezone)
-    void persistTimezone(browserTimezone)
-  }, [parsedInitialTimezone])
 
   const setTimezone = useCallback(
     async (nextTimezone: Timezone) => {


### PR DESCRIPTION
When a user has no saved timezone preference, the dashboard now falls back to UTC instead of auto-detecting and persisting the browser's local timezone.

- Removed the effect that detected and saved the browser timezone on first load.
- The provider fallback stays `DEFAULT_TIMEZONE` (UTC), both server- and client-side.
- Users can still opt into their browser timezone via the "Use browser timezone" button in Account → Timezone settings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)