### PR TITLE
Target feature flags by stable team ID

### DIFF
--- a/src/app/dashboard/[teamSlug]/agents/page.tsx
+++ b/src/app/dashboard/[teamSlug]/agents/page.tsx
@@ -41,7 +41,6 @@ export default async function AgentsPage({ params }: AgentsPageProps) {
     },
     team: {
       id: teamId.data,
-      slug: teamSlug,
     },
   })
 

--- a/src/app/dashboard/[teamSlug]/byoc/page.tsx
+++ b/src/app/dashboard/[teamSlug]/byoc/page.tsx
@@ -38,7 +38,6 @@ export default async function ByocPage({ params }: ByocPageProps) {
     },
     team: {
       id: teamId.data,
-      slug: teamSlug,
     },
   })
 

--- a/src/app/dashboard/[teamSlug]/layout.tsx
+++ b/src/app/dashboard/[teamSlug]/layout.tsx
@@ -69,7 +69,6 @@ export default async function DashboardLayout({
     ? {
         id: team.id,
         name: team.name,
-        slug: teamSlug,
       }
     : undefined
 

--- a/src/app/dashboard/[teamSlug]/usage/page.tsx
+++ b/src/app/dashboard/[teamSlug]/usage/page.tsx
@@ -34,8 +34,7 @@ export default async function UsagePage({
       id: authContext.user.id,
       email: authContext.user.email ?? undefined,
     },
-    team:
-      teamId.ok && teamId.data ? { id: teamId.data } : undefined,
+    team: teamId.ok && teamId.data ? { id: teamId.data } : undefined,
   })
 
   const result = await getUsage({ teamSlug })

--- a/src/app/dashboard/[teamSlug]/usage/page.tsx
+++ b/src/app/dashboard/[teamSlug]/usage/page.tsx
@@ -35,9 +35,7 @@ export default async function UsagePage({
       email: authContext.user.email ?? undefined,
     },
     team:
-      teamId.ok && teamId.data
-        ? { id: teamId.data, slug: teamSlug }
-        : undefined,
+      teamId.ok && teamId.data ? { id: teamId.data } : undefined,
   })
 
   const result = await getUsage({ teamSlug })

--- a/src/core/modules/feature-flags/context.ts
+++ b/src/core/modules/feature-flags/context.ts
@@ -5,7 +5,6 @@ export type FeatureFlagContext = {
   }
   team?: {
     id: string
-    slug?: string
     name?: string
   }
 }

--- a/src/core/modules/feature-flags/launchdarkly-openfeature-provider.server.ts
+++ b/src/core/modules/feature-flags/launchdarkly-openfeature-provider.server.ts
@@ -50,7 +50,6 @@ export function createOpenFeatureEvaluationContext(
       targetingKey: context.team.id,
       ...definedStringAttributes({
         name: context.team.name,
-        slug: context.team.slug,
       }),
     },
   }

--- a/src/features/dashboard/sandboxes/list/feature-flag.server.ts
+++ b/src/features/dashboard/sandboxes/list/feature-flag.server.ts
@@ -22,6 +22,6 @@ export async function isNewSandboxListEnabled(teamSlug: string) {
       id: authContext.user.id,
       email: authContext.user.email ?? undefined,
     },
-    team: teamId ? { id: teamId, slug: teamSlug } : undefined,
+    team: teamId ? { id: teamId } : undefined,
   })
 }

--- a/tests/unit/feature-flags.test.ts
+++ b/tests/unit/feature-flags.test.ts
@@ -11,7 +11,6 @@ const context = {
   },
   team: {
     id: 'team-id',
-    slug: 'team-slug',
     name: 'Team Name',
   },
 } satisfies FeatureFlagContext
@@ -192,7 +191,6 @@ describe('createOpenFeatureEvaluationContext', () => {
       team: {
         targetingKey: 'team-id',
         name: 'Team Name',
-        slug: 'team-slug',
       },
     })
   })


### PR DESCRIPTION
## Summary
- remove dashboard slugs from the shared feature-flag context
- stop forwarding `team.slug` to LaunchDarkly
- update every existing feature-flag call site and the provider contract test

## Why
Dashboard slugs are mutable routing identifiers, while the verified team ID is the stable LaunchDarkly targeting key. Keeping slug in the evaluation context allowed future rules to produce inconsistent results for the same team.

A read-only audit of the Dashboard LaunchDarkly project found no slug-based clauses or segments in Test, Staging, or Production. Existing team targets use team context keys with UUID team IDs, so this does not change current targeting behavior.

## Validation
- `bunx vitest run tests/unit/feature-flags.test.ts tests/unit/sidebar.test.ts`
- `bun run next typegen && bunx tsc --noEmit`
- `bun run knip:ci`
- focused Biome check
- `bunx react-doctor --verbose --diff origin/main --blocking warning --no-score --no-telemetry`
