### PR TITLE
docs: tag e2b.dev links with UTM parameters

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 Open-source dashboard for self-hosted [E2B infrastructure](https://github.com/e2b-dev/infra). Manage and monitor sandboxes and templates with a team API key — no user accounts, no external auth provider.
 
 ## Quick Links
-- 📚 [Documentation](https://e2b.dev/docs)
+- 📚 [Documentation](https://e2b.dev/docs?utm_source=github&utm_medium=referral&utm_campaign=readme&utm_content=dashboard)
 - 💬 [Discord Community](https://discord.gg/e2b)
 - 🐛 [Issue Tracker](https://github.com/e2b-dev/dashboard/issues)
 - 🤝 [Contributing Guide](CONTRIBUTING.md)


### PR DESCRIPTION
Tags the README's e2b.dev links with the UTM convention already used across the org's other READMEs (utm_campaign=readme, utm_content set to the repo name), so these visits attribute to GitHub instead of landing in direct.

🤖 Generated with [Claude Code](https://claude.com/claude-code)