### PR TITLE
chore: point README docs link at docs.e2b.dev

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 Open-source dashboard for self-hosted [E2B infrastructure](https://github.com/e2b-dev/infra). Manage and monitor sandboxes and templates with a team API key — no user accounts, no external auth provider.
 
 ## Quick Links
-- 📚 [Documentation](https://e2b.dev/docs?utm_source=github&utm_medium=referral&utm_campaign=readme&utm_content=dashboard)
+- 📚 [Documentation](https://docs.e2b.dev/?utm_source=github&utm_medium=referral&utm_campaign=readme&utm_content=dashboard)
 - 💬 [Discord Community](https://discord.gg/e2b)
 - 🐛 [Issue Tracker](https://github.com/e2b-dev/dashboard/issues)
 - 🤝 [Contributing Guide](CONTRIBUTING.md)


### PR DESCRIPTION
Follow-up to #525. The docs site moved to its own subdomain, so the link that PR tagged points at the pre-migration domain.

`e2b.dev/docs` returns a 308 to `docs.e2b.dev/`, and the subdomain has no `/docs` path prefix.

The UTM query string is preserved across the redirect, so attribution was not broken. This removes the redirect hop.

One link. `src/configs/urls.ts` and two components also reference the old domain; those are application code rather than an owned marketing link, so they are queued separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)