### PR TITLE
feat(templates): show plus label to indicate more pages results

### DIFF
--- a/src/features/dashboard/templates/list/header.tsx
+++ b/src/features/dashboard/templates/list/header.tsx
@@ -7,16 +7,21 @@ import { SearchInput } from './table-search'
 
 interface TemplatesHeaderProps {
   table: Table<Template>
+  hasNextPage: boolean
 }
 
-export default function TemplatesHeader({ table }: TemplatesHeaderProps) {
+export default function TemplatesHeader({
+  table,
+  hasNextPage,
+}: TemplatesHeaderProps) {
   'use no memo'
 
   const { globalFilter, isPublic } = useTemplateTableStore()
   const isFiltered = Boolean(globalFilter) || isPublic !== undefined
 
   // With server-side pagination we only know how many rows are currently
-  // loaded, not the grand total.
+  // loaded, not the grand total — so once all pages are loaded the count is
+  // exact, otherwise "N+" marks it as a lower bound.
   const loadedCount = table.options.data.length
 
   return (
@@ -34,7 +39,9 @@ export default function TemplatesHeader({ table }: TemplatesHeaderProps) {
 
       <span className="prose-label-highlight h-9 flex w-full min-w-0 items-center gap-1 uppercase sm:w-auto">
         <span className="text-fg">
-          {loadedCount} {loadedCount === 1 ? 'template' : 'templates'}
+          {loadedCount}
+          {hasNextPage ? '+' : ''}{' '}
+          {loadedCount === 1 && !hasNextPage ? 'template' : 'templates'}
         </span>
         {isFiltered ? (
           <span className="text-fg-tertiary"> · filtered</span>

--- a/src/features/dashboard/templates/list/table.tsx
+++ b/src/features/dashboard/templates/list/table.tsx
@@ -166,7 +166,7 @@ export default function TemplatesTable() {
 
   return (
     <ClientOnly className="flex h-full min-h-0 flex-col md:max-w-[calc(100svw-var(--sidebar-width-active))] p-3 md:p-6">
-      <TemplatesHeader table={table} />
+      <TemplatesHeader table={table} hasNextPage={hasNextPage} />
 
       <div
         className={cn(


### PR DESCRIPTION
Updates the templates list count label to better reflect pagination:
- Shows 50+ templates when more pages are available.
- Shows the exact count when all templates fit on the current page.

This avoids implying that customers with additional pages have only 50 templates.