### PR TITLE
Add feature-flagged BYOC setup

### DIFF
--- a/src/app/dashboard/[teamSlug]/byoc/page.tsx
+++ b/src/app/dashboard/[teamSlug]/byoc/page.tsx
@@ -4,6 +4,7 @@ import { AUTH_URLS } from '@/configs/urls'
 import { featureFlags } from '@/core/modules/feature-flags/feature-flags.server'
 import { getAuthContext } from '@/core/server/auth'
 import { getTeamIdFromSlug } from '@/core/server/functions/team/get-team-id-from-slug'
+import { ByocSetup } from '@/features/dashboard/byoc/byoc-setup'
 
 export const metadata: Metadata = {
   title: 'BYOC - E2B',
@@ -31,7 +32,7 @@ export default async function ByocPage({ params }: ByocPageProps) {
     notFound()
   }
 
-  const byocEnabled = await featureFlags.isEnabled('byocEnabled', {
+  const byocSetup = await featureFlags.getPayload('byocSetup', {
     user: {
       id: authContext.user.id,
       email: authContext.user.email ?? undefined,
@@ -42,9 +43,9 @@ export default async function ByocPage({ params }: ByocPageProps) {
     },
   })
 
-  if (!byocEnabled) {
+  if (!byocSetup.enabled) {
     notFound()
   }
 
-  return null
+  return <ByocSetup config={byocSetup} />
 }

--- a/src/configs/sidebar.ts
+++ b/src/configs/sidebar.ts
@@ -22,13 +22,15 @@ type SidebarNavArgs = {
   teamSlug?: string
 }
 
+export type SidebarFeatureFlagId = BooleanFeatureFlagId | 'byocSetup'
+
 export type SidebarNavItem = {
   label: string
   href: (args: SidebarNavArgs) => string
   icon: Icon
   group?: string
   activeMatch?: string
-  featureFlag?: BooleanFeatureFlagId
+  featureFlag?: SidebarFeatureFlagId
 }
 
 export const SIDEBAR_MAIN_LINKS: SidebarNavItem[] = [
@@ -69,7 +71,7 @@ export const SIDEBAR_MAIN_LINKS: SidebarNavItem[] = [
     href: (args) => PROTECTED_URLS.BYOC(args.teamSlug!),
     icon: CloudIcon,
     activeMatch: `/dashboard/*/byoc`,
-    featureFlag: 'byocEnabled',
+    featureFlag: 'byocSetup',
   },
   ...(INCLUDE_ARGUS
     ? [
@@ -148,7 +150,7 @@ export const SIDEBAR_ALL_LINKS = [...SIDEBAR_MAIN_LINKS, ...SIDEBAR_EXTRA_LINKS]
 
 export function filterSidebarLinks(
   links: SidebarNavItem[],
-  isEnabled: (flagId: BooleanFeatureFlagId) => boolean
+  isEnabled: (flagId: SidebarFeatureFlagId) => boolean
 ) {
   return links.filter(
     (link) => !link.featureFlag || isEnabled(link.featureFlag)

--- a/src/core/modules/feature-flags/boolean-definitions.ts
+++ b/src/core/modules/feature-flags/boolean-definitions.ts
@@ -8,13 +8,6 @@ export const BOOLEAN_FEATURE_FLAGS = {
     description: 'Enables the dashboard agents launcher.',
     exposure: 'both',
   },
-  byocEnabled: {
-    kind: 'boolean',
-    key: 'byoc_enabled',
-    defaultValue: false,
-    description: 'Enables the dashboard BYOC page.',
-    exposure: 'both',
-  },
   connectionsEnabled: {
     kind: 'boolean',
     key: 'connections_enabled',

--- a/src/core/modules/feature-flags/definitions.ts
+++ b/src/core/modules/feature-flags/definitions.ts
@@ -16,8 +16,48 @@ export const developmentConnectionSchema = z.object({
 
 export type DevelopmentConnection = z.infer<typeof developmentConnectionSchema>
 
+const gcpRegionSchema = z
+  .string()
+  .trim()
+  .regex(/^[a-z][a-z0-9-]{2,62}$/)
+
+const byocSetupTemplateSchema = z.string().trim().min(1).max(50_000)
+
+export const byocSetupSchema = z.object({
+  enabled: z.literal(true),
+  principal: z
+    .string()
+    .trim()
+    .regex(
+      /^serviceAccount:[a-z][a-z0-9-]{4,28}[a-z0-9]@[a-z][a-z0-9-]{4,28}[a-z0-9]\.iam\.gserviceaccount\.com$/
+    ),
+  regions: z
+    .array(gcpRegionSchema)
+    .min(1)
+    .max(20)
+    .refine((regions) => new Set(regions).size === regions.length),
+  templates: z.object({
+    gcloud: byocSetupTemplateSchema,
+    terraform: byocSetupTemplateSchema,
+  }),
+})
+
+export type ByocSetupConfig = z.infer<typeof byocSetupSchema>
+export type ByocSetupValue = ByocSetupConfig | { enabled: false }
+
 export const FEATURE_FLAGS = {
   ...BOOLEAN_FEATURE_FLAGS,
+  byocSetup: {
+    kind: 'payload',
+    key: 'byoc_setup',
+    defaultValue: { enabled: false } as ByocSetupValue,
+    schema: z.discriminatedUnion('enabled', [
+      z.object({ enabled: z.literal(false) }),
+      byocSetupSchema,
+    ]),
+    description: 'Configures team-targeted BYOC onboarding.',
+    exposure: 'both',
+  },
   developmentConnections: {
     kind: 'payload',
     key: 'dev_connections',

--- a/src/core/modules/feature-flags/feature-flags.client.tsx
+++ b/src/core/modules/feature-flags/feature-flags.client.tsx
@@ -16,6 +16,7 @@ import type { EvaluatedFeatureFlag } from '@/core/modules/feature-flags/types'
 type FeatureFlagsContextValue = {
   flags: EvaluatedFeatureFlag[]
   isEnabled(flagId: BooleanFeatureFlagId): boolean
+  hasPayload(flagId: 'byocSetup'): boolean
 }
 
 const FeatureFlagsContext = createContext<FeatureFlagsContextValue | undefined>(
@@ -47,10 +48,17 @@ export function FeatureFlagsProvider({
     [flagsById]
   )
 
-  const value = useMemo(
-    () => ({ flags: initialFlags, isEnabled }),
-    [initialFlags, isEnabled]
-  )
+  const hasPayload = (flagId: 'byocSetup') => {
+    const value = flagsById.get(flagId)?.value
+    return (
+      typeof value === 'object' &&
+      value !== null &&
+      'enabled' in value &&
+      value.enabled === true
+    )
+  }
+
+  const value = { flags: initialFlags, hasPayload, isEnabled }
 
   return (
     <FeatureFlagsContext.Provider value={value}>

--- a/src/core/modules/feature-flags/feature-flags.server.ts
+++ b/src/core/modules/feature-flags/feature-flags.server.ts
@@ -112,13 +112,12 @@ export function createFeatureFlagService(
     },
 
     async getPayload(flagId, context) {
-      const flag = FEATURE_FLAGS[flagId]
+      const flag = FEATURE_FLAGS[flagId] as PayloadFeatureFlagDefinition<
+        PayloadFeatureFlagValue<typeof flagId>
+      >
       const snapshot = await provider.evaluate(context, [flag])
 
-      return parsePayload(
-        flag,
-        snapshot.getPayload(flag.key)
-      ) as PayloadFeatureFlagValue<typeof flagId>
+      return parsePayload(flag, snapshot.getPayload(flag.key))
     },
 
     async evaluateAll(context) {

--- a/src/features/dashboard/byoc/byoc-setup.tsx
+++ b/src/features/dashboard/byoc/byoc-setup.tsx
@@ -1,0 +1,174 @@
+'use client'
+
+import { useState } from 'react'
+import type { ByocSetupConfig } from '@/core/modules/feature-flags/definitions'
+import { Page } from '@/features/dashboard/layouts/page'
+import { CodeBlock } from '@/ui/code-block'
+import { CloudIcon, InfoIcon, TerminalIcon } from '@/ui/primitives/icons'
+import { Input } from '@/ui/primitives/input'
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/ui/primitives/select'
+import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/ui/primitives/tabs'
+import { isValidGcpProjectId, renderByocSetupTemplate } from './terraform'
+
+const PROJECT_PLACEHOLDER = 'YOUR_GCP_PROJECT_ID'
+
+export function ByocSetup({ config }: { config: ByocSetupConfig }) {
+  const [projectId, setProjectId] = useState('')
+  const [region, setRegion] = useState(() => config.regions[0] ?? '')
+  const trimmedProjectId = projectId.trim()
+  const projectIdValid = isValidGcpProjectId(trimmedProjectId)
+  const projectIdInvalid = trimmedProjectId.length > 0 && !projectIdValid
+  const templateValues = {
+    principal: config.principal,
+    projectId: projectIdValid ? trimmedProjectId : PROJECT_PLACEHOLDER,
+    region,
+  }
+  const templates = {
+    gcloud: renderByocSetupTemplate({
+      ...templateValues,
+      template: config.templates.gcloud,
+    }),
+    terraform: renderByocSetupTemplate({
+      ...templateValues,
+      template: config.templates.terraform,
+    }),
+  }
+
+  return (
+    <Page className="max-w-[1100px]">
+      <div className="flex flex-col gap-6">
+        <header className="flex max-w-2xl flex-col gap-1">
+          <div className="flex items-center gap-2">
+            <CloudIcon className="text-accent-main-highlight size-5" />
+            <h1 className="prose-title text-fg">Set up BYOC</h1>
+          </div>
+          <p className="prose-body text-fg-tertiary">
+            Create the project-local identity E2B will use to deploy and operate
+            your region. E2B receives impersonation access, never a service
+            account key.
+          </p>
+        </header>
+
+        <div className="border-stroke grid min-w-0 border-y lg:grid-cols-[minmax(260px,0.55fr)_minmax(0,1.45fr)]">
+          <section className="border-stroke flex min-w-0 flex-col gap-5 px-3 py-5 md:px-5 lg:border-r">
+            <div>
+              <p className="prose-label text-fg-tertiary">Configuration</p>
+              <h2 className="prose-headline-small text-fg mt-1">
+                Choose the destination
+              </h2>
+            </div>
+
+            <label className="flex flex-col gap-2" htmlFor="byoc-region">
+              <span className="prose-body-highlight text-fg">Region</span>
+              <Select onValueChange={setRegion} value={region}>
+                <SelectTrigger id="byoc-region">
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  {config.regions.map((availableRegion) => (
+                    <SelectItem key={availableRegion} value={availableRegion}>
+                      {availableRegion}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            </label>
+
+            <label className="flex flex-col gap-2" htmlFor="byoc-project-id">
+              <span className="prose-body-highlight text-fg">
+                Google Cloud project ID
+              </span>
+              <Input
+                aria-describedby="byoc-project-id-help"
+                aria-invalid={projectIdInvalid}
+                autoComplete="off"
+                className="font-mono"
+                id="byoc-project-id"
+                onChange={(event) => setProjectId(event.currentTarget.value)}
+                placeholder="your-gcp-project-id"
+                spellCheck={false}
+                value={projectId}
+              />
+              <p
+                className={
+                  projectIdInvalid
+                    ? 'prose-caption text-accent-error-highlight'
+                    : 'prose-caption text-fg-tertiary'
+                }
+                id="byoc-project-id-help"
+              >
+                {projectIdInvalid
+                  ? 'Enter a valid Google Cloud project ID.'
+                  : 'The Terraform preview updates as you type.'}
+              </p>
+            </label>
+
+            <div className="border-stroke bg-bg-1 flex min-w-0 gap-3 border p-3">
+              <InfoIcon className="text-fg-tertiary mt-0.5 size-4 shrink-0" />
+              <div className="min-w-0">
+                <p className="prose-caption text-fg-tertiary">
+                  E2B access principal
+                </p>
+                <p className="prose-caption text-fg mt-1 break-all font-mono">
+                  {config.principal}
+                </p>
+              </div>
+            </div>
+          </section>
+
+          <section className="bg-bg-1 flex min-w-0 flex-col gap-4 px-3 py-5 md:px-5">
+            <div className="flex flex-col gap-1 sm:flex-row sm:items-end sm:justify-between sm:gap-4">
+              <div>
+                <p className="prose-label text-fg-tertiary">Generated file</p>
+                <h2 className="prose-headline-small text-fg mt-1">
+                  Access setup
+                </h2>
+              </div>
+              <p className="prose-caption text-fg-tertiary">
+                Choose Terraform or gcloud
+              </p>
+            </div>
+            <Tabs className="min-w-0 gap-3" defaultValue="terraform">
+              <TabsList className="h-9 gap-5 border-b-0 bg-transparent p-0 max-md:px-0">
+                <TabsTrigger layoutkey="byoc-setup-code-tabs" value="terraform">
+                  Terraform
+                </TabsTrigger>
+                <TabsTrigger layoutkey="byoc-setup-code-tabs" value="gcloud">
+                  gcloud
+                </TabsTrigger>
+              </TabsList>
+              <TabsContent className="mt-0 min-w-0" value="terraform">
+                <CodeBlock
+                  className="min-w-0 max-w-full overflow-hidden"
+                  icon={<TerminalIcon />}
+                  lang="hcl"
+                  title="main.tf"
+                  viewportProps={{ className: 'max-h-[560px] max-w-full' }}
+                >
+                  {templates.terraform}
+                </CodeBlock>
+              </TabsContent>
+              <TabsContent className="mt-0 min-w-0" value="gcloud">
+                <CodeBlock
+                  className="min-w-0 max-w-full overflow-hidden"
+                  icon={<TerminalIcon />}
+                  lang="bash"
+                  title="Run in Cloud Shell"
+                  viewportProps={{ className: 'max-h-[560px] max-w-full' }}
+                >
+                  {templates.gcloud}
+                </CodeBlock>
+              </TabsContent>
+            </Tabs>
+          </section>
+        </div>
+      </div>
+    </Page>
+  )
+}

--- a/src/features/dashboard/byoc/terraform.ts
+++ b/src/features/dashboard/byoc/terraform.ts
@@ -1,0 +1,22 @@
+const GCP_PROJECT_ID_PATTERN = /^[a-z][a-z0-9-]{4,28}[a-z0-9]$/
+
+export function isValidGcpProjectId(projectId: string) {
+  return GCP_PROJECT_ID_PATTERN.test(projectId)
+}
+
+export function renderByocSetupTemplate({
+  principal,
+  projectId,
+  region,
+  template,
+}: {
+  principal: string
+  projectId: string
+  region: string
+  template: string
+}) {
+  return template
+    .replaceAll('{{PROJECT_ID}}', projectId)
+    .replaceAll('{{REGION}}', region)
+    .replaceAll('{{E2B_PRINCIPAL}}', principal)
+}

--- a/src/features/dashboard/sidebar/use-visible-links.ts
+++ b/src/features/dashboard/sidebar/use-visible-links.ts
@@ -1,11 +1,16 @@
 'use client'
 
-import { useMemo } from 'react'
-import { filterSidebarLinks, type SidebarNavItem } from '@/configs/sidebar'
+import {
+  filterSidebarLinks,
+  type SidebarFeatureFlagId,
+  type SidebarNavItem,
+} from '@/configs/sidebar'
 import { useFeatureFlags } from '@/core/modules/feature-flags/feature-flags.client'
 
 export function useVisibleSidebarLinks(links: SidebarNavItem[]) {
-  const { isEnabled } = useFeatureFlags()
+  const { hasPayload, isEnabled } = useFeatureFlags()
 
-  return useMemo(() => filterSidebarLinks(links, isEnabled), [isEnabled, links])
+  return filterSidebarLinks(links, (flagId: SidebarFeatureFlagId) =>
+    flagId === 'byocSetup' ? hasPayload(flagId) : isEnabled(flagId)
+  )
 }

--- a/tests/unit/byoc-page.test.tsx
+++ b/tests/unit/byoc-page.test.tsx
@@ -1,0 +1,91 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const mocks = vi.hoisted(() => ({
+  getAuthContext: vi.fn(),
+  getPayload: vi.fn(),
+  getTeamIdFromSlug: vi.fn(),
+  notFound: vi.fn(() => {
+    throw new Error('not found')
+  }),
+  redirect: vi.fn(() => {
+    throw new Error('redirect')
+  }),
+}))
+
+vi.mock('next/navigation', () => ({
+  notFound: mocks.notFound,
+  redirect: mocks.redirect,
+}))
+
+vi.mock('@/core/server/auth', () => ({
+  getAuthContext: mocks.getAuthContext,
+}))
+
+vi.mock('@/core/server/functions/team/get-team-id-from-slug', () => ({
+  getTeamIdFromSlug: mocks.getTeamIdFromSlug,
+}))
+
+vi.mock('@/core/modules/feature-flags/feature-flags.server', () => ({
+  featureFlags: {
+    getPayload: mocks.getPayload,
+  },
+}))
+
+import ByocPage from '@/app/dashboard/[teamSlug]/byoc/page'
+
+describe('ByocPage', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mocks.getAuthContext.mockResolvedValue({
+      accessToken: 'access-token',
+      user: {
+        id: 'user-id',
+        email: 'user@example.com',
+      },
+    })
+    mocks.getTeamIdFromSlug.mockResolvedValue({
+      ok: true,
+      data: 'team-id',
+    })
+  })
+
+  it('returns not found when BYOC setup is not configured', async () => {
+    mocks.getPayload.mockResolvedValue({ enabled: false })
+
+    await expect(
+      ByocPage({
+        params: Promise.resolve({ teamSlug: 'team-slug' }),
+      })
+    ).rejects.toThrow('not found')
+  })
+
+  it('targets the resolved team and renders its setup configuration', async () => {
+    const config = {
+      enabled: true,
+      principal:
+        'serviceAccount:byoc-deployments-api@example-project.iam.gserviceaccount.com',
+      regions: ['us-central1'],
+      templates: {
+        gcloud: 'gcloud --project={{PROJECT_ID}}',
+        terraform: 'project_id = "{{PROJECT_ID}}"',
+      },
+    }
+    mocks.getPayload.mockResolvedValue(config)
+
+    const page = await ByocPage({
+      params: Promise.resolve({ teamSlug: 'team-slug' }),
+    })
+
+    expect(mocks.getPayload).toHaveBeenCalledWith('byocSetup', {
+      user: {
+        id: 'user-id',
+        email: 'user@example.com',
+      },
+      team: {
+        id: 'team-id',
+        slug: 'team-slug',
+      },
+    })
+    expect(page.props.config).toEqual(config)
+  })
+})

--- a/tests/unit/byoc-terraform.test.ts
+++ b/tests/unit/byoc-terraform.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from 'vitest'
+import {
+  isValidGcpProjectId,
+  renderByocSetupTemplate,
+} from '@/features/dashboard/byoc/terraform'
+
+describe('BYOC setup templates', () => {
+  it('substitutes only the selected values into flag-provided content', () => {
+    const rendered = renderByocSetupTemplate({
+      principal:
+        'serviceAccount:byoc-deployments-api@example-project.iam.gserviceaccount.com',
+      projectId: 'customer-project',
+      region: 'us-west1',
+      template:
+        'project={{PROJECT_ID}} region={{REGION}} principal={{E2B_PRINCIPAL}}',
+    })
+
+    expect(rendered).toBe(
+      'project=customer-project region=us-west1 principal=serviceAccount:byoc-deployments-api@example-project.iam.gserviceaccount.com'
+    )
+  })
+
+  it('accepts only Google Cloud project IDs', () => {
+    expect(isValidGcpProjectId('customer-project')).toBe(true)
+    expect(isValidGcpProjectId('Customer Project')).toBe(false)
+    expect(isValidGcpProjectId('x')).toBe(false)
+    expect(isValidGcpProjectId('customer_project')).toBe(false)
+  })
+})

--- a/tests/unit/feature-flags.test.ts
+++ b/tests/unit/feature-flags.test.ts
@@ -16,6 +16,17 @@ const context = {
   },
 } satisfies FeatureFlagContext
 
+const byocSetup = {
+  enabled: true,
+  principal:
+    'serviceAccount:byoc-deployments-api@example-project.iam.gserviceaccount.com',
+  regions: ['us-central1', 'us-west1'],
+  templates: {
+    gcloud: 'gcloud --project={{PROJECT_ID}}',
+    terraform: 'project_id = "{{PROJECT_ID}}"',
+  },
+}
+
 describe('createFeatureFlagService', () => {
   it('evaluates boolean flags through the provider', async () => {
     const provider = {
@@ -120,7 +131,11 @@ describe('createFeatureFlagService', () => {
     const provider = {
       evaluate: vi.fn().mockResolvedValue({
         getFlagValue: vi.fn().mockReturnValue(true),
-        getPayload: vi.fn(),
+        getPayload: vi
+          .fn()
+          .mockImplementation((key) =>
+            key === FEATURE_FLAGS.byocSetup.key ? byocSetup : undefined
+          ),
       }),
     }
 
@@ -129,10 +144,10 @@ describe('createFeatureFlagService', () => {
     expect(provider.evaluate).toHaveBeenCalledTimes(1)
     expect(provider.evaluate).toHaveBeenCalledWith(context, [
       FEATURE_FLAGS.agentsEnabled,
-      FEATURE_FLAGS.byocEnabled,
       FEATURE_FLAGS.connectionsEnabled,
       FEATURE_FLAGS.newSandboxList,
       FEATURE_FLAGS.disableE2BAccessTokenProvisioning,
+      FEATURE_FLAGS.byocSetup,
     ])
     expect(result).toEqual([
       {
@@ -140,14 +155,6 @@ describe('createFeatureFlagService', () => {
         key: 'agents_enabled',
         kind: 'boolean',
         description: 'Enables the dashboard agents launcher.',
-        defaultValue: false,
-        value: true,
-      },
-      {
-        id: 'byocEnabled',
-        key: 'byoc_enabled',
-        kind: 'boolean',
-        description: 'Enables the dashboard BYOC page.',
         defaultValue: false,
         value: true,
       },
@@ -176,6 +183,14 @@ describe('createFeatureFlagService', () => {
           'Disables provisioning of e2b access tokens via generateE2BUserAccessToken. When enabled, the legacy CLI flow shows an upgrade prompt and the createAccessToken tRPC mutation returns an error.',
         defaultValue: false,
         value: true,
+      },
+      {
+        id: 'byocSetup',
+        key: 'byoc_setup',
+        kind: 'payload',
+        description: 'Configures team-targeted BYOC onboarding.',
+        defaultValue: { enabled: false },
+        value: byocSetup,
       },
     ])
   })

--- a/tests/unit/sidebar-feature-flags.test.ts
+++ b/tests/unit/sidebar-feature-flags.test.ts
@@ -1,0 +1,61 @@
+import { createElement } from 'react'
+import { renderToStaticMarkup } from 'react-dom/server'
+import { describe, expect, it } from 'vitest'
+import { SIDEBAR_MAIN_LINKS } from '@/configs/sidebar'
+import {
+  FeatureFlagsProvider,
+  useFeatureFlags,
+} from '@/core/modules/feature-flags/feature-flags.client'
+
+function ByocVisibility() {
+  const { hasPayload } = useFeatureFlags()
+  return createElement(
+    'span',
+    null,
+    hasPayload('byocSetup') ? 'shown' : 'hidden'
+  )
+}
+
+function renderByocVisibility(value: unknown) {
+  return renderToStaticMarkup(
+    createElement(
+      FeatureFlagsProvider,
+      {
+        initialFlags: [
+          {
+            id: 'byocSetup',
+            key: 'byoc_setup',
+            kind: 'payload',
+            value,
+            defaultValue: { enabled: false },
+          },
+        ],
+      },
+      createElement(ByocVisibility)
+    )
+  )
+}
+
+describe('BYOC sidebar payload', () => {
+  it('uses the configured payload as the visibility gate', () => {
+    expect(
+      renderByocVisibility({
+        enabled: true,
+        principal:
+          'serviceAccount:byoc-deployments-api@example-project.iam.gserviceaccount.com',
+        regions: ['us-central1'],
+        templates: {
+          gcloud: 'gcloud --project={{PROJECT_ID}}',
+          terraform: 'project_id = "{{PROJECT_ID}}"',
+        },
+      })
+    ).toContain('shown')
+    expect(renderByocVisibility({ enabled: false })).toContain('hidden')
+  })
+
+  it('keeps the BYOC navigation tied to the payload flag', () => {
+    expect(
+      SIDEBAR_MAIN_LINKS.find((link) => link.label === 'BYOC')?.featureFlag
+    ).toBe('byocSetup')
+  })
+})

--- a/tests/unit/sidebar.test.ts
+++ b/tests/unit/sidebar.test.ts
@@ -13,7 +13,7 @@ describe('filterSidebarLinks', () => {
     )
     const byocOnly = filterSidebarLinks(
       SIDEBAR_MAIN_LINKS,
-      (flagId) => flagId === 'byocEnabled'
+      (flagId) => flagId === 'byocSetup'
     )
 
     expect(agentsOnly.map((link) => link.label)).toContain('Agents')


### PR DESCRIPTION
## Summary

- add a setup-only BYOC page for selecting a Google Cloud project and allowed region
- render Terraform and gcloud setup templates supplied by a team-targeted LaunchDarkly payload
- use the same `byoc_setup` payload to gate the page and supply the E2B principal, allowed regions, and templates
- keep non-targeted teams out of both the sidebar and the direct route
- keep provider-specific bootstrap contents out of the public dashboard source

## Scope

This intentionally stops after rendering the setup instructions. It does not add deployment orchestration, Terraform execution, status polling, or cluster registration.

The dashboard only substitutes the validated `PROJECT_ID`, `REGION`, and `E2B_PRINCIPAL` placeholders into flag-provided templates.

## Validation

- `bun run test:unit` (512 tests)
- `bun run next typegen && bunx tsc --noEmit`
- `bun run knip:ci`
- `bunx react-doctor --verbose --scope changed --base origin/main --blocking warning --no-score --no-telemetry`
- `bun run build`
- rendered Terraform passes `terraform fmt -check`
- rendered gcloud script passes `bash -n`
- desktop and mobile browser smoke of project validation, region selection, and live template updates