### PR TITLE
Add server-driven Connections catalog

### DIFF
--- a/src/app/dashboard/[teamSlug]/connections/page.tsx
+++ b/src/app/dashboard/[teamSlug]/connections/page.tsx
@@ -1,9 +1,17 @@
 import type { Metadata } from 'next'
+import Link from 'next/link'
 import { notFound, redirect } from 'next/navigation'
-import { AUTH_URLS } from '@/configs/urls'
+import { AUTH_URLS, PROTECTED_URLS } from '@/configs/urls'
 import { featureFlags } from '@/core/modules/feature-flags/feature-flags.server'
 import { getAuthContext } from '@/core/server/auth'
 import { getTeamIdFromSlug } from '@/core/server/functions/team/get-team-id-from-slug'
+import {
+  DECLARED_CONNECTIONS,
+  mergeConnectionCatalog,
+} from '@/features/dashboard/connections/catalog'
+import { Page } from '@/features/dashboard/layouts/page'
+import { Button } from '@/ui/primitives/button'
+import { IntegrationsIcon } from '@/ui/primitives/icons'
 
 export const metadata: Metadata = {
   title: 'Connections - E2B',
@@ -33,23 +41,82 @@ export default async function ConnectionsPage({
     notFound()
   }
 
+  const featureFlagContext = {
+    user: {
+      id: authContext.user.id,
+      email: authContext.user.email ?? undefined,
+    },
+    team: {
+      id: teamId.data,
+    },
+  }
   const connectionsEnabled = await featureFlags.isEnabled(
     'connectionsEnabled',
-    {
-      user: {
-        id: authContext.user.id,
-        email: authContext.user.email ?? undefined,
-      },
-      team: {
-        id: teamId.data,
-        slug: teamSlug,
-      },
-    }
+    featureFlagContext
   )
 
   if (!connectionsEnabled) {
     notFound()
   }
 
-  return null
+  const additionalConnections = await featureFlags.getPayload(
+    'developmentConnections',
+    featureFlagContext
+  )
+  const connections = mergeConnectionCatalog(
+    DECLARED_CONNECTIONS,
+    additionalConnections
+  )
+
+  return (
+    <Page>
+      <div className="flex flex-col gap-6">
+        <header className="flex flex-col gap-1">
+          <h1 className="prose-title text-fg">Connections</h1>
+          <p className="prose-body text-fg-tertiary max-w-2xl">
+            Connect services that run workloads in your E2B team.
+          </p>
+        </header>
+
+        {connections.length > 0 ? (
+          <div className="border-stroke border-y">
+            {connections.map((connection) => (
+              <div
+                className="border-stroke flex min-h-24 flex-col items-stretch gap-4 border-b px-3 py-4 last:border-b-0 sm:flex-row sm:items-center md:px-4"
+                key={connection.template}
+              >
+                <div className="flex min-w-0 flex-1 items-center gap-4">
+                  <div className="border-stroke bg-bg-1 flex size-11 shrink-0 items-center justify-center border">
+                    <IntegrationsIcon className="size-5" aria-hidden />
+                  </div>
+                  <div className="min-w-0 flex-1">
+                    <div className="flex flex-wrap items-center gap-2">
+                      <h2 className="prose-body-highlight text-fg min-w-0 break-words">
+                        {connection.name}
+                      </h2>
+                      <span className="prose-label text-fg-tertiary border-stroke max-w-full break-all border px-1.5 py-0.5">
+                        {connection.template}
+                      </span>
+                    </div>
+                    <p className="prose-body text-fg-tertiary mt-1 break-words">
+                      {connection.description}
+                    </p>
+                  </div>
+                </div>
+                <Button asChild className="w-full shrink-0 sm:w-auto">
+                  <Link
+                    aria-label={`Start ${connection.name}`}
+                    href={`${PROTECTED_URLS.TERMINAL(teamSlug)}?${new URLSearchParams({ template: connection.template })}`}
+                    prefetch={false}
+                  >
+                    Start
+                  </Link>
+                </Button>
+              </div>
+            ))}
+          </div>
+        ) : null}
+      </div>
+    </Page>
+  )
 }

--- a/src/configs/sidebar.ts
+++ b/src/configs/sidebar.ts
@@ -1,4 +1,4 @@
-import type { BooleanFeatureFlagId } from '@/core/modules/feature-flags/definitions'
+import type { BooleanFeatureFlagId } from '@/core/modules/feature-flags/boolean-definitions'
 import {
   AccountSettingsIcon,
   CardIcon,

--- a/src/core/modules/feature-flags/boolean-definitions.ts
+++ b/src/core/modules/feature-flags/boolean-definitions.ts
@@ -1,0 +1,57 @@
+import type { BooleanFeatureFlagDefinition } from '@/core/modules/feature-flags/types'
+
+export const BOOLEAN_FEATURE_FLAGS = {
+  agentsEnabled: {
+    kind: 'boolean',
+    key: 'agents_enabled',
+    defaultValue: false,
+    description: 'Enables the dashboard agents launcher.',
+    exposure: 'both',
+  },
+  byocEnabled: {
+    kind: 'boolean',
+    key: 'byoc_enabled',
+    defaultValue: false,
+    description: 'Enables the dashboard BYOC page.',
+    exposure: 'both',
+  },
+  connectionsEnabled: {
+    kind: 'boolean',
+    key: 'connections_enabled',
+    defaultValue: false,
+    description: 'Enables the dashboard connections page.',
+    exposure: 'both',
+  },
+  isAdmin: {
+    kind: 'boolean',
+    key: 'is_admin',
+    defaultValue: false,
+    description: 'Enables dashboard admin-only surfaces.',
+    exposure: 'server',
+  },
+  newSandboxList: {
+    kind: 'boolean',
+    key: 'new_sandbox_list',
+    defaultValue: false,
+    description:
+      'Enables the new sandbox list with pagination and paused sandbox coverage.',
+    exposure: 'both',
+  },
+  newUsagePage: {
+    kind: 'boolean',
+    key: 'new-usage-page',
+    defaultValue: false,
+    description: 'Enables the redesigned (Dashboard 2.0) usage page skeleton.',
+    exposure: 'server',
+  },
+  disableE2BAccessTokenProvisioning: {
+    kind: 'boolean',
+    key: 'disable_e2b_access_token_provisioning',
+    defaultValue: false,
+    description:
+      'Disables provisioning of e2b access tokens via generateE2BUserAccessToken. When enabled, the legacy CLI flow shows an upgrade prompt and the createAccessToken tRPC mutation returns an error.',
+    exposure: 'both',
+  },
+} as const satisfies Record<string, BooleanFeatureFlagDefinition>
+
+export type BooleanFeatureFlagId = keyof typeof BOOLEAN_FEATURE_FLAGS

--- a/src/core/modules/feature-flags/definitions.ts
+++ b/src/core/modules/feature-flags/definitions.ts
@@ -1,55 +1,30 @@
+import { z } from 'zod'
+import {
+  BOOLEAN_FEATURE_FLAGS,
+  type BooleanFeatureFlagId,
+} from '@/core/modules/feature-flags/boolean-definitions'
 import type { FeatureFlagDefinition } from '@/core/modules/feature-flags/types'
 
+export const developmentConnectionSchema = z.object({
+  name: z.string().trim().min(1).max(100),
+  template: z
+    .string()
+    .trim()
+    .regex(/^[a-zA-Z0-9][a-zA-Z0-9_.:/-]{0,127}$/),
+  description: z.string().trim().min(1).max(500),
+})
+
+export type DevelopmentConnection = z.infer<typeof developmentConnectionSchema>
+
 export const FEATURE_FLAGS = {
-  agentsEnabled: {
-    kind: 'boolean',
-    key: 'agents_enabled',
-    defaultValue: false,
-    description: 'Enables the dashboard agents launcher.',
-    exposure: 'both',
-  },
-  byocEnabled: {
-    kind: 'boolean',
-    key: 'byoc_enabled',
-    defaultValue: false,
-    description: 'Enables the dashboard BYOC page.',
-    exposure: 'both',
-  },
-  connectionsEnabled: {
-    kind: 'boolean',
-    key: 'connections_enabled',
-    defaultValue: false,
-    description: 'Enables the dashboard connections page.',
-    exposure: 'both',
-  },
-  isAdmin: {
-    kind: 'boolean',
-    key: 'is_admin',
-    defaultValue: false,
-    description: 'Enables dashboard admin-only surfaces.',
-    exposure: 'server',
-  },
-  newSandboxList: {
-    kind: 'boolean',
-    key: 'new_sandbox_list',
-    defaultValue: false,
+  ...BOOLEAN_FEATURE_FLAGS,
+  developmentConnections: {
+    kind: 'payload',
+    key: 'dev_connections',
+    defaultValue: [] as DevelopmentConnection[],
+    schema: z.array(developmentConnectionSchema).max(50),
     description:
-      'Enables the new sandbox list with pagination and paused sandbox coverage.',
-    exposure: 'both',
-  },
-  newUsagePage: {
-    kind: 'boolean',
-    key: 'new-usage-page',
-    defaultValue: false,
-    description: 'Enables the redesigned (Dashboard 2.0) usage page skeleton.',
-    exposure: 'server',
-  },
-  disableE2BAccessTokenProvisioning: {
-    kind: 'boolean',
-    key: 'disable_e2b_access_token_provisioning',
-    defaultValue: false,
-    description:
-      'Disables provisioning of e2b access tokens via generateE2BUserAccessToken. When enabled, the legacy CLI flow shows an upgrade prompt and the createAccessToken tRPC mutation returns an error.',
+      'Adds team-targeted development services to the Connections page.',
     exposure: 'server',
   },
 } as const satisfies Record<string, FeatureFlagDefinition>
@@ -62,5 +37,8 @@ export type FeatureFlagIdByKind<Kind extends FeatureFlagDefinition['kind']> = {
     : never
 }[FeatureFlagId]
 
-export type BooleanFeatureFlagId = FeatureFlagIdByKind<'boolean'>
+export type { BooleanFeatureFlagId }
 export type PayloadFeatureFlagId = FeatureFlagIdByKind<'payload'>
+
+export type PayloadFeatureFlagValue<Id extends PayloadFeatureFlagId> =
+  (typeof FEATURE_FLAGS)[Id]['defaultValue']

--- a/src/core/modules/feature-flags/feature-flags.client.tsx
+++ b/src/core/modules/feature-flags/feature-flags.client.tsx
@@ -8,9 +8,9 @@ import {
   useMemo,
 } from 'react'
 import {
+  BOOLEAN_FEATURE_FLAGS,
   type BooleanFeatureFlagId,
-  FEATURE_FLAGS,
-} from '@/core/modules/feature-flags/definitions'
+} from '@/core/modules/feature-flags/boolean-definitions'
 import type { EvaluatedFeatureFlag } from '@/core/modules/feature-flags/types'
 
 type FeatureFlagsContextValue = {
@@ -42,7 +42,7 @@ export function FeatureFlagsProvider({
         return evaluatedFlag.value
       }
 
-      return FEATURE_FLAGS[flagId].defaultValue
+      return BOOLEAN_FEATURE_FLAGS[flagId].defaultValue
     },
     [flagsById]
   )

--- a/src/core/modules/feature-flags/feature-flags.server.ts
+++ b/src/core/modules/feature-flags/feature-flags.server.ts
@@ -5,6 +5,8 @@ import {
   type BooleanFeatureFlagId,
   FEATURE_FLAGS,
   type FeatureFlagId,
+  type PayloadFeatureFlagId,
+  type PayloadFeatureFlagValue,
 } from '@/core/modules/feature-flags/definitions'
 import type {
   EvaluatedFeatureFlag,
@@ -23,6 +25,10 @@ export type FeatureFlagService = {
     flagId: BooleanFeatureFlagId,
     context: FeatureFlagContext
   ): Promise<boolean>
+  getPayload<Id extends PayloadFeatureFlagId>(
+    flagId: Id,
+    context: FeatureFlagContext
+  ): Promise<PayloadFeatureFlagValue<Id>>
   evaluateAll(context: FeatureFlagContext): Promise<EvaluatedFeatureFlag[]>
 }
 
@@ -105,11 +111,23 @@ export function createFeatureFlagService(
       return flag.defaultValue
     },
 
+    async getPayload(flagId, context) {
+      const flag = FEATURE_FLAGS[flagId]
+      const snapshot = await provider.evaluate(context, [flag])
+
+      return parsePayload(
+        flag,
+        snapshot.getPayload(flag.key)
+      ) as PayloadFeatureFlagValue<typeof flagId>
+    },
+
     async evaluateAll(context) {
-      const flags = Object.entries(FEATURE_FLAGS) as [
-        FeatureFlagId,
-        FeatureFlagDefinition,
-      ][]
+      const flags = (
+        Object.entries(FEATURE_FLAGS) as [
+          FeatureFlagId,
+          FeatureFlagDefinition,
+        ][]
+      ).filter(([, flag]) => flag.exposure !== 'server')
       const snapshot = await provider.evaluate(
         context,
         flags.map(([, flag]) => flag)

--- a/src/features/dashboard/connections/catalog.ts
+++ b/src/features/dashboard/connections/catalog.ts
@@ -1,0 +1,24 @@
+import type { DevelopmentConnection } from '@/core/modules/feature-flags/definitions'
+
+export type ConnectionCatalogEntry = DevelopmentConnection
+
+export const DECLARED_CONNECTIONS: readonly ConnectionCatalogEntry[] = []
+
+export function mergeConnectionCatalog(
+  declared: readonly ConnectionCatalogEntry[],
+  additional: readonly ConnectionCatalogEntry[]
+): ConnectionCatalogEntry[] {
+  const catalog = [...declared]
+  const templates = new Set(declared.map((connection) => connection.template))
+
+  for (const connection of additional) {
+    if (templates.has(connection.template)) {
+      continue
+    }
+
+    catalog.push(connection)
+    templates.add(connection.template)
+  }
+
+  return catalog
+}

--- a/tests/unit/connections-catalog.test.ts
+++ b/tests/unit/connections-catalog.test.ts
@@ -1,0 +1,89 @@
+import { describe, expect, it } from 'vitest'
+import { mergeConnectionCatalog } from '@/features/dashboard/connections/catalog'
+
+describe('mergeConnectionCatalog', () => {
+  it('appends additional connections after declared connections', () => {
+    expect(
+      mergeConnectionCatalog(
+        [
+          {
+            name: 'Declared',
+            template: 'declared-template',
+            description: 'Declared connection',
+          },
+        ],
+        [
+          {
+            name: 'Development',
+            template: 'development-template',
+            description: 'Development connection',
+          },
+        ]
+      )
+    ).toEqual([
+      {
+        name: 'Declared',
+        template: 'declared-template',
+        description: 'Declared connection',
+      },
+      {
+        name: 'Development',
+        template: 'development-template',
+        description: 'Development connection',
+      },
+    ])
+  })
+
+  it('keeps declared connections when templates collide', () => {
+    expect(
+      mergeConnectionCatalog(
+        [
+          {
+            name: 'Declared',
+            template: 'shared-template',
+            description: 'Declared connection',
+          },
+        ],
+        [
+          {
+            name: 'Override',
+            template: 'shared-template',
+            description: 'Flag connection',
+          },
+        ]
+      )
+    ).toEqual([
+      {
+        name: 'Declared',
+        template: 'shared-template',
+        description: 'Declared connection',
+      },
+    ])
+  })
+
+  it('deduplicates repeated additional templates', () => {
+    expect(
+      mergeConnectionCatalog(
+        [],
+        [
+          {
+            name: 'First',
+            template: 'shared-template',
+            description: 'First connection',
+          },
+          {
+            name: 'Second',
+            template: 'shared-template',
+            description: 'Second connection',
+          },
+        ]
+      )
+    ).toEqual([
+      {
+        name: 'First',
+        template: 'shared-template',
+        description: 'First connection',
+      },
+    ])
+  })
+})

--- a/tests/unit/connections-page.test.tsx
+++ b/tests/unit/connections-page.test.tsx
@@ -1,0 +1,106 @@
+import { renderToStaticMarkup } from 'react-dom/server'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const mocks = vi.hoisted(() => ({
+  getAuthContext: vi.fn(),
+  getTeamIdFromSlug: vi.fn(),
+  isEnabled: vi.fn(),
+  getPayload: vi.fn(),
+  notFound: vi.fn(() => {
+    throw new Error('not found')
+  }),
+  redirect: vi.fn(() => {
+    throw new Error('redirect')
+  }),
+}))
+
+vi.mock('next/navigation', () => ({
+  notFound: mocks.notFound,
+  redirect: mocks.redirect,
+}))
+
+vi.mock('@/core/server/auth', () => ({
+  getAuthContext: mocks.getAuthContext,
+}))
+
+vi.mock('@/core/server/functions/team/get-team-id-from-slug', () => ({
+  getTeamIdFromSlug: mocks.getTeamIdFromSlug,
+}))
+
+vi.mock('@/core/modules/feature-flags/feature-flags.server', () => ({
+  featureFlags: {
+    isEnabled: mocks.isEnabled,
+    getPayload: mocks.getPayload,
+  },
+}))
+
+import ConnectionsPage from '@/app/dashboard/[teamSlug]/connections/page'
+
+describe('ConnectionsPage', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mocks.getAuthContext.mockResolvedValue({
+      accessToken: 'access-token',
+      user: {
+        id: 'user-id',
+        email: 'user@example.com',
+      },
+    })
+    mocks.getTeamIdFromSlug.mockResolvedValue({
+      ok: true,
+      data: 'team-id',
+    })
+  })
+
+  it('does not evaluate the catalog when the page flag is disabled', async () => {
+    mocks.isEnabled.mockResolvedValue(false)
+
+    await expect(
+      ConnectionsPage({
+        params: Promise.resolve({ teamSlug: 'team-slug' }),
+      })
+    ).rejects.toThrow('not found')
+
+    expect(mocks.getPayload).not.toHaveBeenCalled()
+  })
+
+  it('targets the resolved team ID and renders additional connections', async () => {
+    mocks.isEnabled.mockResolvedValue(true)
+    mocks.getPayload.mockResolvedValue([
+      {
+        name: 'Development service',
+        template: 'development-template',
+        description: 'Development connection',
+      },
+    ])
+
+    const page = await ConnectionsPage({
+      params: Promise.resolve({ teamSlug: 'team-slug' }),
+    })
+    const featureFlagContext = {
+      user: {
+        id: 'user-id',
+        email: 'user@example.com',
+      },
+      team: {
+        id: 'team-id',
+      },
+    }
+
+    expect(mocks.isEnabled).toHaveBeenCalledWith(
+      'connectionsEnabled',
+      featureFlagContext
+    )
+    expect(mocks.getPayload).toHaveBeenCalledWith(
+      'developmentConnections',
+      featureFlagContext
+    )
+    const markup = renderToStaticMarkup(page)
+
+    expect(markup).toContain('Development service')
+    expect(markup).toContain(
+      'href="/dashboard/team-slug/terminal?template=development-template"'
+    )
+    expect(markup).toContain('aria-label="Start Development service"')
+  })
+})

--- a/tests/unit/feature-flags.test.ts
+++ b/tests/unit/feature-flags.test.ts
@@ -52,7 +52,71 @@ describe('createFeatureFlagService', () => {
     expect(result).toBe(false)
   })
 
-  it('evaluates the registry in a single provider call', async () => {
+  it('evaluates payload flags through the provider', async () => {
+    const payload = [
+      {
+        name: 'Development service',
+        template: 'development-template',
+        description: 'Development connection',
+      },
+    ]
+    const provider = {
+      evaluate: vi.fn().mockResolvedValue({
+        getFlagValue: vi.fn(),
+        getPayload: vi.fn().mockReturnValue(payload),
+      }),
+    }
+
+    const result = await createFeatureFlagService(provider).getPayload(
+      'developmentConnections',
+      context
+    )
+
+    expect(result).toEqual(payload)
+    expect(provider.evaluate).toHaveBeenCalledWith(context, [
+      FEATURE_FLAGS.developmentConnections,
+    ])
+  })
+
+  it('falls back to the payload default when validation fails', async () => {
+    const provider = {
+      evaluate: vi.fn().mockResolvedValue({
+        getFlagValue: vi.fn(),
+        getPayload: vi.fn().mockReturnValue([
+          {
+            name: '',
+            template: 'development-template',
+            description: 'Development connection',
+          },
+        ]),
+      }),
+    }
+
+    const result = await createFeatureFlagService(provider).getPayload(
+      'developmentConnections',
+      context
+    )
+
+    expect(result).toEqual([])
+  })
+
+  it('falls back to the payload default when the provider has no value', async () => {
+    const provider = {
+      evaluate: vi.fn().mockResolvedValue({
+        getFlagValue: vi.fn(),
+        getPayload: vi.fn().mockReturnValue(undefined),
+      }),
+    }
+
+    const result = await createFeatureFlagService(provider).getPayload(
+      'developmentConnections',
+      context
+    )
+
+    expect(result).toEqual([])
+  })
+
+  it('evaluates only client-exposed flags for the client snapshot', async () => {
     const provider = {
       evaluate: vi.fn().mockResolvedValue({
         getFlagValue: vi.fn().mockReturnValue(true),
@@ -67,9 +131,7 @@ describe('createFeatureFlagService', () => {
       FEATURE_FLAGS.agentsEnabled,
       FEATURE_FLAGS.byocEnabled,
       FEATURE_FLAGS.connectionsEnabled,
-      FEATURE_FLAGS.isAdmin,
       FEATURE_FLAGS.newSandboxList,
-      FEATURE_FLAGS.newUsagePage,
       FEATURE_FLAGS.disableE2BAccessTokenProvisioning,
     ])
     expect(result).toEqual([
@@ -98,28 +160,11 @@ describe('createFeatureFlagService', () => {
         value: true,
       },
       {
-        id: 'isAdmin',
-        key: 'is_admin',
-        kind: 'boolean',
-        description: 'Enables dashboard admin-only surfaces.',
-        defaultValue: false,
-        value: true,
-      },
-      {
         id: 'newSandboxList',
         key: 'new_sandbox_list',
         kind: 'boolean',
         description:
           'Enables the new sandbox list with pagination and paused sandbox coverage.',
-        defaultValue: false,
-        value: true,
-      },
-      {
-        id: 'newUsagePage',
-        key: 'new-usage-page',
-        kind: 'boolean',
-        description:
-          'Enables the redesigned (Dashboard 2.0) usage page skeleton.',
         defaultValue: false,
         value: true,
       },


### PR DESCRIPTION
- add a server-only LaunchDarkly JSON catalog for team-targeted Connections entries
- merge flagged entries with declared connections and launch templates in the current team's terminal
